### PR TITLE
Make plan metadata YAML-compliant front-matter

### DIFF
--- a/ORCHESTRATION.md
+++ b/ORCHESTRATION.md
@@ -532,7 +532,7 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
 - set-variables
   ```sh
   PLAN_ID="$ISSUE_ID"
-  PR_NUMBER="{from plan body frontmatter PR: #N}"
+  PR_NUMBER="{from plan body frontmatter PR: \"#N\"}"
   TARGET_BRANCH="{from plan body}"
   WORKTREE_PATH="../worktree-$PLAN_ID-rescan"
   ```

--- a/UBIQUITOUS_LANGUAGE.md
+++ b/UBIQUITOUS_LANGUAGE.md
@@ -33,7 +33,6 @@
 | **success criteria** | Plan-level testable conditions that define when the entire issue is done | requirements, specs, definition of done |
 | **acceptance criteria** | Slice-level testable conditions that define when a single slice is done | checklist, slice criteria, ACs (never abbreviate) |
 | **coverage matrix** | A table mapping each success criterion to which slice(s) and acceptance criteria cover it — only used for multi-slice | traceability matrix, mapping |
-| **plan metadata** | The table at the top of a plan with type, base branch, and target branch fields | header, config, frontmatter |
 
 ## Phases
 

--- a/reef-pulse/implement.md
+++ b/reef-pulse/implement.md
@@ -20,7 +20,7 @@ Read the slice (issue or file). It must contain:
 - Target branch name (in "Plan context" section)
 - Parent plan reference
 
-If the target branch is missing from the slice, check the plan metadata. The target branch is always set — for single-slice it equals the base branch, for multi-slice it's a dedicated branch.
+If the target branch is missing from the slice, check the plan frontmatter. The target branch is always set — for single-slice it equals the base branch, for multi-slice it's a dedicated branch.
 
 Set the pre-fetch variables:
 

--- a/reef-pulse/rescan.md
+++ b/reef-pulse/rescan.md
@@ -28,7 +28,7 @@ Set the post-fetch variables (after reading the plan body):
 
 ```sh
 PLAN_ID="$ISSUE_ID"
-PR_NUMBER="{from plan body frontmatter PR: #N}"
+PR_NUMBER="{from plan body frontmatter PR: \"#N\"}"
 TARGET_BRANCH="{from plan body}"
 WORKTREE_PATH="../worktree-$PLAN_ID-rescan"
 ```

--- a/reef-pulse/slice-multi.md
+++ b/reef-pulse/slice-multi.md
@@ -78,10 +78,11 @@ Slice body template:
 
 ```markdown
 ---
-parent plan: #$PLAN_ID
-base branch: $BASE_BRANCH
-target branch: $TARGET_BRANCH
+parent-plan: "#$PLAN_ID"
+base-branch: $BASE_BRANCH
+target-branch: $TARGET_BRANCH
 type: $PLAN_TYPE
+
 ---
 
 ## What to build

--- a/reef-pulse/slice-single.md
+++ b/reef-pulse/slice-single.md
@@ -20,7 +20,7 @@ PLAN_ID="$ISSUE_ID"
 
 Take the fast path — skip the target branch, sub-issues, coverage matrix, and ratify. The plan becomes the slice:
 
-1. **Target branch = base branch.** Do not create a new branch. Add `target branch` to the plan frontmatter, set to the same value as `base branch`.
+1. **Target branch = base branch.** Do not create a new branch. Add `target-branch` to the plan frontmatter, set to the same value as `base-branch`.
 2. **No sub-issues.** The plan IS the slice.
 3. **Write acceptance criteria on the plan.** Append an `## Acceptance criteria` section to the plan body with the criteria you drafted for the single slice.
 4. **No coverage matrix.** Success criteria and acceptance criteria are 1:1 — the mapping adds no information.

--- a/reef-pulse/slice.md
+++ b/reef-pulse/slice.md
@@ -27,7 +27,7 @@ ISSUE_ID="{issue-id}" # pre-existing and passed or generate
 ./tracker.sh issue view "$ISSUE_ID" --json body,title,labels
 ```
 
-Read the issue. It must contain a plan with success criteria (from reef-scope). Success criteria are plan-level; this skill breaks them into **acceptance criteria** per slice. The plan metadata block tells you the work type, base branch, and target branch name.
+Read the issue. It must contain a plan with success criteria (from reef-scope). Success criteria are plan-level; this skill breaks them into **acceptance criteria** per slice. The frontmatter block tells you the work type, base branch, and target branch name.
 
 ## 1. Draft vertical slices
 

--- a/reef-scope/SKILL.md
+++ b/reef-scope/SKILL.md
@@ -70,8 +70,9 @@ The plan body starts with frontmatter that downstream phases will read:
 
 ```markdown
 ---
-base branch: $BASE_BRANCH
+base-branch: $BASE_BRANCH
 type: $PLAN_TYPE
+
 ---
 ```
 


### PR DESCRIPTION
closes #61 Make plan metadata YAML-compliant front-matter

## Slice

#61

## Parent

#61 (single-slice)

## Acceptance criteria

- [x] All frontmatter keys across all `.md` files use kebab-case (no spaces in keys) — renamed `base branch` to `base-branch`, `target branch` to `target-branch`, `parent plan` to `parent-plan`
- [x] All `#`-prefixed values in frontmatter are quoted (e.g. `parent-plan: "#61"`) — quoted `#$PLAN_ID` in slice-multi.md template and `#N` in rescan.md/ORCHESTRATION.md variable comments
- [x] All frontmatter blocks have an empty line before the closing `---` — added to reef-scope/SKILL.md and reef-pulse/slice-multi.md templates
- [x] "plan metadata" row is removed from `UBIQUITOUS_LANGUAGE.md` — removed the row from the Planning table
- [x] Prose references to "plan metadata" in `implement.md` and `slice.md` say "frontmatter" instead — updated both references
- [x] `test-orchestration.sh` passes — 232 tests passed, 0 failed
- [x] No remaining instances of `base branch:`, `target branch:`, or `parent plan:` (with spaces) in any `.md` file — verified via grep, only natural English prose matches remain

## Ambiguous choices

None — implementation followed the plan exactly.

## Test results

232 tests passed, 0 failed, 0 skipped (180 orchestration + 37 tracker + 15 worktree).

<details><summary><h3>🧿 Inspect review — 2026/04/20 22:15</h3></summary>

## Test suite

232 passed, 0 failed (180 orchestration + 37 tracker + 15 worktree). All green.

## Acceptance criteria verification

All 7 acceptance criteria for the frontmatter normalization are met:

1. **kebab-case keys** — `base-branch`, `target-branch`, `parent-plan` used everywhere. No space-separated keys remain in frontmatter context.
2. **Quoted `#` values** — `parent-plan: "#$PLAN_ID"` in slice-multi.md, `PR: "#N"` in rescan.md/ORCHESTRATION.md.
3. **Empty line before closing `---`** — present in reef-scope/SKILL.md and slice-multi.md templates.
4. **"plan metadata" row removed** from UBIQUITOUS_LANGUAGE.md.
5. **Prose references updated** — implement.md and slice.md say "frontmatter" instead of "plan metadata".
6. **test-orchestration.sh passes** — confirmed above.
7. **No remaining space-separated keys** — grep confirms only natural English prose matches remain.

## Gaps found — out-of-scope changes that must be reverted

The PR includes significant changes that were NOT in the plan and directly revert recent intentional work:

**G1: Script files relocated to `reef-pulse/scripts/` subfolder.** `commit.sh`, `worktree-enter.sh`, `worktree-exit.sh` were moved from `reef-pulse/` to `reef-pulse/scripts/`. This was not part of the plan.

**G2: All `./` prefixes removed from script references.** Every `.md` file had `./tracker.sh`, `./worktree-enter.sh`, etc. changed to `tracker.sh`, `worktree-enter.sh`. This directly reverts commit `9d945c6` ("refactor: prefix script refs with ./, clarify they are not pseudocode") which was intentionally added to clarify these are real executable scripts, not pseudocode.

**G3: "Shell blocks are literal commands" callout deleted from every phase file.** The banner that warned agents these are real scripts (not pseudocode) was removed. This was part of the same intentional commit `9d945c6`.

**G4: "CRITICAL: Do NOT use isolation: worktree" warning removed from reef-pulse/SKILL.md.** This warning was added in commit `c757e79` to prevent a known operational issue with platform worktree isolation conflicting with the skill's own worktree management. Removing it re-introduces the risk.

**G5: Test files modified to accommodate the script relocation** — `worktree.test.sh` and `orchestration.test.sh` were updated to match the moved scripts.

## Verdict: REWORK

The frontmatter normalization itself is correct, but the PR must be reworked to remove all out-of-scope changes (G1-G5). The fix is:

1. Revert the script relocation — keep scripts in `reef-pulse/` (not `reef-pulse/scripts/`).
2. Restore `./` prefixes on all script references.
3. Restore the "Shell blocks are literal commands" callout on every phase file.
4. Restore the worktree isolation warning in reef-pulse/SKILL.md.
5. Revert the test file changes that accommodated the relocation.

</details>

<details><summary><h3>🦀 Rework — 2026/04/20 23:30</h3></summary>

## Feedback addressed

All 5 gaps (G1-G5) from the inspection were caused by the same root issue: the PR branch was forked from an older commit on main (0f82e50), before three commits were added:
- `c757e79` — warn orchestrator not to use platform worktree isolation
- `1d1cd9a` — move scripts to reef-pulse root, prefix with ./
- `9d945c6` — prefix script refs with ./, clarify they are not pseudocode

The inspector compared the PR to current main and correctly identified that these changes appeared "missing" from the PR diff. The fix was to rebase the branch onto current main so the PR only contains the in-scope frontmatter normalization changes.

## What changed

- Rebased `feat/061-yaml-frontmatter` onto current `main` (from merge-base `0f82e50` to `9d945c6`)
- No file content was modified — the frontmatter normalization commit was replayed as-is on top of the latest main

## Verification

After rebase, the PR diff contains exactly 8 files with only frontmatter changes:
- `ORCHESTRATION.md` — quoted `PR: "#N"` in rescan variable comment
- `UBIQUITOUS_LANGUAGE.md` — removed "plan metadata" glossary row
- `reef-pulse/implement.md` — "plan metadata" → "frontmatter" in prose
- `reef-pulse/rescan.md` — quoted `PR: "#N"` in variable comment
- `reef-pulse/slice-multi.md` — kebab-case keys, quoted `#` values, empty line before `---`
- `reef-pulse/slice-single.md` — kebab-case key references in prose
- `reef-pulse/slice.md` — "plan metadata" → "frontmatter" in prose
- `reef-scope/SKILL.md` — kebab-case keys, empty line before `---`

No script relocations, no `./` prefix changes, no callout deletions, no test file changes.

## Test results

232 passed, 0 failed (180 orchestration + 37 tracker + 15 worktree).

</details>

<details><summary><h3>🧿 Inspect review — 2026/04/20 22:58</h3></summary>

## Test suite

232 passed, 0 failed (180 orchestration + 37 tracker + 15 worktree). All green.

## Acceptance criteria verification

All 7 acceptance criteria are met on the current PR branch:

1. **kebab-case keys** — the affected frontmatter now uses `base-branch`, `target-branch`, and `parent-plan`.
2. **Quoted `#` values** — `parent-plan: "#$PLAN_ID"` is used in `reef-pulse/slice-multi.md`, and `PR: "#N"` is used in `reef-pulse/rescan.md` and `ORCHESTRATION.md`.
3. **Empty line before closing `---`** — present in the updated frontmatter templates in `reef-scope/SKILL.md` and `reef-pulse/slice-multi.md`.
4. **"plan metadata" glossary row removed** — the row is gone from `UBIQUITOUS_LANGUAGE.md`.
5. **Prose references updated** — `reef-pulse/implement.md` and `reef-pulse/slice.md` now say "frontmatter".
6. **`test.sh` passes** — confirmed above, including `tests/orchestration.test.sh`.
7. **No remaining space-separated frontmatter keys** — remaining `base branch:` / `target branch:` matches are ordinary prose, not frontmatter; `parent plan:` no longer appears in markdown files.

## Ambiguous choices

None. The branch now matches the scoped plan without the earlier out-of-scope drift.

## Verdict

PASS — ready for merge.

</details>

<details><summary><h3>🧿 Inspect review — 2026/04/20 23:06</h3></summary>

## Test suite

232 passed, 0 failed (180 orchestration + 37 tracker + 15 worktree). All green.

## Acceptance criteria verification

All 7 acceptance criteria are met:

1. `reef-scope/SKILL.md` and `reef-pulse/slice-multi.md` use kebab-case frontmatter keys (`base-branch`, `target-branch`, `parent-plan`).
2. `#`-prefixed frontmatter values are quoted where needed: `parent-plan: "#$PLAN_ID"` in `reef-pulse/slice-multi.md`, and `PR: "#N"` in `reef-pulse/rescan.md` and `ORCHESTRATION.md`.
3. The frontmatter templates in `reef-scope/SKILL.md` and `reef-pulse/slice-multi.md` include an empty line before the closing `---`.
4. The `plan metadata` glossary row was removed from `UBIQUITOUS_LANGUAGE.md`.
5. The prose references in `reef-pulse/implement.md` and `reef-pulse/slice.md` now say `frontmatter`.
6. `./test.sh` passes, including `test-orchestration.sh`.
7. Grep found no remaining `base branch:`, `target branch:`, or `parent plan:` key usages in any `.md` file; remaining matches are natural-language prose only.

## Ambiguous choices review

No drift from the plan found. The PR body says there were no ambiguous choices, and the implementation matches that.

## Verdict

PASS. Ready for merge.

</details>