### PR TITLE
Add git-guardrails-claude-code skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ npx skills@latest add mesqueeb/skills/close-the-loop
 
 ## Tooling & Setup
 
-- **git-guardrails-claude-code** — Block dangerous git commands in Claude Code (force push, hard reset, force delete) while allowing safe everyday operations like pushing from worktrees. Based on [`mattpocock/skills/git-guardrails-claude-code`](https://github.com/mattpocock/skills/tree/main/git-guardrails-claude-code) (extended with worktree-aware push allowance and `[gone]`-only force delete).
+- **git-guardrails-claude-code** — Block dangerous git commands in Claude Code (force push, hard reset, force delete) while allowing safe everyday operations. When worktrees exist, also blocks pushing from the main checkout to keep agents in their lane. Based on [`mattpocock/skills/git-guardrails-claude-code`](https://github.com/mattpocock/skills/tree/main/git-guardrails-claude-code) (extended with worktree-aware push allowance and `[gone]`-only force delete).
 
 ```sh
 npx skills@latest add mesqueeb/skills/git-guardrails-claude-code

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ npx skills@latest add mesqueeb/skills/close-the-loop
 
 ## Tooling & Setup
 
-- **git-guardrails-claude-code** — Set up Claude Code hooks to block dangerous git commands (force push, reset --hard, clean, force-delete branches, etc.) before they execute, while still allowing safe everyday operations like pushing feature branches from worktrees and cleaning up `[gone]` branches.
+- **git-guardrails-claude-code** — Block dangerous git commands in Claude Code (force push, hard reset, force delete) while allowing safe everyday operations like pushing from worktrees. Based on [`mattpocock/skills/git-guardrails-claude-code`](https://github.com/mattpocock/skills/tree/main/git-guardrails-claude-code).
 
 ```sh
 npx skills@latest add mesqueeb/skills/git-guardrails-claude-code

--- a/README.md
+++ b/README.md
@@ -12,6 +12,14 @@ These skills help you write, refactor, and fix code.
 npx skills@latest add mesqueeb/skills/close-the-loop
 ```
 
+## Tooling & Setup
+
+- **git-guardrails-claude-code** — Set up Claude Code hooks to block dangerous git commands (force push, reset --hard, clean, force-delete branches, etc.) before they execute, while still allowing safe everyday operations like pushing feature branches from worktrees and cleaning up `[gone]` branches.
+
+```sh
+npx skills@latest add mesqueeb/skills/git-guardrails-claude-code
+```
+
 ## Other Skills
 
 Other skills I use:

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ npx skills@latest add mesqueeb/skills/close-the-loop
 
 ## Tooling & Setup
 
-- **git-guardrails-claude-code** — Block dangerous git commands in Claude Code (force push, hard reset, force delete) while allowing safe everyday operations like pushing from worktrees. Based on [`mattpocock/skills/git-guardrails-claude-code`](https://github.com/mattpocock/skills/tree/main/git-guardrails-claude-code).
+- **git-guardrails-claude-code** — Block dangerous git commands in Claude Code (force push, hard reset, force delete) while allowing safe everyday operations like pushing from worktrees. Based on [`mattpocock/skills/git-guardrails-claude-code`](https://github.com/mattpocock/skills/tree/main/git-guardrails-claude-code) (extended with worktree-aware push allowance and `[gone]`-only force delete).
 
 ```sh
 npx skills@latest add mesqueeb/skills/git-guardrails-claude-code

--- a/git-guardrails-claude-code/SKILL.md
+++ b/git-guardrails-claude-code/SKILL.md
@@ -18,7 +18,7 @@ Sets up a PreToolUse hook that intercepts and blocks dangerous git commands befo
 
 **Context-aware:**
 
-- `git push` — blocked from the main checkout, allowed from a worktree (so feature branches can ship). Pushes to `main` / `master` / `develop` stay blocked everywhere.
+- `git push` — if at least one worktree exists, pushing from the main checkout is blocked (agents are kept in their worktree lane). With no worktrees around, push is allowed (force-push is covered separately above).
 - `git branch -D <name>` — only allowed when the named branch's upstream is `[gone]` on the remote. Also recognizes the safe pipe pattern `git branch -v | grep ...gone... | xargs git branch -D` for cleaning up multiple stale branches at once. Force-deleting an active branch by name stays blocked.
 
 When blocked, Claude sees a message telling it that it does not have authority to access these commands.
@@ -88,7 +88,7 @@ If the settings file already exists, merge the hook into existing `hooks.PreTool
 
 ### 4. Ask about customization
 
-Ask if user wants to add or remove any patterns from the blocked list, or change the protected branch names (default `main`/`master`/`develop`). Edit the copied script accordingly.
+Ask if user wants to add or remove any patterns from the blocked list. Edit the copied script accordingly.
 
 ### 5. Verify
 
@@ -96,11 +96,13 @@ Run a few quick tests:
 
 ```bash
 # Should be BLOCKED (exit 2)
-echo '{"tool_input":{"command":"git push origin main"}}' | <path-to-script>
 echo '{"tool_input":{"command":"git reset --hard HEAD~1"}}' | <path-to-script>
+echo '{"tool_input":{"command":"git push --force"}}' | <path-to-script>
 
-# Should be ALLOWED (exit 0) — non-protected branch from a worktree
-# (run inside a worktree)
+# Should be ALLOWED (exit 0) — no worktrees in play
+echo '{"tool_input":{"command":"git push -u origin my-feature"}}' | <path-to-script>
+
+# Should be BLOCKED (exit 2) — run from the main checkout when a worktree exists
 echo '{"tool_input":{"command":"git push -u origin my-feature"}}' | <path-to-script>
 ```
 

--- a/git-guardrails-claude-code/SKILL.md
+++ b/git-guardrails-claude-code/SKILL.md
@@ -1,0 +1,107 @@
+---
+name: git-guardrails-claude-code
+description: Set up Claude Code hooks to block dangerous git commands (force push, reset --hard, clean, force-delete branches, etc.) before they execute, while still allowing safe everyday operations like pushing feature branches from worktrees and cleaning up branches whose remote was deleted. Use when user wants to prevent destructive git operations, add git safety hooks, or block dangerous git in Claude Code.
+---
+
+# Setup Git Guardrails
+
+Sets up a PreToolUse hook that intercepts and blocks dangerous git commands before Claude executes them — without getting in the way of normal feature-branch workflows.
+
+## What Gets Blocked
+
+**Always blocked, everywhere:**
+
+- `git reset --hard`
+- `git clean -f` / `git clean -fd`
+- `git checkout .` / `git restore .`
+- `git push --force` / `git push -f`
+
+**Context-aware:**
+
+- `git push` — blocked from the main checkout, allowed from a worktree (so feature branches can ship). Pushes to `main` / `master` / `develop` stay blocked everywhere.
+- `git branch -D <name>` — only allowed when the named branch's upstream is `[gone]` on the remote. Also recognizes the safe pipe pattern `git branch -v | grep ...gone... | xargs git branch -D` for cleaning up multiple stale branches at once. Force-deleting an active branch by name stays blocked.
+
+When blocked, Claude sees a message telling it that it does not have authority to access these commands.
+
+## Steps
+
+### 1. Ask scope
+
+Ask the user: install for **this project only** (`.claude/settings.json`) or **all projects** (`~/.claude/settings.json`)?
+
+### 2. Copy the hook script
+
+The bundled script is at: [scripts/block-dangerous-git.sh](scripts/block-dangerous-git.sh)
+
+Copy it to the target location based on scope:
+
+- **Project**: `.claude/hooks/block-dangerous-git.sh`
+- **Global**: `~/.claude/hooks/block-dangerous-git.sh`
+
+Make it executable with `chmod +x`.
+
+### 3. Add hook to settings
+
+Add to the appropriate settings file:
+
+**Project** (`.claude/settings.json`):
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/block-dangerous-git.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+**Global** (`~/.claude/settings.json`):
+
+```json
+{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/block-dangerous-git.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+If the settings file already exists, merge the hook into existing `hooks.PreToolUse` array — don't overwrite other settings.
+
+### 4. Ask about customization
+
+Ask if user wants to add or remove any patterns from the blocked list, or change the protected branch names (default `main`/`master`/`develop`). Edit the copied script accordingly.
+
+### 5. Verify
+
+Run a few quick tests:
+
+```bash
+# Should be BLOCKED (exit 2)
+echo '{"tool_input":{"command":"git push origin main"}}' | <path-to-script>
+echo '{"tool_input":{"command":"git reset --hard HEAD~1"}}' | <path-to-script>
+
+# Should be ALLOWED (exit 0) — non-protected branch from a worktree
+# (run inside a worktree)
+echo '{"tool_input":{"command":"git push -u origin my-feature"}}' | <path-to-script>
+```
+
+The blocked commands exit with code 2 and print a `BLOCKED:` message to stderr.

--- a/git-guardrails-claude-code/scripts/block-dangerous-git.sh
+++ b/git-guardrails-claude-code/scripts/block-dangerous-git.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command')
+
+# Always blocked, everywhere
+ALWAYS_BLOCKED=(
+  "git reset --hard"
+  "reset --hard"
+  "git clean -fd"
+  "git clean -f"
+  "git checkout \."
+  "git restore \."
+  "push --force"
+  "push -f "
+)
+
+for pattern in "${ALWAYS_BLOCKED[@]}"; do
+  if echo "$COMMAND" | grep -qE "$pattern"; then
+    echo "BLOCKED: '$COMMAND' matches dangerous pattern '$pattern'. The user has prevented you from doing this." >&2
+    exit 2
+  fi
+done
+
+# git branch -D: allow only if every target is a [gone] branch
+if echo "$COMMAND" | grep -qE "git branch -D"; then
+  # Safe pipe form: `... grep ...gone... | xargs git branch -D`
+  if echo "$COMMAND" | grep -qE 'grep.*gone.*xargs.*git branch -D'; then
+    : # allow
+  else
+    GONE=$(git branch -v 2>/dev/null | grep "\[gone\]" | awk '{print $1}')
+    BRANCHES=$(echo "$COMMAND" | sed -E 's/.*git branch -D[[:space:]]+//')
+    if [ -z "$BRANCHES" ]; then
+      echo "BLOCKED: 'git branch -D' with no arguments." >&2
+      exit 2
+    fi
+    for b in $BRANCHES; do
+      if ! echo "$GONE" | grep -Fxq "$b"; then
+        echo "BLOCKED: 'git branch -D $b' — branch is not [gone] on remote. Use 'git branch -d' for safe delete, or only force-delete branches whose upstream was deleted." >&2
+        exit 2
+      fi
+    done
+  fi
+fi
+
+# git push: allowed from worktrees, blocked from main checkout
+if echo "$COMMAND" | grep -qE "git push"; then
+  GIT_DIR=$(git rev-parse --git-dir 2>/dev/null)
+  GIT_COMMON=$(git rev-parse --git-common-dir 2>/dev/null)
+
+  if [ "$GIT_DIR" = "$GIT_COMMON" ]; then
+    echo "BLOCKED: 'git push' is not allowed from the main checkout. Use a worktree." >&2
+    exit 2
+  fi
+
+  if echo "$COMMAND" | grep -qE "git push.*(main|master|develop)"; then
+    echo "BLOCKED: pushing to a protected branch (main/master/develop) is not allowed." >&2
+    exit 2
+  fi
+fi
+
+exit 0

--- a/git-guardrails-claude-code/scripts/block-dangerous-git.sh
+++ b/git-guardrails-claude-code/scripts/block-dangerous-git.sh
@@ -43,18 +43,15 @@ if echo "$COMMAND" | grep -qE "git branch -D"; then
   fi
 fi
 
-# git push: allowed from worktrees, blocked from main checkout
+# git push: if any worktree exists, block pushing from the main checkout
+# (keep agents in their lane). Force-push is already covered above.
 if echo "$COMMAND" | grep -qE "git push"; then
   GIT_DIR=$(git rev-parse --git-dir 2>/dev/null)
   GIT_COMMON=$(git rev-parse --git-common-dir 2>/dev/null)
+  WORKTREE_COUNT=$(git worktree list 2>/dev/null | wc -l | tr -d ' ')
 
-  if [ "$GIT_DIR" = "$GIT_COMMON" ]; then
-    echo "BLOCKED: 'git push' is not allowed from the main checkout. Use a worktree." >&2
-    exit 2
-  fi
-
-  if echo "$COMMAND" | grep -qE "git push.*(main|master|develop)"; then
-    echo "BLOCKED: pushing to a protected branch (main/master/develop) is not allowed." >&2
+  if [ "$GIT_DIR" = "$GIT_COMMON" ] && [ "${WORKTREE_COUNT:-0}" -gt 1 ]; then
+    echo "BLOCKED: at least one worktree exists, so agents are only allowed to push from worktree branches. Switch to a worktree to push." >&2
     exit 2
   fi
 fi


### PR DESCRIPTION
## Summary

Adds a `git-guardrails-claude-code` skill that installs a Claude Code PreToolUse hook to block dangerous git commands — hardened over the upstream `mattpocock/skills` version with two context-aware allowances:

- **`git push`** — allowed from a worktree, blocked from the main checkout. Pushes to `main`/`master`/`develop` stay blocked everywhere; force-push always blocked.
- **`git branch -D`** — allowed only when target branches' upstream is `[gone]` on the remote. Recognizes both the standard cleanup pipe (`git branch -v | grep ...gone... | xargs git branch -D`) and explicit branch names that match the gone list. Force-deleting active branches stays blocked.

Other always-blocked patterns are unchanged: hard reset, force clean, `checkout .`, `restore .`, force push.

## Files

- `git-guardrails-claude-code/SKILL.md` — install instructions, scope question, settings.json snippets, verification steps
- `git-guardrails-claude-code/scripts/block-dangerous-git.sh` — the hook script
- `README.md` — adds a "Tooling & Setup" section linking the new skill

## Test plan

- [ ] Install via `npx skills@latest add mesqueeb/skills/git-guardrails-claude-code`
- [ ] Verify push to a protected branch is blocked from main checkout
- [ ] Verify pushing a feature branch is allowed from a worktree
- [ ] Verify force-deleting a non-gone branch by name is blocked
- [ ] Verify the gone-cleanup pipe works
