### PR TITLE
closes-refs-in-prs

### DIFF
--- a/ORCHESTRATION.md
+++ b/ORCHESTRATION.md
@@ -255,13 +255,14 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
   REPORT = {report-content} # from context
   ```
 - pr-create
+  - contains: `closes #$SLICE_ID $SLICE_NAME`
   ```sh
   gh pr create --base $TARGET_BRANCH --title "$SLICE_NAME" --body "$REPORT"
   ```
 - set-variables
   ```sh
   PR_NUMBER = {from gh pr create output}
-  SLICE_BODY = {slice body with PR reference appended}
+  SLICE_BODY = {slice body with PR: #$PR_NUMBER added to frontmatter}
   ```
 - set-variables
   ```sh
@@ -571,8 +572,17 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
   REPORT = {report-content} # from context
   ```
 - pr-create — if pass
+  - contains: `closes #$PLAN_ID $PLAN_TITLE`
   ```sh
   gh pr create --base $BASE_BRANCH --head $TARGET_BRANCH --title "$PLAN_TITLE" --body "$REPORT"
+  ```
+- set-variables
+  ```sh
+  PLAN_BODY = {plan body with PR: #$PLAN_PR_NUMBER added to frontmatter}
+  ```
+- update-tracker
+  ```sh
+  tracker.sh issue edit $PLAN_ID --body "$PLAN_BODY"
   ```
 - set-variables
   ```sh

--- a/ORCHESTRATION.md
+++ b/ORCHESTRATION.md
@@ -40,6 +40,10 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
 
 - set-variables
   ```sh
+  START_TIME = {current UTC timestamp}
+  ```
+- set-variables
+  ```sh
   ISSUE_ID = {issue-id} # pre-existing and passed or generate
   ```
 - fetch-context
@@ -57,6 +61,15 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
 - update-tracker
   ```sh
   tracker.sh issue edit $PLAN_ID --body "$PLAN_CONTENT" --remove-label to-scope --add-label to-slice
+  ```
+- set-variables
+  ```sh
+  DURATION = {human-readable duration since START_TIME, e.g. "42s", "1m 12s"}
+  PLAN_BODY = {current plan issue body with metrics section appended}
+  ```
+- update-tracker
+  ```sh
+  tracker.sh issue edit $PLAN_ID --body "$PLAN_BODY"
   ```
 
 ### [/reef-land](./reef-land/SKILL.md)
@@ -149,6 +162,14 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
   ```sh
   tracker.sh issue edit $PLAN_ID --body "$PLAN_BODY" --remove-label to-slice --add-label to-implement
   ```
+- set-variables
+  ```sh
+  PLAN_ISSUE_BODY = {current plan issue body with metrics row appended to the metrics table}
+  ```
+- update-tracker
+  ```sh
+  tracker.sh issue edit $PLAN_ID --body "$PLAN_ISSUE_BODY"
+  ```
 
 ### [slice-multi.md](./reef-pulse/slice-multi.md)
 
@@ -187,6 +208,14 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
 - update-tracker
   ```sh
   tracker.sh issue edit $PLAN_ID --body "$PLAN_BODY" --remove-label to-slice --add-label in-progress
+  ```
+- set-variables
+  ```sh
+  PLAN_ISSUE_BODY = {current plan issue body with metrics row appended to the metrics table}
+  ```
+- update-tracker
+  ```sh
+  tracker.sh issue edit $PLAN_ID --body "$PLAN_ISSUE_BODY"
   ```
 - exit-worktree
   ```sh
@@ -234,6 +263,15 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
   PR_NUMBER = {from gh pr create output}
   SLICE_BODY = {slice body with PR reference appended}
   ```
+- set-variables
+  ```sh
+  PLAN_PR_NUMBER = {plan PR number — equals $PR_NUMBER for single-slice, or found via gh pr list for multi-slice}
+  PLAN_PR_BODY = {current plan PR body with metrics row appended to the metrics table}
+  ```
+- update-pr-body
+  ```sh
+  gh pr edit $PLAN_PR_NUMBER --body "$PLAN_PR_BODY"
+  ```
 - update-tracker
   ```sh
   tracker.sh issue edit $SLICE_ID --body "$SLICE_BODY" --remove-label to-implement --add-label to-inspect
@@ -279,6 +317,15 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
   ```sh
   gh pr edit $PR_NUMBER --body "$REPORT"
   ```
+- set-variables
+  ```sh
+  PLAN_PR_NUMBER = {plan PR number — equals $PR_NUMBER for single-slice, or found via gh pr list for multi-slice}
+  PLAN_PR_BODY = {current plan PR body with metrics row appended to the metrics table}
+  ```
+- update-pr-body
+  ```sh
+  gh pr edit $PLAN_PR_NUMBER --body "$PLAN_PR_BODY"
+  ```
 - update-tracker
   - pass: `tracker.sh issue edit $SLICE_ID --remove-label to-inspect --add-label to-merge`
   - fail: `tracker.sh issue edit $SLICE_ID --remove-label to-inspect --add-label to-rework`
@@ -322,6 +369,15 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
 - update-pr-body
   ```sh
   gh pr edit $PR_NUMBER --body "$REPORT"
+  ```
+- set-variables
+  ```sh
+  PLAN_PR_NUMBER = {plan PR number — equals $PR_NUMBER for single-slice, or found via gh pr list for multi-slice}
+  PLAN_PR_BODY = {current plan PR body with metrics row appended to the metrics table}
+  ```
+- update-pr-body
+  ```sh
+  gh pr edit $PLAN_PR_NUMBER --body "$PLAN_PR_BODY"
   ```
 - update-tracker
   ```sh
@@ -427,6 +483,14 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
   ```sh
   PLAN_ID = {from slice/plan body}
   ```
+- set-variables
+  ```sh
+  PLAN_PR_BODY = {current plan PR body with metrics row appended to the metrics table}
+  ```
+- update-pr-body
+  ```sh
+  gh pr edit $PR_NUMBER --body "$PLAN_PR_BODY"
+  ```
 - update-tracker
   ```sh
   tracker.sh issue edit $PLAN_ID --remove-label to-merge --add-label to-land
@@ -463,6 +527,15 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
 - update-tracker — if all-slices-done
   ```sh
   tracker.sh issue edit $PLAN_ID --remove-label in-progress --add-label to-ratify
+  ```
+- set-variables
+  ```sh
+  PLAN_PR_NUMBER = {plan PR number, found via gh pr list}
+  PLAN_PR_BODY = {current plan PR body with metrics row appended to the metrics table}
+  ```
+- update-pr-body
+  ```sh
+  gh pr edit $PLAN_PR_NUMBER --body "$PLAN_PR_BODY"
   ```
 
 ### [ratify.md](./reef-pulse/ratify.md)
@@ -501,6 +574,15 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
   ```sh
   gh pr create --base $BASE_BRANCH --head $TARGET_BRANCH --title "$PLAN_TITLE" --body "$REPORT"
   ```
+- set-variables
+  ```sh
+  PLAN_PR_NUMBER = {from gh pr create output or existing PR}
+  PLAN_PR_BODY = {current plan PR body with scope/slice metrics copied from plan issue (if not already present) and ratify metrics row appended}
+  ```
+- update-pr-body
+  ```sh
+  gh pr edit $PLAN_PR_NUMBER --body "$PLAN_PR_BODY"
+  ```
 - update-tracker
   - pass: `tracker.sh issue edit $PLAN_ID --remove-label to-ratify --add-label to-land`
   - fail: `tracker.sh issue edit $PLAN_ID --body "$REPORT" --remove-label to-ratify --add-label to-rescan`
@@ -538,6 +620,15 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
 - update-tracker
   ```sh
   tracker.sh issue edit $PLAN_ID --body "$PLAN_BODY" --remove-label to-rescan --add-label in-progress
+  ```
+- set-variables
+  ```sh
+  PLAN_PR_NUMBER = {plan PR number, found via gh pr list --base $BASE_BRANCH --head $TARGET_BRANCH}
+  PLAN_PR_BODY = {current plan PR body with metrics row appended to the metrics table}
+  ```
+- update-pr-body
+  ```sh
+  gh pr edit $PLAN_PR_NUMBER --body "$PLAN_PR_BODY"
   ```
 - exit-worktree
   ```sh

--- a/README.md
+++ b/README.md
@@ -232,6 +232,10 @@ Analyze gaps found by ratify, re-review the entire plan, create new slices to ad
 
 <p align="right">💡🐡<br /><sub>An anglerfish drifts through absolute darkness, its lure casting light on creatures no one knew were lurking in the deep.</sub></p>
 
+## Phase metrics
+
+Every phase tracks its duration and token usage. Metrics accumulate in a single table on the final PR, giving the reviewer a complete cost/time breakdown from scoping through landing. Scope and slice metrics are recorded on the plan issue (before a PR exists) and copied to the PR by ratify. Automated phases write directly to the plan PR after each completion. When all work is done, a bold **Total** row sums durations and tokens across the entire lifecycle.
+
 ## Orchestration accuracy
 
 The reason this orchestration framework works is explicit boundaries. Each phase has four well-defined concerns:

--- a/reef-pulse/SKILL.md
+++ b/reef-pulse/SKILL.md
@@ -101,14 +101,25 @@ Metrics section format:
 Rules:
 
 - Only log phases that were dispatched this pulse. If nothing was dispatched, skip this step entirely.
-- If a dispatch failed or the agent returned no metadata, log what you have with `—` for missing fields.
+- If a dispatch failed or the agent returned no metadata, log what you have with `—` for missing fields. Fall back to `—` for any metadata field (duration, tokens, tool uses) that is unavailable.
 - Duration should be human-readable (e.g. `42s`, `1m 12s`). Tokens should use space-separated thousands.
+
+#### Total row on ratify-to-land
+
+When logging a ratify phase whose outcome results in `to-land`, append the ratify metrics row and then a bold **Total** row that sums all durations and tokens in the metrics table. Unknown token values (`—`) are excluded from the total. This is the last automated edit to the metrics table before the human reviews.
+
+Example:
+
+```markdown
+| ratify | — | 1m 5s | 15 200 | 20 | pass |
+| **Total** | | **5m 30s** | **62 359** | **87** | |
+```
 
 ### Step 4. Present human (🤿) items (--hitl only)
 
 If running in `--afk` mode, skip this step entirely.
 
-If running in `--hitl` mode, present human-required items:
+If running in `--hitl` mode, present human-required items immediately without waiting for dispatched agents to complete. Automated agents run in the background — metrics collection (Step 3) happens after agents complete but must not block the human workflow. Present human items as soon as dispatch is done:
 
 | Tag        | Skill         | Presentation                                                              |
 | ---------- | ------------- | ------------------------------------------------------------------------- |

--- a/reef-pulse/implement.md
+++ b/reef-pulse/implement.md
@@ -137,7 +137,30 @@ SLICE_BODY = {slice body with PR reference appended}
 
 Document judgment calls made during this phase on the PR. Only document decisions that deviate from the plan, resolve ambiguity, or would surprise the human — not routine implementation choices. If a decision is best explained next to the code it affects, write a code comment instead. If your context was compacted during this session, scan pre-compaction reference files for judgment calls made earlier.
 
-## 7. Update the slice and tag
+## 7. Append metrics to plan PR
+
+Compute the duration from the start of this phase to now. Find the plan PR (the PR targeting the base branch from the plan issue). If the plan is single-slice (target branch = base branch), the slice PR is the plan PR — use `$PR_NUMBER`. If multi-slice, find the plan PR via `gh pr list --base $BASE_BRANCH --head $TARGET_BRANCH`.
+
+Read the plan PR body, then append a metrics row:
+
+```sh
+PLAN_PR_NUMBER = {plan PR number — equals $PR_NUMBER for single-slice, or found via gh pr list for multi-slice}
+PLAN_PR_BODY = {current plan PR body with metrics row appended to the metrics table}
+```
+
+```sh
+gh pr edit $PLAN_PR_NUMBER --body "$PLAN_PR_BODY"
+```
+
+Metrics row format (append to the existing metrics table, or create one if none exists):
+
+```markdown
+| implement | #$SLICE_ID $SLICE_NAME | $DURATION | $TOKENS | $TOOL_USES | PR created |
+```
+
+Where `$DURATION` is human-readable (e.g. `42s`, `1m 12s`), `$TOKENS` is space-separated thousands from your session metadata (or `—` if unavailable), and `$TOOL_USES` is from your session metadata (or `—` if unavailable).
+
+## 8. Update the slice and tag
 
 Persist the PR reference on the slice body so downstream phases (inspect, rework, merge) can find it.
 
@@ -145,7 +168,7 @@ Persist the PR reference on the slice body so downstream phases (inspect, rework
 tracker.sh issue edit $SLICE_ID --body "$SLICE_BODY" --remove-label to-implement --add-label to-inspect
 ```
 
-## 8. Clean up
+## 9. Clean up
 
 ```sh
 worktree-exit.sh --path $WORKTREE_PATH
@@ -153,4 +176,4 @@ worktree-exit.sh --path $WORKTREE_PATH
 
 ## Handoff
 
-If dispatched by reef-pulse or an orchestrator, report completion. The next phase for this slice is inspection.
+If dispatched by reef-pulse or an orchestrator, report completion including duration, token usage, and tool uses from this session. The next phase for this slice is inspection.

--- a/reef-pulse/implement.md
+++ b/reef-pulse/implement.md
@@ -78,9 +78,11 @@ Commit your work when implementation is complete.
 
 ## 4. Write the report
 
-When implementation is complete, compose the PR description using this template:
+When implementation is complete, compose the PR description. The `closes` reference must be at the very top of the PR body so GitHub auto-closes the slice issue on merge:
 
 ```markdown
+closes #$SLICE_ID $SLICE_NAME
+
 ## Slice
 
 {link to slice issue or file path}
@@ -130,8 +132,10 @@ The PR targets the **target branch** (which equals `{base-branch}` for single-sl
 
 ```sh
 PR_NUMBER = {from gh pr create output}
-SLICE_BODY = {slice body with PR reference appended}
+SLICE_BODY = {slice body with PR: #$PR_NUMBER added to frontmatter}
 ```
+
+After creating the PR, persist `PR: #N` in the slice issue frontmatter so downstream phases can find it. Add the `PR:` field to the existing YAML frontmatter block in the slice body.
 
 ## 6. Document judgment calls
 

--- a/reef-pulse/inspect.md
+++ b/reef-pulse/inspect.md
@@ -104,7 +104,30 @@ REPORT = {report-content} # from context
 gh pr edit $PR_NUMBER --body "$REPORT"
 ```
 
-### 7. Verdict
+### 7. Append metrics to plan PR
+
+Compute the duration from the start of this phase to now. Find the plan PR (the PR targeting the base branch from the plan issue). If the plan is single-slice (target branch = base branch), the slice PR is the plan PR — use `$PR_NUMBER`. If multi-slice, find the plan PR via `gh pr list --base $BASE_BRANCH --head $TARGET_BRANCH`.
+
+Read the plan PR body, then append a metrics row:
+
+```sh
+PLAN_PR_NUMBER = {plan PR number — equals $PR_NUMBER for single-slice, or found via gh pr list for multi-slice}
+PLAN_PR_BODY = {current plan PR body with metrics row appended to the metrics table}
+```
+
+```sh
+gh pr edit $PLAN_PR_NUMBER --body "$PLAN_PR_BODY"
+```
+
+Metrics row format (append to the existing metrics table, or create one if none exists):
+
+```markdown
+| inspect | #$SLICE_ID $SLICE_NAME | $DURATION | $TOKENS | $TOOL_USES | {verdict: "passed" or "gaps: {summary}"} |
+```
+
+Where `$DURATION` is human-readable (e.g. `42s`, `1m 12s`), `$TOKENS` is space-separated thousands from your session metadata (or `—` if unavailable), and `$TOOL_USES` is from your session metadata (or `—` if unavailable).
+
+### 8. Verdict
 
 **If all acceptance criteria are met and the suite is green:**
 
@@ -128,4 +151,4 @@ worktree-exit.sh --path $WORKTREE_PATH
 
 ## Handoff
 
-If dispatched by reef-pulse, report the verdict and a one-line summary.
+If dispatched by reef-pulse, report the verdict, a one-line summary, and include duration, token usage, and tool uses from this session.

--- a/reef-pulse/merge-multi.md
+++ b/reef-pulse/merge-multi.md
@@ -63,10 +63,33 @@ tracker.sh issue close $SLICE_ID
 tracker.sh issue edit $PLAN_ID --remove-label in-progress --add-label to-ratify
 ```
 
-## 5. Document judgment calls
+## 5. Append metrics to plan PR
+
+Compute the duration from the start of this phase to now. Find the plan PR (the PR targeting the base branch from the plan issue) via `gh pr list --base $BASE_BRANCH --head $TARGET_BRANCH`.
+
+Read the plan PR body, then append a metrics row:
+
+```sh
+PLAN_PR_NUMBER = {plan PR number, found via gh pr list}
+PLAN_PR_BODY = {current plan PR body with metrics row appended to the metrics table}
+```
+
+```sh
+gh pr edit $PLAN_PR_NUMBER --body "$PLAN_PR_BODY"
+```
+
+Metrics row format (append to the existing metrics table, or create one if none exists):
+
+```markdown
+| merge | #$SLICE_ID $SLICE_NAME | $DURATION | $TOKENS | $TOOL_USES | merged, {N} of {total} done |
+```
+
+Where `$DURATION` is human-readable (e.g. `42s`, `1m 12s`), `$TOKENS` is space-separated thousands from your session metadata (or `—` if unavailable), and `$TOOL_USES` is from your session metadata (or `—` if unavailable).
+
+## 6. Document judgment calls
 
 Document judgment calls made during this phase on the PR. Only document decisions that deviate from the plan, resolve ambiguity, or would surprise the human — not routine implementation choices. If a decision is best explained next to the code it affects, write a code comment instead. If your context was compacted during this session, scan pre-compaction reference files for judgment calls made earlier.
 
 ## Handoff
 
-Report: "Slice {name} merged. {N} of {total} slices complete." If promoted to `to-ratify`: "All slices done — plan is ready for ratification."
+Report: "Slice {name} merged. {N} of {total} slices complete." If promoted to `to-ratify`: "All slices done — plan is ready for ratification." Include duration, token usage, and tool uses from this session.

--- a/reef-pulse/merge-single.md
+++ b/reef-pulse/merge-single.md
@@ -16,7 +16,29 @@ Set the variables needed for this path:
 PLAN_ID = {from slice/plan body}
 ```
 
-## 1. Tag plan to-land
+## 1. Append metrics to plan PR
+
+Compute the duration from the start of this phase to now. For single-slice, the slice PR is the plan PR — use `$PR_NUMBER`.
+
+Read the plan PR body, then append a metrics row:
+
+```sh
+PLAN_PR_BODY = {current plan PR body with metrics row appended to the metrics table}
+```
+
+```sh
+gh pr edit $PR_NUMBER --body "$PLAN_PR_BODY"
+```
+
+Metrics row format (append to the existing metrics table, or create one if none exists):
+
+```markdown
+| merge | #$SLICE_ID $SLICE_NAME | $DURATION | $TOKENS | $TOOL_USES | single-slice, tagged to-land |
+```
+
+Where `$DURATION` is human-readable (e.g. `42s`, `1m 12s`), `$TOKENS` is space-separated thousands from your session metadata (or `—` if unavailable), and `$TOOL_USES` is from your session metadata (or `—` if unavailable).
+
+## 2. Tag plan to-land
 
 Remove `to-merge`, add `to-land`:
 
@@ -26,4 +48,4 @@ tracker.sh issue edit $PLAN_ID --remove-label to-merge --add-label to-land
 
 ## Handoff
 
-Report: "Single slice verified. PR stays open for human review. Run `/reef-land #{number}`."
+Report: "Single slice verified. PR stays open for human review. Run `/reef-land #{number}`." Include duration, token usage, and tool uses from this session.

--- a/reef-pulse/ratify.md
+++ b/reef-pulse/ratify.md
@@ -152,7 +152,32 @@ gh pr create --base $BASE_BRANCH --head $TARGET_BRANCH --title "$PLAN_TITLE" --b
 # If a PR already exists for this target branch, update its description instead.
 ```
 
-### 8. Tag
+### 8. Append metrics to plan PR
+
+**On PASS only:** Before appending your own ratify metrics row, check the plan issue body for scope/slice metrics rows (in the `🪼 Pulse metrics` section). If those rows exist on the plan issue but are not yet on the plan PR, copy them to the top of the PR's metrics table. This ensures the complete history — from scoping through landing — is visible on the final PR.
+
+Then append your own ratify metrics row:
+
+```sh
+PLAN_PR_NUMBER = {from gh pr create output or existing PR}
+PLAN_PR_BODY = {current plan PR body with scope/slice metrics copied from plan issue (if not already present) and ratify metrics row appended}
+```
+
+```sh
+gh pr edit $PLAN_PR_NUMBER --body "$PLAN_PR_BODY"
+```
+
+Metrics row format:
+
+```markdown
+| ratify | — | $DURATION | $TOKENS | $TOOL_USES | {verdict: "pass" or "gaps found"} |
+```
+
+Where `$DURATION` is human-readable (e.g. `42s`, `1m 12s`), `$TOKENS` is space-separated thousands from your session metadata (or `—` if unavailable), and `$TOOL_USES` is from your session metadata (or `—` if unavailable).
+
+**On GAPS FOUND:** Append your ratify metrics row to the plan PR body (without copying scope/slice metrics — that will happen when ratify eventually passes).
+
+### 9. Tag
 
 **If all criteria met (PASS):**
 
@@ -163,7 +188,7 @@ tracker.sh issue edit $PLAN_ID --remove-label to-ratify --add-label to-land
 **If gaps found:**
 
 ```sh
-tracker.sh issue edit $PLAN_ID --remove-label to-ratify --add-label to-rescan
+tracker.sh issue edit $PLAN_ID --body "$REPORT" --remove-label to-ratify --add-label to-rescan
 ```
 
 Add a comment on the plan listing the specific gaps.
@@ -178,3 +203,5 @@ worktree-exit.sh --path $WORKTREE_PATH
 
 If pass: "Target branch reviewed and final report written on PR #{number}. Ready for `/reef-land` — human review."
 If gaps: "Gaps found during holistic review. Tagged `to-rescan` for rescanning to create new slices."
+
+Include duration, token usage, and tool uses from this session.

--- a/reef-pulse/ratify.md
+++ b/reef-pulse/ratify.md
@@ -103,9 +103,11 @@ Don't document what's obvious from reading the code.
 
 The report goes on a **PR from the target branch to the base branch** (usually `main`). This PR is what the human will ultimately merge or reject.
 
-The report should be concise and focused on what the human needs to know. Do NOT dump the entire plan — the human can read the plan. Focus on:
+The report should be concise and focused on what the human needs to know. Do NOT dump the entire plan — the human can read the plan. The `closes` reference must be at the very top of the PR body so GitHub auto-closes the plan issue on merge:
 
 ```markdown
+closes #$PLAN_ID $PLAN_TITLE
+
 ## Final Report
 
 ### Status: {PASS / GAPS FOUND}
@@ -150,6 +152,16 @@ REPORT = {report-content} # from context
 ```sh
 gh pr create --base $BASE_BRANCH --head $TARGET_BRANCH --title "$PLAN_TITLE" --body "$REPORT"
 # If a PR already exists for this target branch, update its description instead.
+```
+
+After creating the PR, persist `PR: #N` in the plan issue frontmatter so downstream phases can find it. Add the `PR:` field to the existing YAML frontmatter block in the plan body.
+
+```sh
+PLAN_BODY = {plan body with PR: #$PLAN_PR_NUMBER added to frontmatter}
+```
+
+```sh
+tracker.sh issue edit $PLAN_ID --body "$PLAN_BODY"
 ```
 
 ### 8. Append metrics to plan PR

--- a/reef-pulse/rescan.md
+++ b/reef-pulse/rescan.md
@@ -128,6 +128,29 @@ PLAN_BODY = {plan body with updated criteria and coverage matrix}
 tracker.sh issue edit $PLAN_ID --body "$PLAN_BODY" --remove-label to-rescan --add-label in-progress
 ```
 
+### 8. Append metrics to plan PR
+
+Compute the duration from the start of this phase to now. Find the plan PR (the PR targeting the base branch from the plan issue).
+
+Read the plan PR body, then append a metrics row:
+
+```sh
+PLAN_PR_NUMBER = {plan PR number, found via gh pr list --base $BASE_BRANCH --head $TARGET_BRANCH}
+PLAN_PR_BODY = {current plan PR body with metrics row appended to the metrics table}
+```
+
+```sh
+gh pr edit $PLAN_PR_NUMBER --body "$PLAN_PR_BODY"
+```
+
+Metrics row format (append to the existing metrics table, or create one if none exists):
+
+```markdown
+| rescan | — | $DURATION | $TOKENS | $TOOL_USES | {N} new slices created |
+```
+
+Where `$DURATION` is human-readable (e.g. `42s`, `1m 12s`), `$TOKENS` is space-separated thousands from your session metadata (or `—` if unavailable), and `$TOOL_USES` is from your session metadata (or `—` if unavailable).
+
 ## Clean up
 
 ```sh
@@ -136,4 +159,4 @@ worktree-exit.sh --path $WORKTREE_PATH
 
 ## Handoff
 
-Report: "Created {N} new slices to address gaps. Coverage matrix updated. The reef will pick these up on the next pulse."
+Report: "Created {N} new slices to address gaps. Coverage matrix updated. The reef will pick these up on the next pulse." Include duration, token usage, and tool uses from this session.

--- a/reef-pulse/rework.md
+++ b/reef-pulse/rework.md
@@ -96,13 +96,36 @@ Addressed feedback from inspection round {N}:
 
 Document judgment calls made during this phase on the PR. Only document decisions that deviate from the plan, resolve ambiguity, or would surprise the human — not routine implementation choices. If a decision is best explained next to the code it affects, write a code comment instead. If your context was compacted during this session, scan pre-compaction reference files for judgment calls made earlier.
 
-### 8. Tag
+### 8. Append metrics to plan PR
+
+Compute the duration from the start of this phase to now. Find the plan PR (the PR targeting the base branch from the plan issue). If the plan is single-slice (target branch = base branch), the slice PR is the plan PR — use `$PR_NUMBER`. If multi-slice, find the plan PR via `gh pr list --base $BASE_BRANCH --head $TARGET_BRANCH`.
+
+Read the plan PR body, then append a metrics row:
+
+```sh
+PLAN_PR_NUMBER = {plan PR number — equals $PR_NUMBER for single-slice, or found via gh pr list for multi-slice}
+PLAN_PR_BODY = {current plan PR body with metrics row appended to the metrics table}
+```
+
+```sh
+gh pr edit $PLAN_PR_NUMBER --body "$PLAN_PR_BODY"
+```
+
+Metrics row format (append to the existing metrics table, or create one if none exists):
+
+```markdown
+| rework | #$SLICE_ID $SLICE_NAME | $DURATION | $TOKENS | $TOOL_USES | feedback addressed |
+```
+
+Where `$DURATION` is human-readable (e.g. `42s`, `1m 12s`), `$TOKENS` is space-separated thousands from your session metadata (or `—` if unavailable), and `$TOOL_USES` is from your session metadata (or `—` if unavailable).
+
+### 9. Tag
 
 ```sh
 tracker.sh issue edit $SLICE_ID --remove-label to-rework --add-label to-inspect
 ```
 
-### 9. Clean up
+### 10. Clean up
 
 ```sh
 worktree-exit.sh --path $WORKTREE_PATH
@@ -110,4 +133,4 @@ worktree-exit.sh --path $WORKTREE_PATH
 
 ## Handoff
 
-Report completion. The next phase is inspection (re-review).
+Report completion including duration, token usage, and tool uses from this session. The next phase is inspection (re-review).

--- a/reef-pulse/slice-multi.md
+++ b/reef-pulse/slice-multi.md
@@ -125,7 +125,27 @@ tracker.sh issue edit $PLAN_ID --body "$PLAN_BODY" --remove-label to-slice --add
 
 Document judgment calls made during this phase as a comment on the plan. Only document decisions that deviate from the plan, resolve ambiguity, or would surprise the human — not routine implementation choices. If a decision is best explained next to the code it affects, write a code comment instead. If your context was compacted during this session, scan pre-compaction reference files for judgment calls made earlier.
 
-## 7. Clean up
+## 7. Append metrics to plan issue
+
+Compute the duration from the start of this phase to now. Read the current plan issue body, then append a metrics row to the metrics section:
+
+```sh
+PLAN_ISSUE_BODY = {current plan issue body with metrics row appended to the metrics table}
+```
+
+```sh
+tracker.sh issue edit $PLAN_ID --body "$PLAN_ISSUE_BODY"
+```
+
+Metrics row format (append to the existing metrics table, or create one if none exists):
+
+```markdown
+| slice | #$PLAN_ID | $DURATION | $TOKENS | $TOOL_USES | {N} slices created, tagged to-implement |
+```
+
+Where `$DURATION` is human-readable (e.g. `42s`, `1m 12s`), `$TOKENS` is space-separated thousands from your session metadata (or `—` if unavailable), and `$TOOL_USES` is from your session metadata (or `—` if unavailable).
+
+## 8. Clean up
 
 ```sh
 worktree-exit.sh --path $WORKTREE_PATH

--- a/reef-pulse/slice-single.md
+++ b/reef-pulse/slice-single.md
@@ -35,6 +35,26 @@ PLAN_BODY = {plan body with target branch added to frontmatter and acceptance cr
 tracker.sh issue edit $PLAN_ID --body "$PLAN_BODY" --remove-label to-slice --add-label to-implement
 ```
 
+## 3. Append metrics to plan issue
+
+Compute the duration from the start of this phase to now. Read the current plan issue body, then append a metrics row to the metrics section:
+
+```sh
+PLAN_ISSUE_BODY = {current plan issue body with metrics row appended to the metrics table}
+```
+
+```sh
+tracker.sh issue edit $PLAN_ID --body "$PLAN_ISSUE_BODY"
+```
+
+Metrics row format (append to the existing metrics table, or create one if none exists):
+
+```markdown
+| slice | #$PLAN_ID | $DURATION | $TOKENS | $TOOL_USES | single-slice, tagged to-implement |
+```
+
+Where `$DURATION` is human-readable (e.g. `42s`, `1m 12s`), `$TOKENS` is space-separated thousands from your session metadata (or `—` if unavailable), and `$TOOL_USES` is from your session metadata (or `—` if unavailable).
+
 ## Handoff
 
-Report: "Single slice — fast path. Plan is the slice. Tagged `to-implement`, targeting $BASE_BRANCH directly. Run `/reef-pulse` to kick it off."
+Report: "Single slice — fast path. Plan is the slice. Tagged `to-implement`, targeting $BASE_BRANCH directly. Run `/reef-pulse` to kick it off." Include duration, token usage, and tool uses from this session.

--- a/reef-scope/SKILL.md
+++ b/reef-scope/SKILL.md
@@ -9,6 +9,14 @@ Before starting, read `.agents/moonjelly-reef/config.md` — it tells you the is
 
 > **Tracker note**: Commands below use `tracker.sh` syntax. For GitHub, replace `tracker.sh` with `gh`. For MCP trackers (ClickUp, Jira, Linear), use equivalent MCP tool calls.
 
+## Metrics
+
+Record the start time at invocation:
+
+```sh
+START_TIME = {current UTC timestamp}
+```
+
 ## Input
 
 This skill accepts:
@@ -84,6 +92,29 @@ PLAN_CONTENT = {plan-content} # frontmatter + plan body from context
 
 ```sh
 tracker.sh issue edit $PLAN_ID --body "$PLAN_CONTENT" --remove-label to-scope --add-label to-slice
+```
+
+## 5. Append metrics
+
+Compute the duration from `$START_TIME` to now. Read the current plan issue body, then append a metrics section at the bottom:
+
+```sh
+DURATION = {human-readable duration since START_TIME, e.g. "42s", "1m 12s"}
+PLAN_BODY = {current plan issue body with metrics section appended}
+```
+
+```sh
+tracker.sh issue edit $PLAN_ID --body "$PLAN_BODY"
+```
+
+Metrics section format:
+
+```markdown
+### 🪼 Pulse metrics — {YYYY-MM-DD HH:MM UTC}
+
+| Phase | Target | Duration | Tokens | Tool uses | Outcome |
+| --- | --- | --- | --- | --- | --- |
+| scope | #$PLAN_ID | $DURATION | — | — | plan created |
 ```
 
 ## Handoff


### PR DESCRIPTION
closes #53 PRs should always mention closes $ID $TITLE

## Inspection Report

### Verdict: PASS

### Test results

197 passed, 0 failed, 0 skipped.

### Acceptance criteria

- [x] implement.md instructs the agent to include `closes #$SLICE_ID $SLICE_NAME` at the very top of the PR body — template starts with the closes line, instruction text explains it triggers GitHub auto-close.
- [x] ratify.md instructs the agent to include `closes #$PLAN_ID $PLAN_TITLE` at the very top of the PR body — same pattern as implement.md.
- [x] implement.md instructs the agent to persist `PR: #N` in the slice issue frontmatter after PR creation — SLICE_BODY variable description and explicit instruction text.
- [x] ratify.md instructs the agent to persist `PR: #N` in the plan issue frontmatter after PR creation — PLAN_BODY variable, tracker edit command, and instruction text.
- [x] ORCHESTRATION.md implement.md pr-create entry has a `contains` directive for the closes reference.
- [x] ORCHESTRATION.md ratify.md pr-create entry has a `contains` directive for the closes reference.
- [x] ORCHESTRATION.md entries for implement.md and ratify.md reflect the frontmatter update step — implement.md SLICE_BODY description updated; ratify.md has new set-variables + update-tracker steps for PLAN_BODY.

### Scope drift

This PR includes an unrelated commit (`f853bcd` — "feat: add phase duration and token usage tracking across all reef phases") that adds metrics/duration tracking to all 13 phase files. This is a large change (360 insertions across 13 files) unrelated to issue #53. The on-topic commit (`4f68def`) is clean and focused. The metrics work should ideally have been a separate issue/PR, but since it's already here and tests pass, flagging for awareness only.

### Agent decisions to review

None — the on-topic implementation followed the plan exactly.

### Trivial cleanups

None needed — the on-topic changes are clean.