### PR TITLE
fix: use skill base directory for dispatch paths

### DIFF
--- a/ORCHESTRATION.md
+++ b/ORCHESTRATION.md
@@ -19,6 +19,7 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
 
 - set-variables
   ```sh
+  SKILL_DIR = {base directory for this skill}
   TRACKER_BRANCH = {from config.md} # e.g. main
   ```
 - checkout-tracker-branch — if local-tracker-committed
@@ -26,6 +27,7 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
   git fetch origin $TRACKER_BRANCH && git checkout $TRACKER_BRANCH && git pull
   ```
 - phase-specific
+  - contains: `$SKILL_DIR/{file}`
 - set-variables
   ```sh
   ISSUE_ID = {from dispatched items}

--- a/ORCHESTRATION.md
+++ b/ORCHESTRATION.md
@@ -19,6 +19,7 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
 
 - set-variables
   ```sh
+  SKILL_DIR = {base directory for this skill}
   TRACKER_BRANCH="{from config.md}" # e.g. main
   ```
 - checkout-tracker-branch — if local-tracker-committed
@@ -26,6 +27,7 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
   git fetch origin "$TRACKER_BRANCH" && git checkout "$TRACKER_BRANCH" && git pull
   ```
 - phase-specific
+  - contains: `$SKILL_DIR/{file}`
 - set-variables
   ```sh
   ISSUE_ID="{from dispatched items}"

--- a/ORCHESTRATION.md
+++ b/ORCHESTRATION.md
@@ -19,7 +19,7 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
 
 - set-variables
   ```sh
-  SKILL_DIR = {base directory for this skill}
+  SKILL_DIR="{base directory for this skill}"
   TRACKER_BRANCH="{from config.md}" # e.g. main
   ```
 - checkout-tracker-branch — if local-tracker-committed

--- a/reef-pulse/SKILL.md
+++ b/reef-pulse/SKILL.md
@@ -16,7 +16,7 @@ You are the orchestrator. You scan, dispatch, and exit. You hold no state — ta
 Capture the skill base directory (provided by the harness as "Base directory for this skill: {path}" at invocation time):
 
 ```sh
-SKILL_DIR = {base directory for this skill}
+SKILL_DIR="{base directory for this skill}"
 ```
 
 ## 0. Sync tracker branch (local-tracker-committed only)

--- a/reef-pulse/SKILL.md
+++ b/reef-pulse/SKILL.md
@@ -13,6 +13,12 @@ Before starting, read `.agents/moonjelly-reef/config.md` — it tells you the is
 
 You are the orchestrator. You scan, dispatch, and exit. You hold no state — tags are the state.
 
+Capture the skill base directory (provided by the harness as "Base directory for this skill: {path}" at invocation time):
+
+```sh
+SKILL_DIR = {base directory for this skill}
+```
+
 ## 0. Sync tracker branch (local-tracker-committed only)
 
 If the tracker type in config is `local-tracker-committed`, the tracker files live in a git-tracked directory on a specific branch. Sync it before scanning:
@@ -62,18 +68,18 @@ Run these queries in parallel where possible for performance.
 
 **CRITICAL: Do NOT use `isolation: "worktree"` when spawning sub-agents.** Each phase manages its own worktree via `worktree-enter.sh` (fetches from origin, forks from the correct remote branch). Platform isolation bypasses this and causes merge conflicts.
 
-For each item, spawn a sub-agent with: `"Read and follow reef-pulse/{file}. Target: #{number}."`
+For each item, spawn a sub-agent with: `"Read and follow $SKILL_DIR/{file}. Target: #{number}."`
 
 | Tag              | File                             |
 | ---------------- | -------------------------------- |
-| `to-slice`       | [slice.md](slice.md)             |
-| `to-await-waves` | [await-waves.md](await-waves.md) |
-| `to-implement`   | [implement.md](implement.md)     |
-| `to-inspect`     | [inspect.md](inspect.md)         |
-| `to-rework`      | [rework.md](rework.md)           |
-| `to-merge`       | [merge.md](merge.md)             |
-| `to-ratify`      | [ratify.md](ratify.md)           |
-| `to-rescan`      | [rescan.md](rescan.md)           |
+| `to-slice`       | `$SKILL_DIR/slice.md`            |
+| `to-await-waves` | `$SKILL_DIR/await-waves.md`      |
+| `to-implement`   | `$SKILL_DIR/implement.md`        |
+| `to-inspect`     | `$SKILL_DIR/inspect.md`          |
+| `to-rework`      | `$SKILL_DIR/rework.md`           |
+| `to-merge`       | `$SKILL_DIR/merge.md`            |
+| `to-ratify`      | `$SKILL_DIR/ratify.md`           |
+| `to-rescan`      | `$SKILL_DIR/rescan.md`           |
 
 ### Step 3. Log phase metrics to plan issues
 

--- a/reef-pulse/SKILL.md
+++ b/reef-pulse/SKILL.md
@@ -11,6 +11,12 @@ Before starting, read `.agents/moonjelly-reef/config.md` — it tells you the is
 
 You are the orchestrator. You scan, dispatch, and exit. You hold no state — tags are the state.
 
+Capture the skill base directory (provided by the harness as "Base directory for this skill: {path}" at invocation time):
+
+```sh
+SKILL_DIR = {base directory for this skill}
+```
+
 ## 0. Sync tracker branch (local-tracker-committed only)
 
 If the tracker type in config is `local-tracker-committed`, the tracker files live in a git-tracked directory on a specific branch. Sync it before scanning:
@@ -58,18 +64,18 @@ Run these queries in parallel where possible for performance.
 
 **Do NOT ask the user for confirmation. Dispatch immediately.** The tags are the authorization — if an item is tagged for automated work, dispatch it without hesitation. Dispatch all items in parallel via sub-agents. When agent teams are supported in the environment, they can be used to parallelise items linked to the same plan.
 
-For each item, spawn a sub-agent with: `"Read and follow reef-pulse/{file}. Target: #{number}."`
+For each item, spawn a sub-agent with: `"Read and follow $SKILL_DIR/{file}. Target: #{number}."`
 
 | Tag              | File                             |
 | ---------------- | -------------------------------- |
-| `to-slice`       | [slice.md](slice.md)             |
-| `to-await-waves` | [await-waves.md](await-waves.md) |
-| `to-implement`   | [implement.md](implement.md)     |
-| `to-inspect`     | [inspect.md](inspect.md)         |
-| `to-rework`      | [rework.md](rework.md)           |
-| `to-merge`       | [merge.md](merge.md)             |
-| `to-ratify`      | [ratify.md](ratify.md)           |
-| `to-rescan`      | [rescan.md](rescan.md)           |
+| `to-slice`       | `$SKILL_DIR/slice.md`            |
+| `to-await-waves` | `$SKILL_DIR/await-waves.md`      |
+| `to-implement`   | `$SKILL_DIR/implement.md`        |
+| `to-inspect`     | `$SKILL_DIR/inspect.md`          |
+| `to-rework`      | `$SKILL_DIR/rework.md`           |
+| `to-merge`       | `$SKILL_DIR/merge.md`            |
+| `to-ratify`      | `$SKILL_DIR/ratify.md`           |
+| `to-rescan`      | `$SKILL_DIR/rescan.md`           |
 
 ### Step 3. Log phase metrics to plan issues
 


### PR DESCRIPTION
## Slice

#58

## Parent

#58 (single-slice, plan is the issue itself)

## Acceptance criteria

- [x] reef-pulse/SKILL.md captures the skill base directory into a variable at the top of the skill — added `SKILL_DIR` variable capture with explanation of where the harness provides it.
- [x] The sub-agent dispatch prompt uses the base directory variable to construct absolute paths to phase files — changed from `reef-pulse/{file}` to `$SKILL_DIR/{file}`.
- [x] All phase file references in the dispatch table use the base directory variable instead of relative `reef-pulse/` paths — all 8 table entries now use `$SKILL_DIR/` prefix.
- [x] ORCHESTRATION.md reflects the updated dispatch format — added `SKILL_DIR` to set-variables and a contains directive validating `$SKILL_DIR/{file}` in the phase-specific step.

## Ambiguous choices

None — implementation followed the plan exactly.

## Test results

167 tests passed, 0 failed, 0 skipped.

## Inspection

All acceptance criteria verified by code review. Test suite passes (167/167). No drift from plan, no cleanup needed, no gaps found.