### PR TITLE
rescan: new slices inherit target-branch=main instead of the existing PR branch

### DIFF
--- a/ORCHESTRATION.md
+++ b/ORCHESTRATION.md
@@ -533,12 +533,15 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
   ```sh
   PLAN_ID="$ISSUE_ID"
   PR_NUMBER="{from plan body frontmatter PR: #N}"
-  TARGET_BRANCH="{from plan body}"
   WORKTREE_PATH="../worktree-$PLAN_ID-rescan"
   ```
 - fetch-pr
   ```sh
-  gh pr view "$PR_NUMBER" --json body
+  gh pr view "$PR_NUMBER" --json body,headRefName
+  ```
+- set-variables
+  ```sh
+  TARGET_BRANCH="{headRefName from PR if PR exists, else from plan body}"
   ```
 - enter-worktree
   - contains: `Enter a worktree forked from $TARGET_BRANCH to read the current state of the code`

--- a/reef-pulse/rescan.md
+++ b/reef-pulse/rescan.md
@@ -29,14 +29,19 @@ Set the post-fetch variables (after reading the plan body):
 ```sh
 PLAN_ID="$ISSUE_ID"
 PR_NUMBER="{from plan body frontmatter PR: #N}"
-TARGET_BRANCH="{from plan body}"
 WORKTREE_PATH="../worktree-$PLAN_ID-rescan"
 ```
 
 ## Fetch PR
 
 ```sh
-gh pr view "$PR_NUMBER" --json body
+gh pr view "$PR_NUMBER" --json body,headRefName
+```
+
+Resolve `TARGET_BRANCH` from the PR's head branch — this is the actual integration point where earlier work lives. Fall back to the plan's `target-branch` frontmatter field only if no PR exists.
+
+```sh
+TARGET_BRANCH="{headRefName from PR if PR exists, else from plan body}"
 ```
 
 ## Mindset


### PR DESCRIPTION
closes #67 rescan: new slices inherit target-branch=main instead of the existing PR branch

## Slice

#67

## Parent

#67 (single-slice)

## Acceptance criteria

- [x] `rescan.md` resolves `TARGET_BRANCH` from the PR's head branch (via `gh pr view $PR_NUMBER --json headRefName`) when a `PR:` field exists in the plan frontmatter — the fetch-pr step now requests `body,headRefName` and TARGET_BRANCH is resolved from headRefName with fallback to plan body
- [x] Falls back to the plan's `target-branch` frontmatter field when no PR exists — the variable description explicitly states fallback behavior
- [x] `ORCHESTRATION.md` rescan section mirrors the updated variable resolution — fetch-pr now includes headRefName, and a new set-variables step resolves TARGET_BRANCH from the PR response
- [x] `test-orchestration.sh` passes — 180 passed, 0 failed
- [x] New slices created by rescan inherit the PR's head branch as their `target-branch`, not the plan's frontmatter value — TARGET_BRANCH is now sourced from the PR's headRefName, which is what the worktree forks from and what new slices will inherit

## Ambiguous choices

None — implementation followed the plan exactly.

## Test results

232 tests passed, 0 failed, 0 skipped (180 orchestration + 37 tracker + 15 worktree).

<details><summary><h3>🧿 Inspect review — 2026/04/20 22:59</h3></summary>

Verdict: pass.

- Acceptance criteria verified in code: `reef-pulse/rescan.md` fetches `headRefName` and resolves `TARGET_BRANCH` from the PR head with fallback to plan frontmatter.
- Mirror verified: `ORCHESTRATION.md` reflects the same fetch-and-resolve flow.
- Tests rerun in a detached review worktree from `fix/067-rescan-target-branch`: `bash ./test.sh` passed (`180 orchestration`, `37 tracker`, `15 worktree`; `232 total`, `0 failed`).
- Ambiguous choices review: none documented, and no unexpected drift found during inspection.

No cleanup commits or follow-up review comments were needed.
</details>

<details><summary><h3>🧿 Inspect review — 2026/04/20 23:00</h3></summary>

Verdict: pass.

- Acceptance criteria verified in code: `reef-pulse/rescan.md` fetches `headRefName` from `gh pr view` and resolves `TARGET_BRANCH` from the PR head, with fallback to the plan frontmatter when no PR exists.
- Mirror verified: `ORCHESTRATION.md` rescan section now matches the same fetch-and-resolve flow.
- Full suite rerun in a detached review worktree forked from `fix/067-rescan-target-branch`: `bash ./test.sh` passed with `232 total`, `0 failed` (`180 orchestration`, `37 tracker`, `15 worktree`).
- Drift review: the implementation is intentionally limited to the instruction/spec layer for this repo, and I found no undocumented behavior drift or cleanup needs.

No cleanup commits or follow-up review comments were needed.
</details>

