### PR TITLE
Fix reef-pulse HITL question and broken label query

### DIFF
--- a/reef-pulse/SKILL.md
+++ b/reef-pulse/SKILL.md
@@ -43,11 +43,7 @@ gh issue list --label "to-rescan" --json number,title --limit 100
 gh issue list --label "to-finalise" --json number,title --limit 100
 ```
 
-Or more efficiently:
-
-```sh
-gh issue list --label "to-probe,to-scope,to-slice,to-await-waves,to-implement,to-inspect,to-rework,to-merge,to-ratify,to-rescan,to-finalise" --json number,title,labels --limit 200
-```
+Run these queries in parallel where possible for performance.
 
 ### Local tracker
 
@@ -57,6 +53,8 @@ Read the local path from config. Scan all work item folders for tagged files:
 - Slice files: look for `[to-*] *.md` in `slices/` subfolders
 
 ### Step 2. Dispatch automated (🌊) work
+
+**Do NOT ask the user for confirmation. Dispatch immediately.** The tags are the authorization — if an item is tagged for automated work, dispatch it without hesitation.
 
 For each item found, dispatch the corresponding skill as a sub-agent. Use the Agent tool. Items that share no dependencies can be dispatched **in parallel**.
 


### PR DESCRIPTION
## Final Report

### Status: PASS

### Success criteria

- ✓ SC1: The "efficient" combined `--label` query is removed — verified: no comma-separated multi-label query exists in the file
- ✓ SC2: Individual per-label queries remain intact with parallel execution note — verified: all 11 queries untouched, note added on line 46
- ✓ SC3: Step 2 contains explicit no-confirmation directive — verified: bold directive at top of Step 2
- ✓ SC4: No other sections modified — verified: diff only touches Step 1 (scan) and Step 2 (dispatch), net -5/+3 lines

### Agent decisions to review

All implementation decisions aligned with the plan.

### Integration notes

No integration issues found. Single slice, single file change.

### Test results

N/A — markdown skill file edit, no automated tests.

### Parent plan

#7