### PR TITLE
pulling latest from base branch when target is behind

### DIFF
--- a/ORCHESTRATION.md
+++ b/ORCHESTRATION.md
@@ -202,7 +202,7 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
 - enter-worktree
   - contains: `Enter a worktree forked from $TARGET_BRANCH to read the codebase for informed slicing decisions`
   ```sh
-  ./worktree-enter.sh --fork-from "$TARGET_BRANCH" --path "$WORKTREE_PATH"
+  ./worktree-enter.sh --fork-from "$TARGET_BRANCH" --pull-latest "$BASE_BRANCH" --path "$WORKTREE_PATH"
   ```
 - create-remote-branch
   ```sh
@@ -252,6 +252,7 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
   ```sh
   SLICE_NAME="{from slice body}"
   SLICE_ID="$ISSUE_ID"
+  BASE_BRANCH="{from slice/plan body}"
   TARGET_BRANCH="{from slice/plan body}"
   SLICE_BRANCH="{PR branch, e.g. feat/001-auth-endpoint}"
   WORKTREE_PATH=".worktrees/$SLICE_NAME-implement"
@@ -259,7 +260,7 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
 - enter-worktree
   - contains: `Enter a worktree forked from $TARGET_BRANCH so you start from a clean integration point`
   ```sh
-  ./worktree-enter.sh --fork-from "$TARGET_BRANCH" --path "$WORKTREE_PATH"
+  ./worktree-enter.sh --fork-from "$TARGET_BRANCH" --pull-latest "$BASE_BRANCH" --path "$WORKTREE_PATH"
   ```
 - phase-specific
 - commit-code
@@ -309,12 +310,13 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
   SLICE_NAME="{from slice body}"
   SLICE_ID="$ISSUE_ID"
   SLICE_BRANCH="{from slice body}"
+  TARGET_BRANCH="{from slice/plan body}"
   WORKTREE_PATH=".worktrees/$SLICE_NAME-inspect"
   ```
 - enter-worktree
   - contains: `Enter a worktree forked from $SLICE_BRANCH to review the implementation`
   ```sh
-  ./worktree-enter.sh --fork-from "$SLICE_BRANCH" --path "$WORKTREE_PATH"
+  ./worktree-enter.sh --fork-from "$SLICE_BRANCH" --pull-latest "$TARGET_BRANCH" --path "$WORKTREE_PATH"
   ```
 - phase-specific
 - commit-code — if cleanup-needed
@@ -358,13 +360,14 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
   SLICE_NAME="{from slice body}"
   SLICE_ID="$ISSUE_ID"
   SLICE_BRANCH="{from slice body}"
+  TARGET_BRANCH="{from slice/plan body}"
   PR_NUMBER="{from slice body}"
   WORKTREE_PATH=".worktrees/$SLICE_NAME-rework"
   ```
 - enter-worktree
   - contains: `Enter a worktree forked from $SLICE_BRANCH to apply fixes to the existing PR branch`
   ```sh
-  ./worktree-enter.sh --fork-from "$SLICE_BRANCH" --path "$WORKTREE_PATH"
+  ./worktree-enter.sh --fork-from "$SLICE_BRANCH" --pull-latest "$TARGET_BRANCH" --path "$WORKTREE_PATH"
   ```
 - phase-specific
 - commit-code
@@ -407,6 +410,7 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
   ```sh
   SLICE_NAME="{from slice body}"
   SLICE_ID="$ISSUE_ID"
+  BASE_BRANCH="{from slice/plan body}"
   TARGET_BRANCH="{from slice/plan body}"
   WORKTREE_PATH=".worktrees/$SLICE_NAME-await-waves"
   ```
@@ -421,7 +425,7 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
 - enter-worktree
   - contains: `Enter a worktree forked from $TARGET_BRANCH to be able to read up to date code`
   ```sh
-  ./worktree-enter.sh --fork-from "$TARGET_BRANCH" --path "$WORKTREE_PATH"
+  ./worktree-enter.sh --fork-from "$TARGET_BRANCH" --pull-latest "$BASE_BRANCH" --path "$WORKTREE_PATH"
   ```
 - phase-specific
 - set-variables
@@ -469,11 +473,7 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
 - enter-worktree
   - contains: `Enter a worktree forked from $SLICE_BRANCH (not $TARGET_BRANCH) so you are testing the slice code with the latest target merged in`
   ```sh
-  ./worktree-enter.sh --fork-from "$SLICE_BRANCH" --path "$WORKTREE_PATH"
-  ```
-- merge-target-into-slice
-  ```sh
-  git merge "origin/$TARGET_BRANCH"
+  ./worktree-enter.sh --fork-from "$SLICE_BRANCH" --pull-latest "$TARGET_BRANCH" --path "$WORKTREE_PATH"
   ```
 - commit-code — if merge-needed
   ```sh
@@ -565,7 +565,7 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
 - enter-worktree
   - contains: `Enter a worktree forked from $TARGET_BRANCH because all slice PRs are merged there`
   ```sh
-  ./worktree-enter.sh --fork-from "$TARGET_BRANCH" --path "$WORKTREE_PATH"
+  ./worktree-enter.sh --fork-from "$TARGET_BRANCH" --pull-latest "$BASE_BRANCH" --path "$WORKTREE_PATH"
   ```
 - phase-specific
 - commit-code — if documentation-added
@@ -612,6 +612,7 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
   ```sh
   PLAN_ID="$ISSUE_ID"
   PR_NUMBER="{from plan body frontmatter PR: \"#N\"}"
+  BASE_BRANCH="{from plan body}"
   TARGET_BRANCH="{from plan body}"
   WORKTREE_PATH=".worktrees/$PLAN_ID-rescan"
   ```
@@ -622,7 +623,7 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
 - enter-worktree
   - contains: `Enter a worktree forked from $TARGET_BRANCH to read the current state of the code`
   ```sh
-  ./worktree-enter.sh --fork-from "$TARGET_BRANCH" --path "$WORKTREE_PATH"
+  ./worktree-enter.sh --fork-from "$TARGET_BRANCH" --pull-latest "$BASE_BRANCH" --path "$WORKTREE_PATH"
   ```
 - phase-specific
 - update-tracker

--- a/reef-pulse/await-waves.md
+++ b/reef-pulse/await-waves.md
@@ -29,6 +29,7 @@ Set the post-fetch variables (after reading the slice body):
 ```sh
 SLICE_NAME="{from slice body}"
 SLICE_ID="$ISSUE_ID"
+BASE_BRANCH="{from slice/plan body}"
 TARGET_BRANCH="{from slice/plan body}"
 WORKTREE_PATH=".worktrees/$SLICE_NAME-await-waves"
 ```
@@ -54,8 +55,16 @@ DEPENDENCY_ID="{from slice blocked-by list}"
 Enter a worktree forked from $TARGET_BRANCH to be able to read up to date code (earlier slices may have changed the codebase):
 
 ```sh
-./worktree-enter.sh --fork-from "$TARGET_BRANCH" --path "$WORKTREE_PATH"
+WORKTREE_STATUS=$(./worktree-enter.sh --fork-from "$TARGET_BRANCH" --pull-latest "$BASE_BRANCH" --path "$WORKTREE_PATH")
 ```
+
+Read the output. On `ready` or `synced`: continue. On `conflicts`: attempt to resolve the conflicts in the worktree. If resolved, commit the merge and push to `origin/$TARGET_BRANCH` using explicit refspec (no force), then continue. If unresolvable:
+
+```sh
+./tracker.sh issue edit "$SLICE_ID" --add-label blocked-with-conflicts
+```
+
+Stop — do not proceed.
 
 Earlier slices may have changed the codebase. Read this slice's acceptance criteria and compare against the current state of the code:
 

--- a/reef-pulse/implement.md
+++ b/reef-pulse/implement.md
@@ -39,6 +39,7 @@ Set the post-fetch variables (after reading the slice body):
 ```sh
 SLICE_NAME="{from slice body}"
 SLICE_ID="$ISSUE_ID"
+BASE_BRANCH="{from slice/plan body}"
 TARGET_BRANCH="{from slice/plan body}"
 SLICE_BRANCH="{PR branch, e.g. feat/001-auth-endpoint}"
 WORKTREE_PATH=".worktrees/$SLICE_NAME-implement"
@@ -51,8 +52,16 @@ This is non-negotiable. Every step must pass before writing any code.
 Enter a worktree forked from $TARGET_BRANCH so you start from a clean integration point (earlier slices' work is already merged there):
 
 ```sh
-./worktree-enter.sh --fork-from "$TARGET_BRANCH" --path "$WORKTREE_PATH"
+WORKTREE_STATUS=$(./worktree-enter.sh --fork-from "$TARGET_BRANCH" --pull-latest "$BASE_BRANCH" --path "$WORKTREE_PATH")
 ```
+
+Read the output. On `ready` or `synced`: continue. On `conflicts`: attempt to resolve the conflicts in the worktree. If resolved, commit the merge and push to `origin/$TARGET_BRANCH` using explicit refspec (no force), then continue. If unresolvable:
+
+```sh
+./tracker.sh issue edit "$SLICE_ID" --add-label blocked-with-conflicts
+```
+
+Stop — do not proceed.
 
 Verify:
 

--- a/reef-pulse/inspect.md
+++ b/reef-pulse/inspect.md
@@ -30,6 +30,7 @@ Set the post-fetch variables (after reading the slice body):
 SLICE_NAME="{from slice body}"
 SLICE_ID="$ISSUE_ID"
 SLICE_BRANCH="{from slice body}"
+TARGET_BRANCH="{from slice/plan body}"
 WORKTREE_PATH=".worktrees/$SLICE_NAME-inspect"
 ```
 
@@ -53,8 +54,16 @@ A few things you naturally do:
 Enter a worktree forked from $SLICE_BRANCH to review the implementation without disturbing the main checkout:
 
 ```sh
-./worktree-enter.sh --fork-from "$SLICE_BRANCH" --path "$WORKTREE_PATH"
+WORKTREE_STATUS=$(./worktree-enter.sh --fork-from "$SLICE_BRANCH" --pull-latest "$TARGET_BRANCH" --path "$WORKTREE_PATH")
 ```
+
+Read the output. On `ready` or `synced`: continue. On `conflicts`: attempt to resolve the conflicts in the worktree. If resolved, commit the merge and push to `origin/$SLICE_BRANCH` using explicit refspec (no force), then continue. If unresolvable:
+
+```sh
+./tracker.sh issue edit "$SLICE_ID" --add-label blocked-with-conflicts
+```
+
+Stop — do not proceed.
 
 Run the full project test suite. Record the result.
 

--- a/reef-pulse/merge.md
+++ b/reef-pulse/merge.md
@@ -50,16 +50,18 @@ gh pr view "$PR_NUMBER" --json mergeStateStatus -q .mergeStateStatus
 Enter a worktree forked from $SLICE_BRANCH (not $TARGET_BRANCH) so you are testing the slice code with the latest target merged in:
 
 ```sh
-./worktree-enter.sh --fork-from "$SLICE_BRANCH" --path "$WORKTREE_PATH"
+WORKTREE_STATUS=$(./worktree-enter.sh --fork-from "$SLICE_BRANCH" --pull-latest "$TARGET_BRANCH" --path "$WORKTREE_PATH")
 ```
 
-Merge the target branch into the slice branch:
+Read the output. On `ready` or `synced`: continue. On `conflicts`: attempt to resolve the conflicts in the worktree. If resolved, commit the merge and push to `origin/$SLICE_BRANCH` using explicit refspec (no force), then continue. If unresolvable:
 
 ```sh
-git merge "origin/$TARGET_BRANCH"
+./tracker.sh issue edit "$SLICE_ID" --add-label blocked-with-conflicts
 ```
 
-Run the full test suite. If the target branch merged cleanly and tests pass, commit and push:
+Stop — do not proceed.
+
+Run the full test suite. If tests pass, commit and push:
 
 ```sh
 ./commit.sh --branch "$SLICE_BRANCH" -m "merge: resolve conflicts with $TARGET_BRANCH"

--- a/reef-pulse/ratify.md
+++ b/reef-pulse/ratify.md
@@ -52,8 +52,16 @@ Think like a CTO doing a final walkthrough before shipping.
 Enter a worktree forked from $TARGET_BRANCH because all slice PRs are merged there — you are reviewing the aggregate, not individual slices:
 
 ```sh
-./worktree-enter.sh --fork-from "$TARGET_BRANCH" --path "$WORKTREE_PATH"
+WORKTREE_STATUS=$(./worktree-enter.sh --fork-from "$TARGET_BRANCH" --pull-latest "$BASE_BRANCH" --path "$WORKTREE_PATH")
 ```
+
+Read the output. On `ready` or `synced`: continue. On `conflicts`: attempt to resolve the conflicts in the worktree. If resolved, commit the merge and push to `origin/$TARGET_BRANCH` using explicit refspec (no force), then continue. If unresolvable:
+
+```sh
+./tracker.sh issue edit "$PLAN_ID" --add-label blocked-with-conflicts
+```
+
+Stop — do not proceed.
 
 Verify you have the latest — all slice PRs should be merged into this branch.
 

--- a/reef-pulse/rescan.md
+++ b/reef-pulse/rescan.md
@@ -29,6 +29,7 @@ Set the post-fetch variables (after reading the plan body):
 ```sh
 PLAN_ID="$ISSUE_ID"
 PR_NUMBER="{from plan body frontmatter PR: \"#N\"}"
+BASE_BRANCH="{from plan body}"
 TARGET_BRANCH="{from plan body}"
 WORKTREE_PATH=".worktrees/$PLAN_ID-rescan"
 ```
@@ -57,8 +58,16 @@ Do NOT ask a human. If the gaps need decisions that aren't in the success criter
 Enter a worktree forked from $TARGET_BRANCH to read the current state of the code:
 
 ```sh
-./worktree-enter.sh --fork-from "$TARGET_BRANCH" --path "$WORKTREE_PATH"
+WORKTREE_STATUS=$(./worktree-enter.sh --fork-from "$TARGET_BRANCH" --pull-latest "$BASE_BRANCH" --path "$WORKTREE_PATH")
 ```
+
+Read the output. On `ready` or `synced`: continue. On `conflicts`: attempt to resolve the conflicts in the worktree. If resolved, commit the merge and push to `origin/$TARGET_BRANCH` using explicit refspec (no force), then continue. If unresolvable:
+
+```sh
+./tracker.sh issue edit "$PLAN_ID" --add-label blocked-with-conflicts
+```
+
+Stop — do not proceed.
 
 ### 1. Analyze the gaps
 

--- a/reef-pulse/rework.md
+++ b/reef-pulse/rework.md
@@ -30,6 +30,7 @@ Set the post-fetch variables (after reading the slice body):
 SLICE_NAME="{from slice body}"
 SLICE_ID="$ISSUE_ID"
 SLICE_BRANCH="{from slice body}"
+TARGET_BRANCH="{from slice/plan body}"
 PR_NUMBER="{from slice body}"
 WORKTREE_PATH=".worktrees/$SLICE_NAME-rework"
 ```
@@ -41,8 +42,16 @@ WORKTREE_PATH=".worktrees/$SLICE_NAME-rework"
 Enter a worktree forked from $SLICE_BRANCH to apply fixes to the existing PR branch:
 
 ```sh
-./worktree-enter.sh --fork-from "$SLICE_BRANCH" --path "$WORKTREE_PATH"
+WORKTREE_STATUS=$(./worktree-enter.sh --fork-from "$SLICE_BRANCH" --pull-latest "$TARGET_BRANCH" --path "$WORKTREE_PATH")
 ```
+
+Read the output. On `ready` or `synced`: continue. On `conflicts`: attempt to resolve the conflicts in the worktree. If resolved, commit the merge and push to `origin/$SLICE_BRANCH` using explicit refspec (no force), then continue. If unresolvable:
+
+```sh
+./tracker.sh issue edit "$SLICE_ID" --add-label blocked-with-conflicts
+```
+
+Stop — do not proceed.
 
 ### 2. Read all feedback
 

--- a/reef-pulse/slice-multi.md
+++ b/reef-pulse/slice-multi.md
@@ -25,8 +25,16 @@ WORKTREE_PATH=".worktrees/$PLAN_ID-slice"
 Enter a worktree forked from $TARGET_BRANCH to read the codebase for informed slicing decisions:
 
 ```sh
-./worktree-enter.sh --fork-from "$TARGET_BRANCH" --path "$WORKTREE_PATH"
+WORKTREE_STATUS=$(./worktree-enter.sh --fork-from "$TARGET_BRANCH" --pull-latest "$BASE_BRANCH" --path "$WORKTREE_PATH")
 ```
+
+Read the output. On `ready` or `synced`: continue. On `conflicts`: attempt to resolve the conflicts in the worktree. If resolved, commit the merge and push to `origin/$TARGET_BRANCH` using explicit refspec (no force), then continue. If unresolvable:
+
+```sh
+./tracker.sh issue edit "$PLAN_ID" --add-label blocked-with-conflicts
+```
+
+Stop — do not proceed.
 
 If the target branch does not exist on origin yet, create it:
 

--- a/reef-pulse/tracker.sh
+++ b/reef-pulse/tracker.sh
@@ -61,7 +61,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 committed_enter() {
   mkdir -p "$ROOT/.worktrees"
   WORKTREE_TMP="$ROOT/.worktrees/tracker-$$"
-  "$SCRIPT_DIR/worktree-enter.sh" --fork-from "$TRACKER_BRANCH" --path "$WORKTREE_TMP" >/dev/null 2>&1
+  "$SCRIPT_DIR/worktree-enter.sh" --fork-from "$TRACKER_BRANCH" --pull-latest "$TRACKER_BRANCH" --path "$WORKTREE_TMP" >/dev/null 2>&1
   # Re-resolve TRACKER_PATH relative to the worktree
   case "$_raw_path" in
     /*) ;; # absolute path, no change

--- a/reef-pulse/worktree-enter.sh
+++ b/reef-pulse/worktree-enter.sh
@@ -2,18 +2,27 @@
 # worktree-enter.sh — create a git worktree at a caller-defined path
 #
 # Usage:
-#   worktree-enter.sh --fork-from {branch} --path {worktree-path}
+#   worktree-enter.sh --fork-from {branch} --pull-latest {branch} --path {worktree-path}
 #
-# --fork-from: the remote branch to fork from (detached HEAD on origin/{branch})
-# --path:      absolute or relative path where the worktree will be created
+# --fork-from:    the remote branch to fork from (detached HEAD on origin/{branch})
+# --pull-latest:  the remote branch to merge into the worktree after creation (required)
+# --path:         absolute or relative path where the worktree will be created
 #
 # Always creates a detached HEAD worktree from origin/{fork-from}.
-# The caller decides the path — Reef phases conventionally keep worktrees inside
-# the repo under .worktrees/ so the main checkout stays self-contained.
-# Prints the absolute worktree path to stdout.
+# After creation, compares fork-from and pull-latest:
+#   - Same branch: outputs "ready" (no merge)
+#   - Different branch, clean merge: pushes merge commit and outputs
+#     "synced: pulled N commits from {pull-latest} into {fork-from}"
+#   - Different branch, already up to date: outputs "ready"
+#   - Different branch, conflicts: outputs
+#     "conflicts: merge of {pull-latest} into {fork-from} has conflicts"
+#
+# Worktree remains detached HEAD throughout (no local branch names created).
+# Prints the absolute worktree path on the first line, status on the second line.
 set -eu
 
 FORK_FROM=""
+PULL_LATEST=""
 WORKTREE_PATH=""
 
 while [ $# -gt 0 ]; do
@@ -21,6 +30,9 @@ while [ $# -gt 0 ]; do
     --fork-from)
       [ $# -lt 2 ] && { echo "Error: --fork-from requires a value" >&2; exit 1; }
       FORK_FROM="$2"; shift 2 ;;
+    --pull-latest)
+      [ $# -lt 2 ] && { echo "Error: --pull-latest requires a value" >&2; exit 1; }
+      PULL_LATEST="$2"; shift 2 ;;
     --path)
       [ $# -lt 2 ] && { echo "Error: --path requires a value" >&2; exit 1; }
       WORKTREE_PATH="$2"; shift 2 ;;
@@ -29,8 +41,8 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-if [ -z "$FORK_FROM" ] || [ -z "$WORKTREE_PATH" ]; then
-  echo "Usage: worktree-enter.sh --fork-from {branch} --path {worktree-path}" >&2
+if [ -z "$FORK_FROM" ] || [ -z "$PULL_LATEST" ] || [ -z "$WORKTREE_PATH" ]; then
+  echo "Usage: worktree-enter.sh --fork-from {branch} --pull-latest {branch} --path {worktree-path}" >&2
   exit 1
 fi
 
@@ -45,4 +57,36 @@ git fetch origin --prune >/dev/null 2>&1
 
 git worktree add "$WORKTREE_PATH" "origin/${FORK_FROM}" --detach >/dev/null 2>&1
 
-cd "$WORKTREE_PATH" && pwd -P
+ABS_PATH="$(cd "$WORKTREE_PATH" && pwd -P)"
+echo "$ABS_PATH"
+
+# If fork-from and pull-latest are the same branch, no merge needed
+if [ "$FORK_FROM" = "$PULL_LATEST" ]; then
+  echo "ready"
+  exit 0
+fi
+
+# Different branches — check if already up to date
+LATEST_SHA="$(git rev-parse "origin/${PULL_LATEST}")"
+MERGE_BASE="$(git -C "$ABS_PATH" merge-base HEAD "$LATEST_SHA")"
+
+if [ "$LATEST_SHA" = "$MERGE_BASE" ]; then
+  # pull-latest is already an ancestor of fork-from — nothing to merge
+  echo "ready"
+  exit 0
+fi
+
+# Count how many commits will be merged
+COMMIT_COUNT="$(git -C "$ABS_PATH" rev-list "$MERGE_BASE".."$LATEST_SHA" | wc -l | tr -d ' ')"
+
+# Attempt the merge (staying detached HEAD)
+if git -C "$ABS_PATH" merge --no-edit "$LATEST_SHA" >/dev/null 2>&1; then
+  # Clean merge — push to origin using explicit refspec (no force)
+  git -C "$ABS_PATH" push origin "HEAD:refs/heads/${FORK_FROM}" >/dev/null 2>&1
+  echo "synced: pulled $COMMIT_COUNT commits from $PULL_LATEST into $FORK_FROM"
+  exit 0
+else
+  # Conflicts — leave conflict markers, don't push
+  echo "conflicts: merge of $PULL_LATEST into $FORK_FROM has conflicts"
+  exit 0
+fi

--- a/tests/worktree.test.sh
+++ b/tests/worktree.test.sh
@@ -66,7 +66,7 @@ test_enter_detached_head() {
   cd "$REPO"
 
   wt_path="$TEST_ROOT/worktree-ratify"
-  if enter --fork-from main --path "$wt_path" >/dev/null 2>&1; then
+  if enter --fork-from main --pull-latest main --path "$wt_path" >/dev/null 2>&1; then
     if [ -d "$wt_path" ]; then
       head_status="$(cd "$wt_path" && git rev-parse --abbrev-ref HEAD)"
       if [ "$head_status" = "HEAD" ]; then
@@ -89,7 +89,9 @@ test_enter_at_caller_defined_path() {
   cd "$REPO"
 
   wt_path="$TEST_ROOT/my-custom-path"
-  if path="$(enter --fork-from main --path "$wt_path" 2>/dev/null)"; then
+  output="$(enter --fork-from main --pull-latest main --path "$wt_path" 2>/dev/null)"
+  if [ $? -eq 0 ]; then
+    path="$(echo "$output" | head -1)"
     resolved_actual="$(cd "$path" && pwd -P)"
     resolved_expected="$(cd "$wt_path" && pwd -P)"
     if [ "$resolved_expected" = "$resolved_actual" ]; then
@@ -109,7 +111,9 @@ test_enter_creates_nested_parent_dirs() {
   cd "$REPO"
 
   wt_path="$REPO/.worktrees/nested/worktree-ratify"
-  if path="$(enter --fork-from main --path "$wt_path" 2>/dev/null)"; then
+  output="$(enter --fork-from main --pull-latest main --path "$wt_path" 2>/dev/null)"
+  if [ $? -eq 0 ]; then
+    path="$(echo "$output" | head -1)"
     resolved_actual="$(cd "$path" && pwd -P)"
     resolved_expected="$(cd "$wt_path" && pwd -P)"
     if [ "$resolved_expected" = "$resolved_actual" ] && [ -d "$REPO/.worktrees/nested" ]; then
@@ -129,9 +133,9 @@ test_enter_fails_if_worktree_exists() {
   cd "$REPO"
 
   wt_path="$TEST_ROOT/worktree-dup"
-  enter --fork-from main --path "$wt_path" >/dev/null 2>&1 || true
+  enter --fork-from main --pull-latest main --path "$wt_path" >/dev/null 2>&1 || true
 
-  if enter --fork-from main --path "$wt_path" >/dev/null 2>&1; then
+  if enter --fork-from main --pull-latest main --path "$wt_path" >/dev/null 2>&1; then
     fail "enter: fails if worktree already exists" "second call succeeded"
   else
     pass "enter: fails if worktree already exists"
@@ -150,16 +154,190 @@ test_enter_fails_on_missing_args() {
     pass "enter: fails with no args"
   fi
 
-  if enter --fork-from main >/dev/null 2>&1; then
+  if enter --fork-from main --pull-latest main >/dev/null 2>&1; then
     fail "enter: fails without --path" "succeeded"
   else
     pass "enter: fails without --path"
   fi
 
-  if enter --path /tmp/some-path >/dev/null 2>&1; then
+  if enter --pull-latest main --path /tmp/some-path >/dev/null 2>&1; then
     fail "enter: fails without --fork-from" "succeeded"
   else
     pass "enter: fails without --fork-from"
+  fi
+
+  if enter --fork-from main --path /tmp/some-path2 >/dev/null 2>&1; then
+    fail "enter: fails without --pull-latest" "succeeded"
+  else
+    pass "enter: fails without --pull-latest"
+  fi
+
+  teardown_repos
+}
+
+# ============================================================
+# PULL-LATEST TESTS
+# ============================================================
+
+test_pull_latest_same_branch() {
+  setup_repos
+  cd "$REPO"
+
+  wt_path="$TEST_ROOT/worktree-same"
+  output="$(enter --fork-from main --pull-latest main --path "$wt_path" 2>/dev/null)"
+  status="$(echo "$output" | tail -1)"
+  if [ "$status" = "ready" ]; then
+    pass "pull-latest: same branch outputs ready"
+  else
+    fail "pull-latest: same branch outputs ready" "got: $status"
+  fi
+
+  teardown_repos
+}
+
+test_pull_latest_clean_merge() {
+  setup_repos
+  cd "$REPO"
+
+  # Create a target branch forked from main
+  git checkout -b feat/target >/dev/null 2>&1
+  echo "target work" > target.txt
+  git add target.txt
+  git commit -m "target commit" >/dev/null 2>&1
+  git push origin feat/target >/dev/null 2>&1
+  git checkout main >/dev/null 2>&1
+
+  # Add a commit to main that feat/target doesn't have
+  echo "main update" > main-update.txt
+  git add main-update.txt
+  git commit -m "main update" >/dev/null 2>&1
+  git push origin main >/dev/null 2>&1
+
+  wt_path="$TEST_ROOT/worktree-merge"
+  output="$(enter --fork-from feat/target --pull-latest main --path "$wt_path" 2>/dev/null)"
+  status="$(echo "$output" | tail -1)"
+
+  if echo "$status" | grep -q "^synced: pulled .* commits from main into feat/target$"; then
+    # Verify push happened
+    git fetch origin >/dev/null 2>&1
+    if git -C "$REPO" log origin/feat/target --oneline | grep -q "Merge"; then
+      # Verify worktree is still detached HEAD
+      head_status="$(cd "$wt_path" && git rev-parse --abbrev-ref HEAD)"
+      if [ "$head_status" = "HEAD" ]; then
+        pass "pull-latest: clean merge syncs and pushes"
+      else
+        fail "pull-latest: clean merge syncs and pushes" "not detached HEAD: $head_status"
+      fi
+    else
+      fail "pull-latest: clean merge syncs and pushes" "merge commit not on origin"
+    fi
+  else
+    fail "pull-latest: clean merge syncs and pushes" "got: $status"
+  fi
+
+  teardown_repos
+}
+
+test_pull_latest_conflicts() {
+  setup_repos
+  cd "$REPO"
+
+  # Create a target branch that modifies README.md
+  git checkout -b feat/conflict >/dev/null 2>&1
+  echo "conflict version A" > README.md
+  git add README.md
+  git commit -m "conflict A" >/dev/null 2>&1
+  git push origin feat/conflict >/dev/null 2>&1
+  git checkout main >/dev/null 2>&1
+
+  # Modify the same file on main
+  echo "conflict version B" > README.md
+  git add README.md
+  git commit -m "conflict B" >/dev/null 2>&1
+  git push origin main >/dev/null 2>&1
+
+  wt_path="$TEST_ROOT/worktree-conflict"
+  output="$(enter --fork-from feat/conflict --pull-latest main --path "$wt_path" 2>/dev/null)"
+  status="$(echo "$output" | tail -1)"
+
+  if [ "$status" = "conflicts: merge of main into feat/conflict has conflicts" ]; then
+    # Verify conflict markers exist in worktree
+    if grep -q "<<<<<<" "$wt_path/README.md" 2>/dev/null; then
+      # Verify nothing was pushed (origin/feat/conflict should still be at "conflict A")
+      git fetch origin >/dev/null 2>&1
+      last_msg="$(git log origin/feat/conflict -1 --format=%s)"
+      if [ "$last_msg" = "conflict A" ]; then
+        pass "pull-latest: conflicts outputs message and leaves markers"
+      else
+        fail "pull-latest: conflicts outputs message and leaves markers" "push happened: $last_msg"
+      fi
+    else
+      fail "pull-latest: conflicts outputs message and leaves markers" "no conflict markers in worktree"
+    fi
+  else
+    fail "pull-latest: conflicts outputs message and leaves markers" "got: $status"
+  fi
+
+  teardown_repos
+}
+
+test_pull_latest_already_up_to_date() {
+  setup_repos
+  cd "$REPO"
+
+  # Create a target branch that is ahead of main (main is ancestor)
+  git checkout -b feat/ahead >/dev/null 2>&1
+  echo "ahead work" > ahead.txt
+  git add ahead.txt
+  git commit -m "ahead commit" >/dev/null 2>&1
+  git push origin feat/ahead >/dev/null 2>&1
+  git checkout main >/dev/null 2>&1
+
+  wt_path="$TEST_ROOT/worktree-uptodate"
+  output="$(enter --fork-from feat/ahead --pull-latest main --path "$wt_path" 2>/dev/null)"
+  status="$(echo "$output" | tail -1)"
+
+  if [ "$status" = "ready" ]; then
+    # Verify no merge commit was created (still at "ahead commit")
+    last_msg="$(cd "$wt_path" && git log -1 --format=%s)"
+    if [ "$last_msg" = "ahead commit" ]; then
+      pass "pull-latest: already up to date outputs ready"
+    else
+      fail "pull-latest: already up to date outputs ready" "unexpected commit: $last_msg"
+    fi
+  else
+    fail "pull-latest: already up to date outputs ready" "got: $status"
+  fi
+
+  teardown_repos
+}
+
+test_pull_latest_detached_head_after_merge() {
+  setup_repos
+  cd "$REPO"
+
+  # Create a target branch
+  git checkout -b feat/detach-test >/dev/null 2>&1
+  echo "detach work" > detach.txt
+  git add detach.txt
+  git commit -m "detach commit" >/dev/null 2>&1
+  git push origin feat/detach-test >/dev/null 2>&1
+  git checkout main >/dev/null 2>&1
+
+  # Add commit to main
+  echo "main detach" > main-detach.txt
+  git add main-detach.txt
+  git commit -m "main detach" >/dev/null 2>&1
+  git push origin main >/dev/null 2>&1
+
+  wt_path="$TEST_ROOT/worktree-detach"
+  enter --fork-from feat/detach-test --pull-latest main --path "$wt_path" >/dev/null 2>&1
+
+  head_status="$(cd "$wt_path" && git rev-parse --abbrev-ref HEAD)"
+  if [ "$head_status" = "HEAD" ]; then
+    pass "pull-latest: worktree stays detached HEAD after merge"
+  else
+    fail "pull-latest: worktree stays detached HEAD after merge" "got: $head_status"
   fi
 
   teardown_repos
@@ -174,7 +352,7 @@ test_exit_removes_clean_worktree() {
   cd "$REPO"
 
   wt_path="$TEST_ROOT/worktree-clean"
-  if enter --fork-from main --path "$wt_path" >/dev/null 2>&1; then
+  if enter --fork-from main --pull-latest main --path "$wt_path" >/dev/null 2>&1; then
     cd "$REPO"
     if exit_wt --path "$wt_path" >/dev/null 2>&1; then
       if [ -d "$wt_path" ]; then
@@ -197,7 +375,7 @@ test_exit_fails_on_unstaged_changes() {
   cd "$REPO"
 
   wt_path="$TEST_ROOT/worktree-dirty"
-  if enter --fork-from main --path "$wt_path" >/dev/null 2>&1; then
+  if enter --fork-from main --pull-latest main --path "$wt_path" >/dev/null 2>&1; then
     echo "dirty" > "$wt_path/dirty.txt"
     cd "$REPO"
     if exit_wt --path "$wt_path" >/dev/null 2>&1; then
@@ -217,7 +395,7 @@ test_exit_fails_on_staged_changes() {
   cd "$REPO"
 
   wt_path="$TEST_ROOT/worktree-staged"
-  if enter --fork-from main --path "$wt_path" >/dev/null 2>&1; then
+  if enter --fork-from main --pull-latest main --path "$wt_path" >/dev/null 2>&1; then
     echo "staged" > "$wt_path/staged.txt"
     (cd "$wt_path" && git add staged.txt)
     cd "$REPO"
@@ -255,7 +433,7 @@ test_commit_pushes_to_branch() {
   cd "$REPO"
 
   wt_path="$TEST_ROOT/worktree-commit"
-  if enter --fork-from main --path "$wt_path" >/dev/null 2>&1; then
+  if enter --fork-from main --pull-latest main --path "$wt_path" >/dev/null 2>&1; then
     echo "new feature" > "$wt_path/feature.txt"
     cd "$wt_path"
     if commit_wt --branch feat/commit-test -m "add feature" >/dev/null 2>&1; then
@@ -281,7 +459,7 @@ test_commit_pushes_to_existing_branch() {
   cd "$REPO"
 
   wt_path="$TEST_ROOT/worktree-commit-main"
-  if enter --fork-from main --path "$wt_path" >/dev/null 2>&1; then
+  if enter --fork-from main --pull-latest main --path "$wt_path" >/dev/null 2>&1; then
     echo "metadata" > "$wt_path/plan.md"
     cd "$wt_path"
     if commit_wt --branch main -m "update plan" >/dev/null 2>&1; then
@@ -326,7 +504,7 @@ test_commit_fails_on_nothing_to_commit() {
   cd "$REPO"
 
   wt_path="$TEST_ROOT/worktree-empty"
-  if enter --fork-from main --path "$wt_path" >/dev/null 2>&1; then
+  if enter --fork-from main --pull-latest main --path "$wt_path" >/dev/null 2>&1; then
     cd "$wt_path"
     if commit_wt --branch feat/empty-test -m "empty" >/dev/null 2>&1; then
       fail "commit: fails when nothing to commit" "succeeded"
@@ -349,6 +527,12 @@ test_enter_at_caller_defined_path
 test_enter_creates_nested_parent_dirs
 test_enter_fails_if_worktree_exists
 test_enter_fails_on_missing_args
+
+test_pull_latest_same_branch
+test_pull_latest_clean_merge
+test_pull_latest_conflicts
+test_pull_latest_already_up_to_date
+test_pull_latest_detached_head_after_merge
 
 test_exit_removes_clean_worktree
 test_exit_fails_on_unstaged_changes


### PR DESCRIPTION
closes #56

<details><summary><h3>🦭 Ratify report — 2026/04/21 07:47</h3></summary>

## Final Report

### Status: GAPS FOUND

### Success criteria

- ✓ SC1: `worktree-enter.sh` accepts a required `--pull-latest` flag — verified: arg parser on lines 33-35, validation on line 44
- ✓ SC2: When fork-from == pull-latest, outputs `ready` and does no merge — verified: early return on lines 64-67
- ✓ SC3: When fork-from != pull-latest, merges and pushes on success (no force push) — verified: explicit refspec `HEAD:refs/heads/${FORK_FROM}` on line 85
- ✓ SC4: When merge has conflicts, outputs `conflicts` and leaves conflict markers — verified: lines 88-91, no push on conflict path
- ✓ SC5: All 8 phase .md files pass `--pull-latest` to `worktree-enter.sh` — verified: grep across all 8 files confirms correct values per spec table
- ✓ SC6: All 8 phase .md files handle `conflicts` (tag `blocked-with-conflicts`, stop) — verified: all 8 files include conflict-handling block
- ✓ SC7: merge.md's explicit merge step removed — verified: no `git merge` call remains; absorbed into `--pull-latest "$TARGET_BRANCH"`
- ✓ SC8: ORCHESTRATION.md reflects all changes — verified: all 8 `enter-worktree` entries include `--pull-latest`, `merge-target-into-slice` removed
- ✗ SC9: `test-orchestration.sh` passes — **Orchestration tests pass (224/224)**, but **tracker tests fail: 33 passed, 4 failed, 37 total**. See integration notes.
- ✓ SC10: Worktrees remain detached HEAD — verified: `--detach` flag on line 58, no local branches created

### Agent decisions to review

- **Two-line output format** (PR #80): `worktree-enter.sh` now outputs path on line 1, status on line 2. Backward compatible for callers that only read line 1. Phase .md files capture full output in `WORKTREE_STATUS` for agent interpretation. Reasonable trade-off.
- **Added BASE_BRANCH/TARGET_BRANCH to variable blocks** (PR #81): Necessary because these variables are now referenced by `--pull-latest`. No drift from plan intent.

### Integration notes

**GAP: `tracker.sh` committed mode is broken.** `tracker.sh:64` calls `worktree-enter.sh --fork-from "$TRACKER_BRANCH" --path "$WORKTREE_TMP"` without `--pull-latest`, which is now a required flag. This causes all 4 committed-mode tracker tests to fail (`committed create`, `committed edit`, `committed view`, `committed close`).

The fix is straightforward — `tracker.sh:64` needs `--pull-latest "$TRACKER_BRANCH"` (same as fork-from, since the tracker worktree just needs the tracker branch, no cross-branch sync):

```sh
"$SCRIPT_DIR/worktree-enter.sh" --fork-from "$TRACKER_BRANCH" --pull-latest "$TRACKER_BRANCH" --path "$WORKTREE_TMP"
```

The plan's coverage matrix listed only the 8 phase `.md` files as callers, but `tracker.sh` is a 9th caller that was missed.

### Test results

- Orchestration tests: 224 passed, 0 failed
- Worktree tests: 22 passed, 0 failed
- Tracker tests: 33 passed, **4 failed** (committed mode broken by missing `--pull-latest`)
- Total: 279 passed, 4 failed

### Parent plan

#56

</details>

### 🪼 Pulse metrics

| Phase | Target | Duration | Tokens | Tool uses | Outcome | Date |
| --- | --- | --- | --- | --- | --- | --- |
| slice | #56 | 3m 21s | 59 803 | 38 | ✅ slices created | 2026-04-21 07:11 |
| implement | #78 | 5m 5s | 52 802 | 47 | ✅ PR #80 created | 2026-04-21 07:21 |
| inspect | #78 | 1m 59s | 36 149 | 23 | ✅ passed → to-merge | 2026-04-21 07:25 |
| merge | #78 | 1m 27s | 20 146 | 18 | ✅ PR #80 squash-merged | 2026-04-21 07:27 |
| await-waves | #79 | 1m 1s | 31 304 | 16 | ✅ unblocked → to-implement | 2026-04-21 07:29 |
| implement | #79 | 6m 10s | 86 322 | 79 | ✅ PR #81 created | 2026-04-21 07:36 |
| inspect | #79 | 1m 40s | 25 277 | 20 | ✅ passed → to-merge | 2026-04-21 07:40 |
| merge | #79 | 1m 19s | 20 186 | 18 | ✅ PR #81 squash-merged, #56 → to-ratify | 2026-04-21 07:43 |
| ratify | #56 | 5m 4s | 42 951 | 50 | ❌ gap found → to-rescan | 2026-04-21 07:48 |
| ratify | #56 | 3m 19s | 60 339 | 44 | ✅ pass | 2026-04-21 08:27 |
| **Total** | | **30m 25s** | **435 279** | **353** | | |