### PR TITLE
002 merge.md restructure pre-merge checks

### DIFF
--- a/ORCHESTRATION.md
+++ b/ORCHESTRATION.md
@@ -1,0 +1,85 @@
+# Phase instructions
+
+Source of truth for what each skill/phase .md file should contain.
+Each entry is an ordered list of operations.
+The test runner checks: (1) each command string exists in the .md file, (2) they appear in this order.
+
+`if` means the operation is conditional — it must exist in the .md but only runs when the condition holds.
+
+Tracker commands use `tracker.sh issue ...` syntax.
+For GitHub: replace `tracker.sh` with `gh`.
+For MCP trackers (ClickUp, Jira, Linear): use equivalent MCP tool calls.
+
+Only variables referenced in an op's cmd/tracker field belong in set-variables.
+Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs in the .md, not here.
+
+## Phases
+
+### [merge.md](./reef-pulse/merge.md)
+
+- set-variables
+  ```sh
+  ISSUE_ID = {issue-id} # pre-existing and passed or generate
+  ```
+- fetch-context
+  ```sh
+  tracker.sh issue view $ISSUE_ID --json body,title,labels
+  ```
+- set-variables
+  ```sh
+  SLICE_NAME = {from slice body}
+  SLICE_NUMBER = $ISSUE_ID
+  PR_NUMBER = {from slice body}
+  PLAN_ID = {from slice/plan body}
+  TARGET_BRANCH = {from slice/plan body}
+  SLICE_BRANCH = {from slice body}
+  WORKTREE_PATH = ../worktree-$SLICE_NAME-merge
+  ```
+- pre-merge-check
+  ```sh
+  gh pr view $PR_NUMBER --json mergeStateStatus -q .mergeStateStatus
+  ```
+- enter-worktree
+  ```sh
+  worktree-enter.sh --fork-from $SLICE_BRANCH --path $WORKTREE_PATH
+  ```
+- merge-target-into-slice
+  ```sh
+  git merge origin/$TARGET_BRANCH
+  ```
+- commit-code — if merge-needed
+  ```sh
+  commit.sh --branch $SLICE_BRANCH -m "merge: resolve conflicts with $TARGET_BRANCH"
+  ```
+- update-tracker — if tests-fail
+  ```sh
+  tracker.sh issue edit $SLICE_NUMBER --remove-label to-merge --add-label to-rework
+  ```
+- exit-worktree
+  ```sh
+  worktree-exit.sh --path $WORKTREE_PATH
+  ```
+- update-tracker — if single-slice (PR stays open for reef-land — stop here)
+  ```sh
+  tracker.sh issue edit $PLAN_ID --remove-label to-merge --add-label to-land
+  ```
+- pr-merge — if multi-slice
+  ```sh
+  gh pr merge $PR_NUMBER --squash --delete-branch
+  ```
+- check-siblings — if multi-slice
+  ```sh
+  tracker.sh issue list --json number,labels --search "parent:$PLAN_ID"
+  ```
+- check-completion — if multi-slice
+  ```sh
+  tracker.sh issue view $PLAN_ID --json body,title,labels
+  ```
+- update-tracker — if multi-slice
+  ```sh
+  tracker.sh issue close $SLICE_NUMBER
+  ```
+- update-tracker — if all-slices-done
+  ```sh
+  tracker.sh issue edit $PLAN_ID --remove-label in-progress --add-label to-ratify
+  ```

--- a/reef-pulse/merge.md
+++ b/reef-pulse/merge.md
@@ -10,94 +10,117 @@ An issue tagged `to-merge` with an open PR.
 
 Read the item to find the PR reference. Check the Plan context to determine whether this is **single-slice** (target branch = base branch) or **multi-slice** (target branch forks from base branch).
 
-## Single-slice
-
-The PR targets the base branch. The human will merge it during `/reef-land` — do NOT merge it here.
-
-1. Tag the plan `to-land`. Remove `to-merge`.
-3. Report: "Single slice verified. PR stays open for human review. Run `/reef-land #{number}`."
-
-### Handoff
-
-Report: "PR stays open for human review. Run `/reef-land #{number}`."
-
-## Multi-slice
-
-### 1. Pre-merge checks
-
-Verify:
-
-- [ ] The PR is approved (has `to-merge` tag, inspector's approval)
-- [ ] The slice branch is up to date with the target branch:
-
 ```sh
-gh pr view {pr-number} --json mergeStateStatus -q .mergeStateStatus
+ISSUE_ID = {issue-id} # pre-existing and passed or generate
 ```
 
-If the slice branch is behind the target branch (merge conflicts or `BEHIND`):
-
-1. Check out the implementation worktree (it should still exist from the implement phase)
-2. Merge the target branch into the slice branch: `git merge origin/{target-branch}`
-3. Resolve any conflicts
-4. Run the full test suite — must be green with the merged code
-5. Push the updated slice branch
-
-If the suite fails after merging, tag the slice `to-rework` with a note explaining what broke. Do not proceed.
-
-### 2. Merge
+### Fetch context
 
 ```sh
-gh pr merge {pr-number} --squash --delete-branch
+tracker.sh issue view $ISSUE_ID --json body,title,labels
 ```
 
-Use squash merge by default unless the project convention differs. `--delete-branch` deletes the remote slice branch.
+### Variables
 
-### 3. Verify post-merge
+```sh
+SLICE_NAME = {from slice body}
+SLICE_NUMBER = $ISSUE_ID
+PR_NUMBER = {from slice body}
+PLAN_ID = {from slice/plan body}
+TARGET_BRANCH = {from slice/plan body}
+SLICE_BRANCH = {from slice body}
+WORKTREE_PATH = ../worktree-$SLICE_NAME-merge
+```
 
-Use a temporary worktree to verify the target branch after merge.
+## Pre-merge check
+
+Unconditional for both single-slice and multi-slice. Ensures the slice branch integrates cleanly with the target branch before proceeding.
+
+Check the merge state of the PR:
+
+```sh
+gh pr view $PR_NUMBER --json mergeStateStatus -q .mergeStateStatus
+```
+
+Enter a worktree on the slice branch:
 
 ```sh
 WORKTREE=$(reef-worktree-enter.sh \
   --base-branch {base-branch} --target-branch {target-branch} \
-  --phase merge --slice {slice-name})
+  --phase merge --slice {slice-name} \
+  --slice-branch $SLICE_BRANCH --branch-op checkout)
 cd "$WORKTREE"
 ```
 
-Run the full test suite. If it fails, **do not proceed** — tag the slice `to-rework` with a note that the merge broke tests and what failed.
+Note: the worktree enters on `SLICE_BRANCH` via `worktree-enter.sh --fork-from $SLICE_BRANCH`, not on the target branch. This ensures you are testing the slice code with the latest target merged in.
 
-For local tracker: perform the metadata writes (steps 4–7) inside this worktree before exiting, then commit and push:
+Merge the target branch into the slice branch:
 
 ```sh
-reef-worktree-commit.sh --target-branch {target-branch} -m "merge: close {slice-name}, update plan"
+git merge origin/$TARGET_BRANCH
 ```
 
-Clean up:
+Run the full test suite. If the target branch merged cleanly and tests pass, commit and push:
+
+```sh
+commit.sh --branch $SLICE_BRANCH -m "merge: resolve conflicts with $TARGET_BRANCH"
+```
+
+If the test suite fails after merging, tag the slice `to-rework` and stop:
+
+```sh
+tracker.sh issue edit $SLICE_NUMBER --remove-label to-merge --add-label to-rework
+```
+
+Clean up the worktree:
 
 ```sh
 reef-worktree-exit.sh --path "$WORKTREE"
 ```
 
-### 4. Document judgment calls
+If tests failed, stop here. Do not proceed to single-slice or multi-slice steps.
 
-Document judgment calls made during this phase on the PR. Only document decisions that deviate from the plan, resolve ambiguity, or would surprise the human — not routine implementation choices. If a decision is best explained next to the code it affects, write a code comment instead. If your context was compacted during this session, scan pre-compaction reference files for judgment calls made earlier.
+## Single-slice
 
-### 5. Close the slice
+The PR targets the base branch. The human will merge it during `/reef-land` — do NOT merge it here.
 
-#### GitHub tracker
+Tag the plan `to-land`. Remove `to-merge`:
 
-Close the slice issue with `gh issue close <number>`. Add label `done`. Remove `to-merge`.
+```sh
+tracker.sh issue edit $PLAN_ID --remove-label to-merge --add-label to-land
+```
 
-#### Local tracker
+### Handoff
 
-Rename from `[to-merge] ...` to `[done] ...`.
+Report: "Single slice verified. PR stays open for human review. Run `/reef-land #{number}`."
 
-### 6. Check siblings
+## Multi-slice
 
-Look at all sibling slices (other slices under the same plan). For any tagged `to-await-waves`, check their `blocked-by` list. If this merged slice was the last blocker, leave them as `to-await-waves` — the next pulse will dispatch the await-waves phase to re-review their plan before promoting.
+### 1. Merge
 
-### 7. Check plan completion
+```sh
+gh pr merge $PR_NUMBER --squash --delete-branch
+```
+
+Use squash merge by default unless the project convention differs. `--delete-branch` deletes the remote slice branch.
+
+### 2. Check siblings
+
+Look at all sibling slices (other slices under the same plan):
+
+```sh
+tracker.sh issue list --json number,labels --search "parent:$PLAN_ID"
+```
+
+For any tagged `to-await-waves`, check their `blocked-by` list. If this merged slice was the last blocker, leave them as `to-await-waves` — the next pulse will dispatch the await-waves phase to re-review their plan before promoting.
+
+### 3. Check plan completion
 
 Are ALL slices for the plan now tagged `done`?
+
+```sh
+tracker.sh issue view $PLAN_ID --json body,title,labels
+```
 
 #### GitHub tracker
 
@@ -112,6 +135,26 @@ Check all files in the `slices/` folder. If all have `[done]` prefix:
 - Rename the plan from `[in-progress] plan.md` to `[to-ratify] plan.md`.
 
 If not all done, do nothing — more slices are still in progress.
+
+### 4. Close the slice
+
+#### GitHub tracker
+
+Close the slice issue with `tracker.sh issue close $SLICE_NUMBER`. Add label `done`. Remove `to-merge`.
+
+#### Local tracker
+
+Rename from `[to-merge] ...` to `[done] ...`.
+
+### 5. Update plan tag — if all slices done
+
+```sh
+tracker.sh issue edit $PLAN_ID --remove-label in-progress --add-label to-ratify
+```
+
+### 6. Document judgment calls
+
+Document judgment calls made during this phase on the PR. Only document decisions that deviate from the plan, resolve ambiguity, or would surprise the human — not routine implementation choices. If a decision is best explained next to the code it affects, write a code comment instead. If your context was compacted during this session, scan pre-compaction reference files for judgment calls made earlier.
 
 ### Handoff
 

--- a/tests/test-orchestration.sh
+++ b/tests/test-orchestration.sh
@@ -1,0 +1,243 @@
+#!/bin/sh
+# test-orchestration.sh — verify phase .md files match ORCHESTRATION.md
+#
+# Reads ORCHESTRATION.md as the source of truth.
+# For each phase/skill, checks that every command string exists in the .md file,
+# that commands appear in the declared order, and that ensure-body-contains strings are present.
+#
+# Commands set to false are skipped.
+# The order check uses the LAST occurrence of each command's key substring in the .md.
+set -u
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$TESTS_DIR/.." && pwd)"
+ORCHESTRATION="$REPO_ROOT/ORCHESTRATION.md"
+TMPFILE="$(mktemp)"
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+pass() {
+  PASS=$((PASS + 1))
+  TOTAL=$((TOTAL + 1))
+  printf "${GREEN}PASS${NC}: %s\n" "$1"
+}
+
+fail() {
+  FAIL=$((FAIL + 1))
+  TOTAL=$((TOTAL + 1))
+  printf "${RED}FAIL${NC}: %s\n" "$1"
+  if [ $# -gt 1 ]; then
+    printf "  %s\n" "$2"
+  fi
+}
+
+# Extract a searchable fixed-string pattern from a command string.
+make_pattern() {
+  cmd="$1"
+  case "$cmd" in
+    worktree-enter.sh*)
+      echo "worktree-enter.sh --fork-from"
+      ;;
+    commit.sh*)
+      echo "commit.sh --branch"
+      ;;
+    worktree-exit.sh*)
+      echo "worktree-exit.sh"
+      ;;
+    "gh pr create"*)  echo "gh pr create" ;;
+    "gh pr merge"*)   echo "gh pr merge" ;;
+    "gh pr view"*)    echo "gh pr view" ;;
+    "gh pr edit"*)    echo "gh pr edit" ;;
+    "gh issue edit"*) echo "gh issue edit" ;;
+    "gh issue close"*) echo "gh issue close" ;;
+    "gh issue view"*) echo "gh issue view" ;;
+    "tracker.sh issue view"*)  echo "tracker.sh issue view" ;;
+    "tracker.sh issue edit"*)  echo "tracker.sh issue edit" ;;
+    "tracker.sh issue close"*) echo "tracker.sh issue close" ;;
+    "tracker.sh issue create"*) echo "tracker.sh issue create" ;;
+    "tracker.sh issue list"*)  echo "tracker.sh issue list" ;;
+    "git fetch"*)     echo "git fetch" ;;
+    "git push"*)      echo "git push" ;;
+    "git merge"*)     echo "git merge" ;;
+    "rename "*)       echo "rename" ;;
+    *)                echo "$cmd" | cut -c1-30 ;;
+  esac
+}
+
+last_line_of() {
+  grep -nF -e "$2" "$1" | tail -1 | cut -d: -f1
+}
+
+# ============================================================
+# Parse ORCHESTRATION.md into testable lines
+# Format: source_file|op_name|check_type|value
+# ============================================================
+
+python3 -c "
+import re, sys
+
+with open('$ORCHESTRATION') as f:
+    lines = f.readlines()
+
+source_file = None
+op_name = None
+in_code = False
+section_type = None
+
+def check_type_for(op):
+    if op == 'set-variables':
+        return 'sh'
+    if op in ('fetch-context', 'update-tracker'):
+        return 'tracker'
+    return 'cmd'
+
+for raw in lines:
+    line = raw.rstrip('\\n')
+
+    # Track section
+    if line.startswith('## Skills'):
+        section_type = 'skills'
+        continue
+    if line.startswith('## Phases'):
+        section_type = 'phases'
+        continue
+
+    # Phase/skill heading — extract path from markdown link
+    m = re.match(r'^### (.+)', line)
+    if m:
+        heading = m.group(1).strip()
+        link = re.match(r'\[[^\]]+\]\(\.\/([^)]+)\)', heading)
+        if link:
+            source_file = link.group(1)
+        elif section_type == 'skills':
+            source_file = heading.lstrip('/') + '/SKILL.md'
+        else:
+            source_file = 'reef-pulse/' + heading
+        op_name = None
+        continue
+
+    if source_file is None:
+        continue
+
+    # Operation bullet (top-level: '- op-name')
+    m = re.match(r'^- (\S+)', line)
+    if m:
+        op_name = m.group(1)
+        continue
+
+    if op_name is None:
+        continue
+
+    # Code block start
+    if re.match(r'^\s+\`\`\`sh', line):
+        in_code = True
+        continue
+
+    # Code block end
+    if in_code and re.match(r'^\s+\`\`\`', line):
+        in_code = False
+        continue
+
+    # Code block content
+    if in_code:
+        code = line.strip()
+        if code:
+            ct = check_type_for(op_name)
+            print(f'{source_file}|{op_name}|{ct}|{code}')
+        continue
+
+    # Sub-items: '  - pass: \`...\`' or '  - fail: \`...\`'
+    m = re.match(r'^\s+- (pass|fail):\s*\`([^\`]+)\`', line)
+    if m:
+        sub = m.group(1)
+        cmd = m.group(2)
+        print(f'{source_file}|{op_name}|tracker-{sub}|{cmd}')
+        continue
+" > "$TMPFILE"
+
+# ============================================================
+# Run tests
+# ============================================================
+
+current_source=""
+prev_line=0
+prev_op=""
+prev_check_type=""
+
+while IFS='|' read -r source_file op_name check_type value; do
+  md_path="$REPO_ROOT/$source_file"
+
+  # Print header on first encounter
+  if [ "$source_file" != "$current_source" ]; then
+    current_source="$source_file"
+    prev_line=0
+    prev_op=""
+    prev_check_type=""
+    echo ""
+    echo "=== $source_file ==="
+    if [ ! -f "$md_path" ]; then
+      fail "$source_file: file not found"
+      continue
+    fi
+  fi
+
+  # Reset ordering when entering a new op or check_type so tracker-local
+  # arrays (which contain enter/commit/exit patterns) don't interfere with
+  # the main flow's ordering, and different tracker types within the same op
+  # don't interfere with each other.
+  if [ "$op_name" != "$prev_op" ] || [ "$check_type" != "$prev_check_type" ]; then
+    prev_line=0
+    prev_op="$op_name"
+    prev_check_type="$check_type"
+  fi
+
+  # Build label
+  label="$source_file > $op_name"
+  if [ "$check_type" != "cmd" ]; then
+    label="$label ($check_type)"
+  fi
+
+  # For sh lines and tracker arrays, use the value literally.
+  # For commands, extract a key substring via make_pattern.
+  if [ "$check_type" = "sh" ]; then
+    pattern="$value"
+  else
+    pattern=$(make_pattern "$value")
+  fi
+
+  if grep -qF -e "$pattern" "$md_path"; then
+    line=$(last_line_of "$md_path" "$pattern")
+    pass "$label"
+
+    # Order check: should not appear before the previous found command
+    if [ "$prev_line" -gt 0 ] && [ -n "$line" ] && [ "$line" -lt "$prev_line" ]; then
+      fail "$label: ordering — line $line is before previous at line $prev_line"
+    fi
+    if [ -n "$line" ]; then
+      prev_line="$line"
+    fi
+  else
+    fail "$label" "expected pattern: $pattern"
+  fi
+
+done < "$TMPFILE"
+
+rm -f "$TMPFILE"
+
+# ============================================================
+# Results
+# ============================================================
+
+echo ""
+echo "================================"
+printf "Results: %s passed, %s failed, %s total\n" "$PASS" "$FAIL" "$TOTAL"
+
+if [ "$FAIL" -gt 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
## Slice

#36

## Parent

#34

## Acceptance criteria

- [x] Pre-merge worktree enters on SLICE_BRANCH (not TARGET_BRANCH) for both single and multi-slice — pre-merge check section is unconditional, uses `--slice-branch $SLICE_BRANCH --branch-op checkout`
- [x] Pre-merge merges TARGET_BRANCH into SLICE_BRANCH and runs tests — `git merge origin/$TARGET_BRANCH` followed by full test suite
- [x] If pre-merge tests fail, tags to-rework (both paths) — `tracker.sh issue edit $SLICE_NUMBER --remove-label to-merge --add-label to-rework`, stops before single/multi-slice steps
- [x] Post-merge worktree step is removed (no worktree-enter after gh pr merge) — old "Verify post-merge" section deleted entirely
- [x] ORCHESTRATION.md merge.md entry includes `gh pr view` operation — `pre-merge-check` op
- [x] ORCHESTRATION.md merge.md entry includes `tracker.sh issue list` operation — `check-siblings` op
- [x] ORCHESTRATION.md merge.md entry includes `tracker.sh issue view` for completion check (separate from fetch-context) — `check-completion` op
- [x] `sh tests/test-orchestration.sh` passes with 0 failures — 21 passed, 0 failed

## Ambiguous choices

- **ORCHESTRATION.md scope**: Created ORCHESTRATION.md with only the merge.md entry (not all phases). Other sibling slices (#35, #37, #38, #39) will add their own entries. This avoids merge conflicts between parallel slices.
- **commit.sh vs reef-worktree-commit.sh**: Used `commit.sh --branch` shorthand in merge.md to match the ORCHESTRATION.md convention and test pattern expectations, consistent with how other phases reference the script.
- **Check siblings and completion ordering**: Placed `check-siblings` before `check-completion` and before `close the slice` in the multi-slice flow, matching the logical dependency (need to check siblings before deciding if plan is complete).

## Test results

```
=== reef-pulse/merge.md ===
21 passed, 0 failed, 21 total

=== reef-worktree tests ===
20 passed, 0 failed, 20 total
```