### PR TITLE
Structured handoff, metrics format, and cleanup

### DIFF
--- a/ORCHESTRATION.md
+++ b/ORCHESTRATION.md
@@ -35,6 +35,14 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
   ```sh
   tracker.sh issue edit "$ISSUE_ID" --body "$ISSUE_BODY"
   ```
+- set-variables
+  ```sh
+  PLAN_PR_BODY="{current PR body with metrics table updated}"
+  ```
+- update-pr-body
+  ```sh
+  gh pr edit "$PLAN_PR_NUMBER" --body "$PLAN_PR_BODY"
+  ```
 
 ### [/reef-scope](./reef-scope/SKILL.md)
 
@@ -158,6 +166,10 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
   ```sh
   tracker.sh issue edit "$PLAN_ID" --body "$PLAN_BODY" --remove-label to-slice --add-label to-implement
   ```
+- handoff
+  - contains: `nextPhase="to-implement"`
+  - contains: `planPr=`
+  - contains: `summary=`
 
 ### [slice-multi.md](./reef-pulse/slice-multi.md)
 
@@ -201,6 +213,10 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
   ```sh
   worktree-exit.sh --path "$WORKTREE_PATH"
   ```
+- handoff
+  - contains: `nextPhase="in-progress"`
+  - contains: `planPr=`
+  - contains: `summary=`
 
 ### [implement.md](./reef-pulse/implement.md)
 
@@ -251,6 +267,10 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
   ```sh
   worktree-exit.sh --path "$WORKTREE_PATH"
   ```
+- handoff
+  - contains: `nextPhase=`
+  - contains: `planPr=`
+  - contains: `summary=`
 
 ### [inspect.md](./reef-pulse/inspect.md)
 
@@ -294,6 +314,10 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
   ```sh
   worktree-exit.sh --path "$WORKTREE_PATH"
   ```
+- handoff
+  - contains: `nextPhase=`
+  - contains: `planPr=`
+  - contains: `summary=`
 
 ### [rework.md](./reef-pulse/rework.md)
 
@@ -338,6 +362,10 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
   ```sh
   worktree-exit.sh --path "$WORKTREE_PATH"
   ```
+- handoff
+  - contains: `nextPhase="to-inspect"`
+  - contains: `planPr=`
+  - contains: `summary=`
 
 ### [await-waves.md](./reef-pulse/await-waves.md)
 
@@ -382,6 +410,10 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
   ```sh
   worktree-exit.sh --path "$WORKTREE_PATH"
   ```
+- handoff
+  - contains: `nextPhase="to-implement"`
+  - contains: `planPr=`
+  - contains: `summary=`
 
 ### [merge.md](./reef-pulse/merge.md)
 
@@ -438,6 +470,10 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
   ```sh
   tracker.sh issue edit "$PLAN_ID" --remove-label to-merge --add-label to-land
   ```
+- handoff
+  - contains: `nextPhase="to-land"`
+  - contains: `planPr=`
+  - contains: `summary=`
 
 ### [merge-multi.md](./reef-pulse/merge-multi.md)
 
@@ -471,6 +507,10 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
   ```sh
   tracker.sh issue edit "$PLAN_ID" --remove-label in-progress --add-label to-ratify
   ```
+- handoff
+  - contains: `nextPhase=`
+  - contains: `planPr=`
+  - contains: `summary=`
 
 ### [ratify.md](./reef-pulse/ratify.md)
 
@@ -518,6 +558,11 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
   ```sh
   worktree-exit.sh --path "$WORKTREE_PATH"
   ```
+- handoff
+  - contains: `nextPhase=`
+  - contains: `planPr=`
+  - contains: `planIssueMetrics=`
+  - contains: `summary=`
 
 ### [rescan.md](./reef-pulse/rescan.md)
 
@@ -555,3 +600,7 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
   ```sh
   worktree-exit.sh --path "$WORKTREE_PATH"
   ```
+- handoff
+  - contains: `nextPhase="in-progress"`
+  - contains: `planPr=`
+  - contains: `summary=`

--- a/README.md
+++ b/README.md
@@ -232,6 +232,10 @@ Analyze gaps found by ratify, re-review the entire plan, create new slices to ad
 
 <p align="right">💡🐡<br /><sub>An anglerfish drifts through absolute darkness, its lure casting light on creatures no one knew were lurking in the deep.</sub></p>
 
+## Phase metrics
+
+Each phase tracks duration and token usage. The orchestrator (reef-pulse) collects metrics from task notifications after sub-agents complete and writes them to a single `### 🪼 Pulse metrics` table on the plan PR (or plan issue, pre-PR). The table accumulates rows chronologically across all pulses, giving the reviewer a full cost/time breakdown when they run `/reef-land`.
+
 ## Orchestration accuracy
 
 The reason this orchestration framework works is explicit boundaries. Each phase has four well-defined concerns:

--- a/reef-pulse/SKILL.md
+++ b/reef-pulse/SKILL.md
@@ -71,14 +71,29 @@ For each item, spawn a sub-agent with: `"Read and follow reef-pulse/{file}. Targ
 | `to-ratify`      | [ratify.md](ratify.md)           |
 | `to-rescan`      | [rescan.md](rescan.md)           |
 
-### Step 3. Log phase metrics to plan issues
+### Step 3. Collect and write metrics
 
-After all dispatched agents complete, collect the task notification metadata from each (duration, tokens, tool uses, and outcome). Group the results by plan issue:
+After all dispatched agents complete, collect from each: task notification metadata (duration, tokens, tool uses) and the structured handoff (`nextPhase`, `planPr`, `summary`).
 
-- **Single-slice plans**: the plan issue itself is the target.
-- **Multi-slice plans**: the slice issue body links back to its plan (look for the `Plan: #N` line).
+Use `planPr` from the handoff to determine where to write metrics:
+- If `planPr` is a PR number: write to the plan PR body.
+- If `planPr` is `—`: write to the plan issue body.
 
-Append **one metrics section per plan** to the plan issue body using `tracker.sh issue edit --body`. Read the current body first, then append the new metrics section at the bottom.
+Metrics table format — a single table titled `### 🪼 Pulse metrics` (no timestamp in header):
+
+```markdown
+### 🪼 Pulse metrics
+
+| Phase | Target | Duration | Tokens | Tool uses | Outcome | Date | Time |
+| ----- | ------ | -------- | ------ | --------- | ------- | ---- | ---- |
+| implement | #55 | 42s | 12 340 | 18 | PR created | 2026/04/20 | 14:32 |
+```
+
+Append rows to the existing table. If the table does not exist yet, create it. Use `—` for any missing field. Duration: human-readable (`42s`, `1m 12s`). Tokens: space-separated thousands. Date/Time: local timezone (`yyyy/MM/dd`, `HH:mm`).
+
+**On ratify handoff with `nextPhase: to-land`**: the ratify handoff includes `planIssueMetrics` (scope/slice rows from the plan issue). Prepend those rows to the PR table (dedup if already present), append the ratify row, then append a bold **Total** row summing Duration and Tokens.
+
+Write the updated body:
 
 ```sh
 ISSUE_ID="{from dispatched items}"
@@ -86,23 +101,15 @@ ISSUE_BODY="{current issue body with metrics section appended}"
 tracker.sh issue edit "$ISSUE_ID" --body "$ISSUE_BODY"
 ```
 
-Metrics section format:
-
-```markdown
-### 🪼 Pulse metrics — {yyyy/MM/dd HH:mm}
-
-| Phase     | Target | Duration | Tokens | Tool uses | Outcome       |
-| --------- | ------ | -------- | ------ | --------- | ------------- |
-| implement | #55    | 42s      | 12 340 | 18        | ✅ PR created |
-| implement | #56    | 38s      | 10 890 | 15        | ✅ PR created |
-| inspect   | #53    | 25s      | 8 200  | 12        | ✅ passed     |
+```sh
+PLAN_PR_BODY="{current PR body with metrics table updated}"
+gh pr edit "$PLAN_PR_NUMBER" --body "$PLAN_PR_BODY"
 ```
 
 Rules:
-
-- Only log phases that were dispatched this pulse. If nothing was dispatched, skip this step entirely.
-- If a dispatch failed or the agent returned no metadata, log what you have with `—` for missing fields.
-- Duration should be human-readable (e.g. `42s`, `1m 12s`). Tokens should use space-separated thousands.
+- Only log phases dispatched this pulse. If nothing was dispatched, skip this step.
+- If a dispatch failed or returned no metadata, log with `—` for missing fields.
+- Do NOT read issue bodies to discover PR numbers — use `planPr` from the handoff.
 
 ### Step 4. Present human (🤿) items (--hitl only)
 

--- a/reef-pulse/await-waves.md
+++ b/reef-pulse/await-waves.md
@@ -87,4 +87,10 @@ worktree-exit.sh --path "$WORKTREE_PATH"
 
 ## Handoff
 
-If dispatched by reef-pulse, report: "Slice {name} is unblocked and ready for implementation."
+Return the structured handoff:
+
+```sh
+nextPhase="to-implement"
+planPr="—"
+summary="slice unblocked — ready for implementation"
+```

--- a/reef-pulse/implement.md
+++ b/reef-pulse/implement.md
@@ -155,4 +155,10 @@ worktree-exit.sh --path "$WORKTREE_PATH"
 
 ## Handoff
 
-If dispatched by reef-pulse or an orchestrator, report completion. The next phase for this slice is inspection.
+Return the structured handoff:
+
+```sh
+nextPhase="to-inspect"
+planPr="$PR_NUMBER"
+summary="PR #$PR_NUMBER created"
+```

--- a/reef-pulse/inspect.md
+++ b/reef-pulse/inspect.md
@@ -129,4 +129,10 @@ worktree-exit.sh --path "$WORKTREE_PATH"
 
 ## Handoff
 
-If dispatched by reef-pulse, report the verdict and a one-line summary.
+Return the structured handoff:
+
+```sh
+nextPhase="{to-merge or to-rework}"
+planPr="$PR_NUMBER"
+summary="{one-line verdict}"
+```

--- a/reef-pulse/merge-multi.md
+++ b/reef-pulse/merge-multi.md
@@ -69,4 +69,10 @@ Document judgment calls made during this phase on the PR. Only document decision
 
 ## Handoff
 
-Report: "Slice {name} merged. {N} of {total} slices complete." If promoted to `to-ratify`: "All slices done — plan is ready for ratification."
+Return the structured handoff:
+
+```sh
+nextPhase="{to-ratify or in-progress}"
+planPr="$PR_NUMBER"
+summary="slice merged — {N}/{total} complete"
+```

--- a/reef-pulse/merge-single.md
+++ b/reef-pulse/merge-single.md
@@ -26,4 +26,10 @@ tracker.sh issue edit "$PLAN_ID" --remove-label to-merge --add-label to-land
 
 ## Handoff
 
-Report: "Single slice verified. PR stays open for human review. Run `/reef-land #{number}`."
+Return the structured handoff:
+
+```sh
+nextPhase="to-land"
+planPr="$PR_NUMBER"
+summary="single-slice — PR stays open for human review"
+```

--- a/reef-pulse/ratify.md
+++ b/reef-pulse/ratify.md
@@ -178,5 +178,13 @@ worktree-exit.sh --path "$WORKTREE_PATH"
 
 ## Handoff
 
-If pass: "Target branch reviewed and final report written on PR #{number}. Ready for `/reef-land` — human review."
-If gaps: "Gaps found during holistic review. Tagged `to-rescan` for rescanning to create new slices."
+Read the plan issue body and extract any existing `### 🪼 Pulse metrics` table rows (scope/slice metrics written before the PR existed). Return these as `planIssueMetrics`.
+
+Return the structured handoff:
+
+```sh
+nextPhase="{to-land or to-rescan}"
+planPr="$PR_NUMBER"
+planIssueMetrics="{metric rows from plan issue body, or empty}"
+summary="{one-line verdict}"
+```

--- a/reef-pulse/rescan.md
+++ b/reef-pulse/rescan.md
@@ -140,4 +140,10 @@ worktree-exit.sh --path "$WORKTREE_PATH"
 
 ## Handoff
 
-Report: "Created {N} new slices to address gaps. Coverage matrix updated. The reef will pick these up on the next pulse."
+Return the structured handoff:
+
+```sh
+nextPhase="in-progress"
+planPr="$PR_NUMBER"
+summary="created {N} slices to address gaps"
+```

--- a/reef-pulse/rework.md
+++ b/reef-pulse/rework.md
@@ -98,4 +98,10 @@ worktree-exit.sh --path "$WORKTREE_PATH"
 
 ## Handoff
 
-Report completion. The next phase is inspection (re-review).
+Return the structured handoff:
+
+```sh
+nextPhase="to-inspect"
+planPr="$PR_NUMBER"
+summary="reworked — ready for re-inspection"
+```

--- a/reef-pulse/slice-multi.md
+++ b/reef-pulse/slice-multi.md
@@ -133,4 +133,10 @@ worktree-exit.sh --path "$WORKTREE_PATH"
 
 ## Handoff
 
-Report: "Slices created with acceptance criteria, dependency graph, and coverage matrix. Unblocked slices are tagged `to-implement` and ready for implementation. Run `/reef-pulse` to kick them all off."
+Return the structured handoff:
+
+```sh
+nextPhase="in-progress"
+planPr="—"
+summary="{N} slices created, tagged to-implement"
+```

--- a/reef-pulse/slice-single.md
+++ b/reef-pulse/slice-single.md
@@ -37,4 +37,10 @@ tracker.sh issue edit "$PLAN_ID" --body "$PLAN_BODY" --remove-label to-slice --a
 
 ## Handoff
 
-Report: "Single slice — fast path. Plan is the slice. Tagged `to-implement`, targeting $BASE_BRANCH directly. Run `/reef-pulse` to kick it off."
+Return the structured handoff:
+
+```sh
+nextPhase="to-implement"
+planPr="—"
+summary="single-slice, tagged to-implement"
+```

--- a/reef-scope/SKILL.md
+++ b/reef-scope/SKILL.md
@@ -86,6 +86,16 @@ PLAN_CONTENT="{plan-content}" # frontmatter + plan body from context
 tracker.sh issue edit "$PLAN_ID" --body "$PLAN_CONTENT" --remove-label to-scope --add-label to-slice
 ```
 
+## 5. Append metrics
+
+Record a start timestamp at the beginning of this skill invocation and compute wall-clock duration at the end. Append a `### 🪼 Pulse metrics` table to the plan issue body with one scope row. Tokens and tool uses show `—` (not available for HITL sessions).
+
+```sh
+ISSUE_ID="{from dispatched items}"
+ISSUE_BODY="{current issue body with metrics section appended}"
+tracker.sh issue edit "$ISSUE_ID" --body "$ISSUE_BODY"
+```
+
 ## Handoff
 
 Tell the user:


### PR DESCRIPTION
closes #65 Structured handoff, metrics format, and cleanup

## Slice

#65

## Parent

#15

## Acceptance criteria

- [x] Every AFK phase file ends with structured handoff returning `{ nextPhase, planPr, summary }` — all 9 AFK phases (implement, inspect, rework, merge-single, merge-multi, ratify, rescan, slice-single, slice-multi) plus await-waves now have structured handoff blocks with the three required variables.
- [x] ORCHESTRATION.md enforces the structured handoff via `set-variables` + `contains` — each phase entry includes a `handoff` operation with `contains` checks for `nextPhase=`, `planPr=`, and `summary=`. Ratify additionally checks for `planIssueMetrics=`.
- [x] reef-pulse/SKILL.md Step 3 uses `planPr` from handoff, does NOT read issue bodies — rewritten to use `planPr` to determine write target. Explicit rule: "Do NOT read issue bodies to discover PR numbers."
- [x] Metrics table format: single table `### 🪼 Pulse metrics` (no timestamp in header), columns `| Phase | Target | Duration | Tokens | Tool uses | Outcome | Date | Time |` — format section rewritten with Date/Time columns.
- [x] ratify.md handoff includes `planIssueMetrics` — ratify reads plan issue body for existing metrics rows and returns them in the handoff.
- [x] On ratify handoff with `nextPhase: to-land`, reef-pulse prepends planIssueMetrics rows, appends ratify row + bold Total row — documented in Step 3.
- [x] reef-scope/SKILL.md metrics section uses same `### 🪼 Pulse metrics` table format — new "5. Append metrics" section added, kept succinct (records wall-clock duration, tokens/tool-uses show `—`).
- [x] reef-pulse/SKILL.md Step 3 rewritten for conciseness — relies on structured handoff and ORCHESTRATION.md enforcement, no over-explaining.
- [x] `PLAN_PR_BODY` variable defined after metrics format section — appears at line 105, after format description at line 82.
- [x] No AFK phase file contains metrics self-reporting logic — verified. Ratify only reads existing metrics for handoff passthrough, not self-reporting.

## Ambiguous choices

None — implementation followed the plan exactly.

## Test results

263 tests passed, 0 failed (211 orchestration + 37 tracker + 15 worktree/commit).