### PR TITLE
Structured handoff, metrics format, and cleanup

### DIFF
--- a/ORCHESTRATION.md
+++ b/ORCHESTRATION.md
@@ -35,6 +35,14 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
   ```sh
   tracker.sh issue edit "$ISSUE_ID" --body "$ISSUE_BODY"
   ```
+- set-variables — if ratify-to-land
+  ```sh
+  PLAN_PR_BODY="{plan PR body with complete metrics table}"
+  ```
+- update-pr — if ratify-to-land
+  ```sh
+  gh pr edit "$PR_NUMBER" --body "$PLAN_PR_BODY"
+  ```
 
 ### [/reef-scope](./reef-scope/SKILL.md)
 
@@ -57,6 +65,11 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
 - update-tracker
   ```sh
   tracker.sh issue edit "$PLAN_ID" --body "$PLAN_CONTENT" --remove-label to-scope --add-label to-slice
+  ```
+- append-metrics
+  ```sh
+  PLAN_CONTENT="{plan content with metrics table appended}"
+  tracker.sh issue edit "$PLAN_ID" --body "$PLAN_CONTENT"
   ```
 
 ### [/reef-land](./reef-land/SKILL.md)
@@ -158,6 +171,13 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
   ```sh
   tracker.sh issue edit "$PLAN_ID" --body "$PLAN_BODY" --remove-label to-slice --add-label to-implement
   ```
+- handoff
+  - contains: `Return structured handoff`
+  ```sh
+  nextPhase="to-implement"
+  planPr="—" # no PR exists yet at slice time
+  summary="{one-line outcome, e.g. single-slice, tagged to-implement}"
+  ```
 
 ### [slice-multi.md](./reef-pulse/slice-multi.md)
 
@@ -200,6 +220,13 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
 - exit-worktree
   ```sh
   worktree-exit.sh --path "$WORKTREE_PATH"
+  ```
+- handoff
+  - contains: `Return structured handoff`
+  ```sh
+  nextPhase="in-progress"
+  planPr="—" # no PR exists yet at slice time
+  summary="{one-line outcome, e.g. N slices created, M unblocked}"
   ```
 
 ### [implement.md](./reef-pulse/implement.md)
@@ -251,6 +278,13 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
   ```sh
   worktree-exit.sh --path "$WORKTREE_PATH"
   ```
+- handoff
+  - contains: `Return structured handoff`
+  ```sh
+  nextPhase="to-inspect"
+  planPr="—" # implement doesn't know the plan PR
+  summary="{one-line outcome, e.g. PR #N created for slice}"
+  ```
 
 ### [inspect.md](./reef-pulse/inspect.md)
 
@@ -293,6 +327,13 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
 - exit-worktree
   ```sh
   worktree-exit.sh --path "$WORKTREE_PATH"
+  ```
+- handoff
+  - contains: `Return structured handoff`
+  ```sh
+  nextPhase="{to-merge or to-rework}"
+  planPr="—" # inspect doesn't know the plan PR
+  summary="{one-line verdict, e.g. passed or gaps found}"
   ```
 
 ### [rework.md](./reef-pulse/rework.md)
@@ -338,6 +379,13 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
   ```sh
   worktree-exit.sh --path "$WORKTREE_PATH"
   ```
+- handoff
+  - contains: `Return structured handoff`
+  ```sh
+  nextPhase="to-inspect"
+  planPr="—" # rework doesn't know the plan PR
+  summary="{one-line outcome, e.g. reworked N issues}"
+  ```
 
 ### [await-waves.md](./reef-pulse/await-waves.md)
 
@@ -381,6 +429,13 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
 - exit-worktree
   ```sh
   worktree-exit.sh --path "$WORKTREE_PATH"
+  ```
+- handoff
+  - contains: `Return structured handoff`
+  ```sh
+  nextPhase="to-implement"
+  planPr="—" # await-waves doesn't know the plan PR
+  summary="{one-line outcome, e.g. slice unblocked and ready}"
   ```
 
 ### [merge.md](./reef-pulse/merge.md)
@@ -438,6 +493,13 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
   ```sh
   tracker.sh issue edit "$PLAN_ID" --remove-label to-merge --add-label to-land
   ```
+- handoff
+  - contains: `Return structured handoff`
+  ```sh
+  nextPhase="to-land"
+  planPr="—" # single-slice has no separate plan PR yet
+  summary="{one-line outcome, e.g. single slice verified, PR stays open}"
+  ```
 
 ### [merge-multi.md](./reef-pulse/merge-multi.md)
 
@@ -470,6 +532,13 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
 - update-tracker — if all-slices-done
   ```sh
   tracker.sh issue edit "$PLAN_ID" --remove-label in-progress --add-label to-ratify
+  ```
+- handoff
+  - contains: `Return structured handoff`
+  ```sh
+  nextPhase="{in-progress or to-ratify}"
+  planPr="—" # multi-slice merge doesn't know the plan PR yet
+  summary="{one-line outcome, e.g. slice merged, N of M complete}"
   ```
 
 ### [ratify.md](./reef-pulse/ratify.md)
@@ -518,6 +587,14 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
   ```sh
   worktree-exit.sh --path "$WORKTREE_PATH"
   ```
+- handoff
+  - contains: `Return structured handoff`
+  ```sh
+  nextPhase="{to-land or to-rescan}"
+  planPr="$PR_NUMBER"
+  summary="{one-line outcome, e.g. passed — final report on PR #N}"
+  planIssueMetrics="{metric table rows from plan issue body, or — if none}"
+  ```
 
 ### [rescan.md](./reef-pulse/rescan.md)
 
@@ -554,4 +631,11 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
 - exit-worktree
   ```sh
   worktree-exit.sh --path "$WORKTREE_PATH"
+  ```
+- handoff
+  - contains: `Return structured handoff`
+  ```sh
+  nextPhase="in-progress"
+  planPr="{plan PR number from plan body, or —}"
+  summary="{one-line outcome, e.g. N slices created to address gaps}"
   ```

--- a/README.md
+++ b/README.md
@@ -247,6 +247,10 @@ The reason this orchestration framework works is explicit boundaries. Each phase
 
 To further ensure no sub-agent messes up worktree creation, branch targeting, or commit flow, all git operations are wrapped in shell scripts (`worktree-enter.sh`, `worktree-exit.sh`, `commit.sh`) with extra sanitisation. Target branch names and paths are passed via shell variables so that sub-agents never have to reason about git orchestration themselves.
 
+## Metrics
+
+Each phase tracks duration and token usage. reef-pulse collects this metadata from sub-agent task notifications and appends rows to a single `### 🪼 Pulse metrics` table on the plan PR (or plan issue pre-PR). When the work lands, the final PR contains an aggregated table covering every phase from scope through ratify.
+
 ## Autopilot
 
 Run the reef on autopilot so it pulses while you're away. In any Claude Code session:

--- a/reef-pulse/SKILL.md
+++ b/reef-pulse/SKILL.md
@@ -71,14 +71,21 @@ For each item, spawn a sub-agent with: `"Read and follow reef-pulse/{file}. Targ
 | `to-ratify`      | [ratify.md](ratify.md)           |
 | `to-rescan`      | [rescan.md](rescan.md)           |
 
-### Step 3. Log phase metrics to plan issues
+### Step 3. Log phase metrics
 
-After all dispatched agents complete, collect the task notification metadata from each (duration, tokens, tool uses, and outcome). Group the results by plan issue:
+After all dispatched agents complete, collect from each: (1) task notification metadata (duration, tokens, tool uses), and (2) the structured handoff (`nextPhase`, `planPr`, `summary`). Use `planPr` from the handoff to determine where to write metrics — do NOT read issue bodies for this purpose. If `planPr` is `—`, write to the plan issue. Otherwise write to the plan PR.
 
-- **Single-slice plans**: the plan issue itself is the target.
-- **Multi-slice plans**: the slice issue body links back to its plan (look for the `Plan: #N` line).
+Metrics table format — a single table titled `### 🪼 Pulse metrics` (no timestamp in header). If the table already exists on the target, append rows to it. If not, create it.
 
-Append **one metrics section per plan** to the plan issue body using `tracker.sh issue edit --body`. Read the current body first, then append the new metrics section at the bottom.
+```markdown
+### 🪼 Pulse metrics
+
+| Phase | Target | Duration | Tokens | Tool uses | Outcome | Date | Time |
+| ----- | ------ | -------- | ------ | --------- | ------- | ---- | ---- |
+| implement | #55 | 42s | 12 340 | 18 | PR #70 created | 2026/04/20 | 14:32 |
+```
+
+Read the current body, append new rows to the existing table (or create the table), then write back:
 
 ```sh
 ISSUE_ID="{from dispatched items}"
@@ -86,23 +93,18 @@ ISSUE_BODY="{current issue body with metrics section appended}"
 tracker.sh issue edit "$ISSUE_ID" --body "$ISSUE_BODY"
 ```
 
-Metrics section format:
+**Ratify → to-land handling**: when a ratify handoff returns `nextPhase: to-land`, read its `planIssueMetrics` field. On the plan PR body: (1) prepend the `planIssueMetrics` rows to the existing metrics table (dedup if already present), (2) append the ratify row, (3) append a bold **Total** row summing Duration and Tokens columns.
 
-```markdown
-### 🪼 Pulse metrics — {yyyy/MM/dd HH:mm}
-
-| Phase     | Target | Duration | Tokens | Tool uses | Outcome       |
-| --------- | ------ | -------- | ------ | --------- | ------------- |
-| implement | #55    | 42s      | 12 340 | 18        | ✅ PR created |
-| implement | #56    | 38s      | 10 890 | 15        | ✅ PR created |
-| inspect   | #53    | 25s      | 8 200  | 12        | ✅ passed     |
+```sh
+PLAN_PR_BODY="{plan PR body with complete metrics table}"
+gh pr edit "$PR_NUMBER" --body "$PLAN_PR_BODY"
 ```
 
 Rules:
 
-- Only log phases that were dispatched this pulse. If nothing was dispatched, skip this step entirely.
-- If a dispatch failed or the agent returned no metadata, log what you have with `—` for missing fields.
-- Duration should be human-readable (e.g. `42s`, `1m 12s`). Tokens should use space-separated thousands.
+- Only log phases dispatched this pulse. If nothing was dispatched, skip this step.
+- Fall back to `—` for any missing metadata field.
+- Duration: human-readable (`42s`, `1m 12s`). Tokens: space-separated thousands. Date/Time: local timezone (`yyyy/MM/dd`, `HH:mm`).
 
 ### Step 4. Present human (🤿) items (--hitl only)
 

--- a/reef-pulse/await-waves.md
+++ b/reef-pulse/await-waves.md
@@ -87,4 +87,10 @@ worktree-exit.sh --path "$WORKTREE_PATH"
 
 ## Handoff
 
-If dispatched by reef-pulse, report: "Slice {name} is unblocked and ready for implementation."
+Return structured handoff:
+
+```sh
+nextPhase="to-implement"
+planPr="—" # await-waves doesn't know the plan PR
+summary="{one-line outcome, e.g. slice unblocked and ready}"
+```

--- a/reef-pulse/implement.md
+++ b/reef-pulse/implement.md
@@ -155,4 +155,10 @@ worktree-exit.sh --path "$WORKTREE_PATH"
 
 ## Handoff
 
-If dispatched by reef-pulse or an orchestrator, report completion. The next phase for this slice is inspection.
+Return structured handoff:
+
+```sh
+nextPhase="to-inspect"
+planPr="—" # implement doesn't know the plan PR
+summary="{one-line outcome, e.g. PR #N created for slice}"
+```

--- a/reef-pulse/inspect.md
+++ b/reef-pulse/inspect.md
@@ -129,4 +129,10 @@ worktree-exit.sh --path "$WORKTREE_PATH"
 
 ## Handoff
 
-If dispatched by reef-pulse, report the verdict and a one-line summary.
+Return structured handoff:
+
+```sh
+nextPhase="{to-merge or to-rework}"
+planPr="—" # inspect doesn't know the plan PR
+summary="{one-line verdict, e.g. passed or gaps found}"
+```

--- a/reef-pulse/merge-multi.md
+++ b/reef-pulse/merge-multi.md
@@ -69,4 +69,10 @@ Document judgment calls made during this phase on the PR. Only document decision
 
 ## Handoff
 
-Report: "Slice {name} merged. {N} of {total} slices complete." If promoted to `to-ratify`: "All slices done — plan is ready for ratification."
+Return structured handoff:
+
+```sh
+nextPhase="{in-progress or to-ratify}"
+planPr="—" # multi-slice merge doesn't know the plan PR yet
+summary="{one-line outcome, e.g. slice merged, N of M complete}"
+```

--- a/reef-pulse/merge-single.md
+++ b/reef-pulse/merge-single.md
@@ -26,4 +26,10 @@ tracker.sh issue edit "$PLAN_ID" --remove-label to-merge --add-label to-land
 
 ## Handoff
 
-Report: "Single slice verified. PR stays open for human review. Run `/reef-land #{number}`."
+Return structured handoff:
+
+```sh
+nextPhase="to-land"
+planPr="—" # single-slice has no separate plan PR yet
+summary="{one-line outcome, e.g. single slice verified, PR stays open}"
+```

--- a/reef-pulse/ratify.md
+++ b/reef-pulse/ratify.md
@@ -178,5 +178,11 @@ worktree-exit.sh --path "$WORKTREE_PATH"
 
 ## Handoff
 
-If pass: "Target branch reviewed and final report written on PR #{number}. Ready for `/reef-land` — human review."
-If gaps: "Gaps found during holistic review. Tagged `to-rescan` for rescanning to create new slices."
+Return structured handoff. If pass, include `planIssueMetrics` — the scope/slice metric rows read from the plan issue body (the `### 🪼 Pulse metrics` table rows, if present).
+
+```sh
+nextPhase="{to-land or to-rescan}"
+planPr="$PR_NUMBER"
+summary="{one-line outcome, e.g. passed — final report on PR #N}"
+planIssueMetrics="{metric table rows from plan issue body, or — if none}"
+```

--- a/reef-pulse/rescan.md
+++ b/reef-pulse/rescan.md
@@ -140,4 +140,10 @@ worktree-exit.sh --path "$WORKTREE_PATH"
 
 ## Handoff
 
-Report: "Created {N} new slices to address gaps. Coverage matrix updated. The reef will pick these up on the next pulse."
+Return structured handoff:
+
+```sh
+nextPhase="in-progress"
+planPr="{plan PR number from plan body, or —}"
+summary="{one-line outcome, e.g. N slices created to address gaps}"
+```

--- a/reef-pulse/rework.md
+++ b/reef-pulse/rework.md
@@ -98,4 +98,10 @@ worktree-exit.sh --path "$WORKTREE_PATH"
 
 ## Handoff
 
-Report completion. The next phase is inspection (re-review).
+Return structured handoff:
+
+```sh
+nextPhase="to-inspect"
+planPr="—" # rework doesn't know the plan PR
+summary="{one-line outcome, e.g. reworked N issues}"
+```

--- a/reef-pulse/slice-multi.md
+++ b/reef-pulse/slice-multi.md
@@ -133,4 +133,10 @@ worktree-exit.sh --path "$WORKTREE_PATH"
 
 ## Handoff
 
-Report: "Slices created with acceptance criteria, dependency graph, and coverage matrix. Unblocked slices are tagged `to-implement` and ready for implementation. Run `/reef-pulse` to kick them all off."
+Return structured handoff:
+
+```sh
+nextPhase="in-progress"
+planPr="—" # no PR exists yet at slice time
+summary="{one-line outcome, e.g. N slices created, M unblocked}"
+```

--- a/reef-pulse/slice-single.md
+++ b/reef-pulse/slice-single.md
@@ -37,4 +37,10 @@ tracker.sh issue edit "$PLAN_ID" --body "$PLAN_BODY" --remove-label to-slice --a
 
 ## Handoff
 
-Report: "Single slice — fast path. Plan is the slice. Tagged `to-implement`, targeting $BASE_BRANCH directly. Run `/reef-pulse` to kick it off."
+Return structured handoff:
+
+```sh
+nextPhase="to-implement"
+planPr="—" # no PR exists yet at slice time
+summary="{one-line outcome, e.g. single-slice, tagged to-implement}"
+```

--- a/reef-scope/SKILL.md
+++ b/reef-scope/SKILL.md
@@ -9,6 +9,10 @@ Before starting, read `.agents/moonjelly-reef/config.md` — it tells you the is
 
 > **Tracker note**: Commands below use `tracker.sh` syntax. For GitHub, replace `tracker.sh` with `gh`. For MCP trackers (ClickUp, Jira, Linear), use equivalent MCP tool calls.
 
+## Start timestamp
+
+Record the current time at invocation for duration calculation at the end.
+
 ## Input
 
 This skill accepts:
@@ -84,6 +88,15 @@ PLAN_CONTENT="{plan-content}" # frontmatter + plan body from context
 
 ```sh
 tracker.sh issue edit "$PLAN_ID" --body "$PLAN_CONTENT" --remove-label to-scope --add-label to-slice
+```
+
+## 5. Append metrics
+
+Compute wall-clock duration from the start timestamp. Append a `### 🪼 Pulse metrics` table to the plan issue body with a single scope row. Tokens and tool uses show `—` (not available in HITL sessions).
+
+```sh
+PLAN_CONTENT="{plan content with metrics table appended}"
+tracker.sh issue edit "$PLAN_ID" --body "$PLAN_CONTENT"
 ```
 
 ## Handoff


### PR DESCRIPTION
closes #65 Structured handoff, metrics format, and cleanup

## Slice

#65

## Parent

#15

## Acceptance criteria

- [x] Every AFK phase file (implement.md, inspect.md, rework.md, merge-single.md, merge-multi.md, ratify.md, rescan.md, slice-single.md, slice-multi.md) ends with a structured handoff returning `{ nextPhase, planPr, summary }` — each file's Handoff section now has a code block with these three variables.
- [x] ORCHESTRATION.md enforces the structured handoff for every phase via `set-variables` + `contains` directive — each AFK phase section now has a `handoff` operation with `contains: Return structured handoff` and the three handoff variables.
- [x] reef-pulse/SKILL.md Step 3 uses `planPr` from the handoff to determine where to write metrics. Does NOT read issue bodies for this purpose — rewritten to explicitly use handoff fields.
- [x] reef-pulse/SKILL.md Step 3 metrics table format: single table titled `### 🪼 Pulse metrics` (no timestamp in header), columns `| Phase | Target | Duration | Tokens | Tool uses | Outcome | Date | Time |`.
- [x] ratify.md handoff includes `planIssueMetrics` — the scope/slice metric rows read from the plan issue body.
- [x] reef-pulse/SKILL.md: on ratify handoff with `nextPhase: to-land`, prepend `planIssueMetrics` rows to PR table (dedup if present), append ratify row, append bold **Total** row — documented in Step 3 with `PLAN_PR_BODY` variable.
- [x] reef-scope/SKILL.md metrics section updated to use the same `### 🪼 Pulse metrics` table format with Date/Time columns. Section kept succinct — added "Start timestamp" section and "5. Append metrics" step.
- [x] ratify.md: verified `$REPORT` is properly defined at the submit-report step. It is used to create/update the PR body. Not stale.
- [x] reef-pulse/SKILL.md Step 3 section rewritten for conciseness — no over-explaining, relies on ORCHESTRATION.md enforcement.
- [x] `PLAN_PR_BODY` variable in reef-pulse/SKILL.md defined after the metrics format section, not before — it appears in the "Ratify → to-land handling" subsection after the table format.
- [x] No AFK phase file contains metrics self-reporting logic — verified via grep. Only reef-scope self-reports (HITL phase, per plan decision), and ratify reads existing metrics (does not write its own).

## Ambiguous choices

- **await-waves.md handoff**: The AC lists 9 AFK phases but await-waves.md is also an AFK phase not in the list. Added a structured handoff to it as well for consistency, since ORCHESTRATION.md enforces all phases.
- **merge.md (router) handoff**: merge.md delegates to merge-single.md or merge-multi.md. Did not add a handoff to merge.md itself since the AC explicitly excludes it from the list and the handoff comes from the delegate files.
- **ORCHESTRATION.md reef-scope append-metrics**: Added an `append-metrics` operation to the reef-scope skill section to enforce the new metrics step via tests.
- **ORCHESTRATION.md reef-pulse ratify-to-land**: Added conditional `set-variables` and `update-pr` operations for the ratify-to-land case to ensure the `PLAN_PR_BODY` and `gh pr edit` are enforced.

## Test results

277 tests passed, 0 failed, 0 skipped (225 orchestration + 37 tracker + 15 worktree).