### PR TITLE
056/001 Add --pull-latest flag to worktree-enter.sh

### DIFF
--- a/reef-pulse/worktree-enter.sh
+++ b/reef-pulse/worktree-enter.sh
@@ -2,18 +2,27 @@
 # worktree-enter.sh — create a git worktree at a caller-defined path
 #
 # Usage:
-#   worktree-enter.sh --fork-from {branch} --path {worktree-path}
+#   worktree-enter.sh --fork-from {branch} --pull-latest {branch} --path {worktree-path}
 #
-# --fork-from: the remote branch to fork from (detached HEAD on origin/{branch})
-# --path:      absolute or relative path where the worktree will be created
+# --fork-from:    the remote branch to fork from (detached HEAD on origin/{branch})
+# --pull-latest:  the remote branch to merge into the worktree after creation (required)
+# --path:         absolute or relative path where the worktree will be created
 #
 # Always creates a detached HEAD worktree from origin/{fork-from}.
-# The caller decides the path — Reef phases conventionally keep worktrees inside
-# the repo under .worktrees/ so the main checkout stays self-contained.
-# Prints the absolute worktree path to stdout.
+# After creation, compares fork-from and pull-latest:
+#   - Same branch: outputs "ready" (no merge)
+#   - Different branch, clean merge: pushes merge commit and outputs
+#     "synced: pulled N commits from {pull-latest} into {fork-from}"
+#   - Different branch, already up to date: outputs "ready"
+#   - Different branch, conflicts: outputs
+#     "conflicts: merge of {pull-latest} into {fork-from} has conflicts"
+#
+# Worktree remains detached HEAD throughout (no local branch names created).
+# Prints the absolute worktree path on the first line, status on the second line.
 set -eu
 
 FORK_FROM=""
+PULL_LATEST=""
 WORKTREE_PATH=""
 
 while [ $# -gt 0 ]; do
@@ -21,6 +30,9 @@ while [ $# -gt 0 ]; do
     --fork-from)
       [ $# -lt 2 ] && { echo "Error: --fork-from requires a value" >&2; exit 1; }
       FORK_FROM="$2"; shift 2 ;;
+    --pull-latest)
+      [ $# -lt 2 ] && { echo "Error: --pull-latest requires a value" >&2; exit 1; }
+      PULL_LATEST="$2"; shift 2 ;;
     --path)
       [ $# -lt 2 ] && { echo "Error: --path requires a value" >&2; exit 1; }
       WORKTREE_PATH="$2"; shift 2 ;;
@@ -29,8 +41,8 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-if [ -z "$FORK_FROM" ] || [ -z "$WORKTREE_PATH" ]; then
-  echo "Usage: worktree-enter.sh --fork-from {branch} --path {worktree-path}" >&2
+if [ -z "$FORK_FROM" ] || [ -z "$PULL_LATEST" ] || [ -z "$WORKTREE_PATH" ]; then
+  echo "Usage: worktree-enter.sh --fork-from {branch} --pull-latest {branch} --path {worktree-path}" >&2
   exit 1
 fi
 
@@ -45,4 +57,36 @@ git fetch origin --prune >/dev/null 2>&1
 
 git worktree add "$WORKTREE_PATH" "origin/${FORK_FROM}" --detach >/dev/null 2>&1
 
-cd "$WORKTREE_PATH" && pwd -P
+ABS_PATH="$(cd "$WORKTREE_PATH" && pwd -P)"
+echo "$ABS_PATH"
+
+# If fork-from and pull-latest are the same branch, no merge needed
+if [ "$FORK_FROM" = "$PULL_LATEST" ]; then
+  echo "ready"
+  exit 0
+fi
+
+# Different branches — check if already up to date
+LATEST_SHA="$(git rev-parse "origin/${PULL_LATEST}")"
+MERGE_BASE="$(git -C "$ABS_PATH" merge-base HEAD "$LATEST_SHA")"
+
+if [ "$LATEST_SHA" = "$MERGE_BASE" ]; then
+  # pull-latest is already an ancestor of fork-from — nothing to merge
+  echo "ready"
+  exit 0
+fi
+
+# Count how many commits will be merged
+COMMIT_COUNT="$(git -C "$ABS_PATH" rev-list "$MERGE_BASE".."$LATEST_SHA" | wc -l | tr -d ' ')"
+
+# Attempt the merge (staying detached HEAD)
+if git -C "$ABS_PATH" merge --no-edit "$LATEST_SHA" >/dev/null 2>&1; then
+  # Clean merge — push to origin using explicit refspec (no force)
+  git -C "$ABS_PATH" push origin "HEAD:refs/heads/${FORK_FROM}" >/dev/null 2>&1
+  echo "synced: pulled $COMMIT_COUNT commits from $PULL_LATEST into $FORK_FROM"
+  exit 0
+else
+  # Conflicts — leave conflict markers, don't push
+  echo "conflicts: merge of $PULL_LATEST into $FORK_FROM has conflicts"
+  exit 0
+fi

--- a/tests/worktree.test.sh
+++ b/tests/worktree.test.sh
@@ -66,7 +66,7 @@ test_enter_detached_head() {
   cd "$REPO"
 
   wt_path="$TEST_ROOT/worktree-ratify"
-  if enter --fork-from main --path "$wt_path" >/dev/null 2>&1; then
+  if enter --fork-from main --pull-latest main --path "$wt_path" >/dev/null 2>&1; then
     if [ -d "$wt_path" ]; then
       head_status="$(cd "$wt_path" && git rev-parse --abbrev-ref HEAD)"
       if [ "$head_status" = "HEAD" ]; then
@@ -89,7 +89,9 @@ test_enter_at_caller_defined_path() {
   cd "$REPO"
 
   wt_path="$TEST_ROOT/my-custom-path"
-  if path="$(enter --fork-from main --path "$wt_path" 2>/dev/null)"; then
+  output="$(enter --fork-from main --pull-latest main --path "$wt_path" 2>/dev/null)"
+  if [ $? -eq 0 ]; then
+    path="$(echo "$output" | head -1)"
     resolved_actual="$(cd "$path" && pwd -P)"
     resolved_expected="$(cd "$wt_path" && pwd -P)"
     if [ "$resolved_expected" = "$resolved_actual" ]; then
@@ -109,7 +111,9 @@ test_enter_creates_nested_parent_dirs() {
   cd "$REPO"
 
   wt_path="$REPO/.worktrees/nested/worktree-ratify"
-  if path="$(enter --fork-from main --path "$wt_path" 2>/dev/null)"; then
+  output="$(enter --fork-from main --pull-latest main --path "$wt_path" 2>/dev/null)"
+  if [ $? -eq 0 ]; then
+    path="$(echo "$output" | head -1)"
     resolved_actual="$(cd "$path" && pwd -P)"
     resolved_expected="$(cd "$wt_path" && pwd -P)"
     if [ "$resolved_expected" = "$resolved_actual" ] && [ -d "$REPO/.worktrees/nested" ]; then
@@ -129,9 +133,9 @@ test_enter_fails_if_worktree_exists() {
   cd "$REPO"
 
   wt_path="$TEST_ROOT/worktree-dup"
-  enter --fork-from main --path "$wt_path" >/dev/null 2>&1 || true
+  enter --fork-from main --pull-latest main --path "$wt_path" >/dev/null 2>&1 || true
 
-  if enter --fork-from main --path "$wt_path" >/dev/null 2>&1; then
+  if enter --fork-from main --pull-latest main --path "$wt_path" >/dev/null 2>&1; then
     fail "enter: fails if worktree already exists" "second call succeeded"
   else
     pass "enter: fails if worktree already exists"
@@ -150,16 +154,190 @@ test_enter_fails_on_missing_args() {
     pass "enter: fails with no args"
   fi
 
-  if enter --fork-from main >/dev/null 2>&1; then
+  if enter --fork-from main --pull-latest main >/dev/null 2>&1; then
     fail "enter: fails without --path" "succeeded"
   else
     pass "enter: fails without --path"
   fi
 
-  if enter --path /tmp/some-path >/dev/null 2>&1; then
+  if enter --pull-latest main --path /tmp/some-path >/dev/null 2>&1; then
     fail "enter: fails without --fork-from" "succeeded"
   else
     pass "enter: fails without --fork-from"
+  fi
+
+  if enter --fork-from main --path /tmp/some-path2 >/dev/null 2>&1; then
+    fail "enter: fails without --pull-latest" "succeeded"
+  else
+    pass "enter: fails without --pull-latest"
+  fi
+
+  teardown_repos
+}
+
+# ============================================================
+# PULL-LATEST TESTS
+# ============================================================
+
+test_pull_latest_same_branch() {
+  setup_repos
+  cd "$REPO"
+
+  wt_path="$TEST_ROOT/worktree-same"
+  output="$(enter --fork-from main --pull-latest main --path "$wt_path" 2>/dev/null)"
+  status="$(echo "$output" | tail -1)"
+  if [ "$status" = "ready" ]; then
+    pass "pull-latest: same branch outputs ready"
+  else
+    fail "pull-latest: same branch outputs ready" "got: $status"
+  fi
+
+  teardown_repos
+}
+
+test_pull_latest_clean_merge() {
+  setup_repos
+  cd "$REPO"
+
+  # Create a target branch forked from main
+  git checkout -b feat/target >/dev/null 2>&1
+  echo "target work" > target.txt
+  git add target.txt
+  git commit -m "target commit" >/dev/null 2>&1
+  git push origin feat/target >/dev/null 2>&1
+  git checkout main >/dev/null 2>&1
+
+  # Add a commit to main that feat/target doesn't have
+  echo "main update" > main-update.txt
+  git add main-update.txt
+  git commit -m "main update" >/dev/null 2>&1
+  git push origin main >/dev/null 2>&1
+
+  wt_path="$TEST_ROOT/worktree-merge"
+  output="$(enter --fork-from feat/target --pull-latest main --path "$wt_path" 2>/dev/null)"
+  status="$(echo "$output" | tail -1)"
+
+  if echo "$status" | grep -q "^synced: pulled .* commits from main into feat/target$"; then
+    # Verify push happened
+    git fetch origin >/dev/null 2>&1
+    if git -C "$REPO" log origin/feat/target --oneline | grep -q "Merge"; then
+      # Verify worktree is still detached HEAD
+      head_status="$(cd "$wt_path" && git rev-parse --abbrev-ref HEAD)"
+      if [ "$head_status" = "HEAD" ]; then
+        pass "pull-latest: clean merge syncs and pushes"
+      else
+        fail "pull-latest: clean merge syncs and pushes" "not detached HEAD: $head_status"
+      fi
+    else
+      fail "pull-latest: clean merge syncs and pushes" "merge commit not on origin"
+    fi
+  else
+    fail "pull-latest: clean merge syncs and pushes" "got: $status"
+  fi
+
+  teardown_repos
+}
+
+test_pull_latest_conflicts() {
+  setup_repos
+  cd "$REPO"
+
+  # Create a target branch that modifies README.md
+  git checkout -b feat/conflict >/dev/null 2>&1
+  echo "conflict version A" > README.md
+  git add README.md
+  git commit -m "conflict A" >/dev/null 2>&1
+  git push origin feat/conflict >/dev/null 2>&1
+  git checkout main >/dev/null 2>&1
+
+  # Modify the same file on main
+  echo "conflict version B" > README.md
+  git add README.md
+  git commit -m "conflict B" >/dev/null 2>&1
+  git push origin main >/dev/null 2>&1
+
+  wt_path="$TEST_ROOT/worktree-conflict"
+  output="$(enter --fork-from feat/conflict --pull-latest main --path "$wt_path" 2>/dev/null)"
+  status="$(echo "$output" | tail -1)"
+
+  if [ "$status" = "conflicts: merge of main into feat/conflict has conflicts" ]; then
+    # Verify conflict markers exist in worktree
+    if grep -q "<<<<<<" "$wt_path/README.md" 2>/dev/null; then
+      # Verify nothing was pushed (origin/feat/conflict should still be at "conflict A")
+      git fetch origin >/dev/null 2>&1
+      last_msg="$(git log origin/feat/conflict -1 --format=%s)"
+      if [ "$last_msg" = "conflict A" ]; then
+        pass "pull-latest: conflicts outputs message and leaves markers"
+      else
+        fail "pull-latest: conflicts outputs message and leaves markers" "push happened: $last_msg"
+      fi
+    else
+      fail "pull-latest: conflicts outputs message and leaves markers" "no conflict markers in worktree"
+    fi
+  else
+    fail "pull-latest: conflicts outputs message and leaves markers" "got: $status"
+  fi
+
+  teardown_repos
+}
+
+test_pull_latest_already_up_to_date() {
+  setup_repos
+  cd "$REPO"
+
+  # Create a target branch that is ahead of main (main is ancestor)
+  git checkout -b feat/ahead >/dev/null 2>&1
+  echo "ahead work" > ahead.txt
+  git add ahead.txt
+  git commit -m "ahead commit" >/dev/null 2>&1
+  git push origin feat/ahead >/dev/null 2>&1
+  git checkout main >/dev/null 2>&1
+
+  wt_path="$TEST_ROOT/worktree-uptodate"
+  output="$(enter --fork-from feat/ahead --pull-latest main --path "$wt_path" 2>/dev/null)"
+  status="$(echo "$output" | tail -1)"
+
+  if [ "$status" = "ready" ]; then
+    # Verify no merge commit was created (still at "ahead commit")
+    last_msg="$(cd "$wt_path" && git log -1 --format=%s)"
+    if [ "$last_msg" = "ahead commit" ]; then
+      pass "pull-latest: already up to date outputs ready"
+    else
+      fail "pull-latest: already up to date outputs ready" "unexpected commit: $last_msg"
+    fi
+  else
+    fail "pull-latest: already up to date outputs ready" "got: $status"
+  fi
+
+  teardown_repos
+}
+
+test_pull_latest_detached_head_after_merge() {
+  setup_repos
+  cd "$REPO"
+
+  # Create a target branch
+  git checkout -b feat/detach-test >/dev/null 2>&1
+  echo "detach work" > detach.txt
+  git add detach.txt
+  git commit -m "detach commit" >/dev/null 2>&1
+  git push origin feat/detach-test >/dev/null 2>&1
+  git checkout main >/dev/null 2>&1
+
+  # Add commit to main
+  echo "main detach" > main-detach.txt
+  git add main-detach.txt
+  git commit -m "main detach" >/dev/null 2>&1
+  git push origin main >/dev/null 2>&1
+
+  wt_path="$TEST_ROOT/worktree-detach"
+  enter --fork-from feat/detach-test --pull-latest main --path "$wt_path" >/dev/null 2>&1
+
+  head_status="$(cd "$wt_path" && git rev-parse --abbrev-ref HEAD)"
+  if [ "$head_status" = "HEAD" ]; then
+    pass "pull-latest: worktree stays detached HEAD after merge"
+  else
+    fail "pull-latest: worktree stays detached HEAD after merge" "got: $head_status"
   fi
 
   teardown_repos
@@ -174,7 +352,7 @@ test_exit_removes_clean_worktree() {
   cd "$REPO"
 
   wt_path="$TEST_ROOT/worktree-clean"
-  if enter --fork-from main --path "$wt_path" >/dev/null 2>&1; then
+  if enter --fork-from main --pull-latest main --path "$wt_path" >/dev/null 2>&1; then
     cd "$REPO"
     if exit_wt --path "$wt_path" >/dev/null 2>&1; then
       if [ -d "$wt_path" ]; then
@@ -197,7 +375,7 @@ test_exit_fails_on_unstaged_changes() {
   cd "$REPO"
 
   wt_path="$TEST_ROOT/worktree-dirty"
-  if enter --fork-from main --path "$wt_path" >/dev/null 2>&1; then
+  if enter --fork-from main --pull-latest main --path "$wt_path" >/dev/null 2>&1; then
     echo "dirty" > "$wt_path/dirty.txt"
     cd "$REPO"
     if exit_wt --path "$wt_path" >/dev/null 2>&1; then
@@ -217,7 +395,7 @@ test_exit_fails_on_staged_changes() {
   cd "$REPO"
 
   wt_path="$TEST_ROOT/worktree-staged"
-  if enter --fork-from main --path "$wt_path" >/dev/null 2>&1; then
+  if enter --fork-from main --pull-latest main --path "$wt_path" >/dev/null 2>&1; then
     echo "staged" > "$wt_path/staged.txt"
     (cd "$wt_path" && git add staged.txt)
     cd "$REPO"
@@ -255,7 +433,7 @@ test_commit_pushes_to_branch() {
   cd "$REPO"
 
   wt_path="$TEST_ROOT/worktree-commit"
-  if enter --fork-from main --path "$wt_path" >/dev/null 2>&1; then
+  if enter --fork-from main --pull-latest main --path "$wt_path" >/dev/null 2>&1; then
     echo "new feature" > "$wt_path/feature.txt"
     cd "$wt_path"
     if commit_wt --branch feat/commit-test -m "add feature" >/dev/null 2>&1; then
@@ -281,7 +459,7 @@ test_commit_pushes_to_existing_branch() {
   cd "$REPO"
 
   wt_path="$TEST_ROOT/worktree-commit-main"
-  if enter --fork-from main --path "$wt_path" >/dev/null 2>&1; then
+  if enter --fork-from main --pull-latest main --path "$wt_path" >/dev/null 2>&1; then
     echo "metadata" > "$wt_path/plan.md"
     cd "$wt_path"
     if commit_wt --branch main -m "update plan" >/dev/null 2>&1; then
@@ -326,7 +504,7 @@ test_commit_fails_on_nothing_to_commit() {
   cd "$REPO"
 
   wt_path="$TEST_ROOT/worktree-empty"
-  if enter --fork-from main --path "$wt_path" >/dev/null 2>&1; then
+  if enter --fork-from main --pull-latest main --path "$wt_path" >/dev/null 2>&1; then
     cd "$wt_path"
     if commit_wt --branch feat/empty-test -m "empty" >/dev/null 2>&1; then
       fail "commit: fails when nothing to commit" "succeeded"
@@ -349,6 +527,12 @@ test_enter_at_caller_defined_path
 test_enter_creates_nested_parent_dirs
 test_enter_fails_if_worktree_exists
 test_enter_fails_on_missing_args
+
+test_pull_latest_same_branch
+test_pull_latest_clean_merge
+test_pull_latest_conflicts
+test_pull_latest_already_up_to_date
+test_pull_latest_detached_head_after_merge
 
 test_exit_removes_clean_worktree
 test_exit_fails_on_unstaged_changes


### PR DESCRIPTION
closes #78 056/001 Add --pull-latest flag to worktree-enter.sh

## Slice

#78

## Parent

#56

## Acceptance criteria

- [x] `worktree-enter.sh` accepts a required `--pull-latest <branch>` flag; exits with error if missing — added to arg parser and validation; test covers missing flag
- [x] When `--fork-from` == `--pull-latest`, the script outputs `ready` and performs no merge — early return after branch name comparison
- [x] When branches differ and merge is clean, the script pushes the merge commit to `origin/$FORK_FROM` using explicit refspec (no force) and outputs `synced: pulled N commits from $PULL_LATEST into $FORK_FROM`
- [x] When branches differ and merge has conflicts, the script outputs `conflicts: merge of $PULL_LATEST into $FORK_FROM has conflicts` and leaves conflict markers in the worktree (no push)
- [x] When branches differ but fork-from is already up to date with pull-latest, the script outputs `ready` (no no-op merge commit) — merge-base check detects ancestry
- [x] Worktree remains detached HEAD after all operations (no local branch names created) — verified by dedicated test
- [x] `worktree.test.sh` updated with tests covering same-branch, clean-merge, conflict, and already-up-to-date scenarios — 6 new tests added (22 total, up from 16)

## Ambiguous choices

- **Output format**: The script now outputs two lines to stdout: line 1 is the absolute worktree path (preserving backward compatibility), line 2 is the status (`ready`, `synced: ...`, or `conflicts: ...`). Callers that captured only the path via `path=$(enter ...)` need to use `head -1` to extract the path and `tail -1` for the status. This is the cleanest approach without introducing stderr for non-error output.

## Test results

22 tests passed, 0 failed, 0 skipped.

### 🪼 Pulse metrics

| Phase | Target | Duration | Tokens | Tool uses | Outcome | Date |
| --- | --- | --- | --- | --- | --- | --- |
| implement | #78 | 5m 5s | 52 802 | 47 | ✅ PR #80 created | 2026-04-21 07:21 |
| inspect | #78 | 1m 59s | 36 149 | 23 | ✅ passed → to-merge | 2026-04-21 07:25 |

<details><summary><h3>Inspect review — 2026/04/21 08:00</h3></summary>

**Test suite**: 22/22 passed (ran independently in inspect worktree)

**Acceptance criteria verification**:

| AC | Status | Evidence |
| --- | --- | --- |
| `--pull-latest` required, exits on missing | Met | Lines 44-47 validation + `test_enter_fails_on_missing_args` (line 169-173) |
| Same branch = `ready` | Met | Lines 64-67 + `test_pull_latest_same_branch` |
| Clean merge pushes with explicit refspec | Met | Lines 83-86 explicit `HEAD:refs/heads/` refspec + `test_pull_latest_clean_merge` verifies push |
| Conflicts leave markers, no push | Met | Lines 88-91 + `test_pull_latest_conflicts` verifies markers and no push |
| Already up-to-date = `ready` | Met | Lines 70-77 merge-base check + `test_pull_latest_already_up_to_date` |
| Detached HEAD preserved | Met | `--detach` on line 58 + two dedicated tests |
| Tests cover all four scenarios | Met | 6 new tests (same-branch, clean-merge, conflict, up-to-date, detached-HEAD-after-merge, missing-flag) |

**Ambiguous choice review**: Output format (two-line stdout: path + status) is clean and preserves backward compatibility for callers that already capture only the first line. Acceptable trade-off vs stderr for non-error status.

**Drift**: All `.md` skill files still reference the old two-arg signature (no `--pull-latest`). This is expected — updating callers is part of the parent plan #56, not this slice.

**Cleanups**: None needed. Code is well-commented, no debug prints or stale TODOs.

**Verdict**: All acceptance criteria met, suite green. Ready to merge.

</details>