### PR TITLE
077/002 reef-land and reef-pulse: replace to-rescan references with to-rework

### DIFF
--- a/ORCHESTRATION.md
+++ b/ORCHESTRATION.md
@@ -118,7 +118,7 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
   ```
 - update-tracker — if change-requests
   ```sh
-  ./tracker.sh issue edit "$PLAN_ID" --remove-label to-land --add-label to-rescan
+  ./tracker.sh issue edit "$PLAN_ID" --remove-label to-land --add-label to-rework
   ```
 - update-plan-body — if change-requests and plan decisions changed
   ```sh

--- a/reef-land/SKILL.md
+++ b/reef-land/SKILL.md
@@ -178,7 +178,7 @@ PR_BODY="{current PR body with gap report appended in <details><summary> block}"
 
 ```sh
 gh pr edit "$PR_NUMBER" --body "$PR_BODY"
-./tracker.sh issue edit "$PLAN_ID" --remove-label to-land --add-label to-rescan
+./tracker.sh issue edit "$PLAN_ID" --remove-label to-land --add-label to-rework
 ```
 
 If the discussion changed any plan-level Decisions, Stories, or Success Criteria, also update the plan body:
@@ -190,7 +190,7 @@ PLAN_BODY=$(./tracker.sh issue view "$PLAN_ID" --json body)
 
 Tell the human:
 
-> "Change requests scoped and written to the PR. The reef will pick this up on the next pulse and create new slices to address them."
+> "Change requests scoped and written to the PR. The reef will pick this up on the next pulse and rework them on the existing PR."
 
 ## 4. Capture concerns in follow-up issue (when chosen in step 2)
 

--- a/reef-pulse/SKILL.md
+++ b/reef-pulse/SKILL.md
@@ -56,7 +56,6 @@ Read the config to determine the tracker type, then scan for all tagged issues.
 ./tracker.sh issue list --label "to-rework" --json number,title --limit 100
 ./tracker.sh issue list --label "to-merge" --json number,title --limit 100
 ./tracker.sh issue list --label "to-ratify" --json number,title --limit 100
-./tracker.sh issue list --label "to-rescan" --json number,title --limit 100
 ./tracker.sh issue list --label "to-land" --json number,title --limit 100
 ```
 
@@ -79,7 +78,6 @@ For each item, spawn a sub-agent with: `"Read and follow $SKILL_DIR/{file}. Targ
 | `to-rework`      | `$SKILL_DIR/rework.md`      |
 | `to-merge`       | `$SKILL_DIR/merge.md`       |
 | `to-ratify`      | `$SKILL_DIR/ratify.md`      |
-| `to-rescan`      | `$SKILL_DIR/rescan.md`      |
 
 ### Step 3. Log phase metrics
 


### PR DESCRIPTION
closes #85 077/002 reef-land and reef-pulse: replace to-rescan references with to-rework

## Slice

#85

## Parent

#77

## Acceptance criteria

- [x] reef-land SKILL.md tags `to-rework` (not `to-rescan`) for substantial changes — changed tracker update in step 3 from `--add-label to-rescan` to `--add-label to-rework`
- [x] ORCHESTRATION.md reef-land section shows `to-rework` in the change-requests tracker update — line 121 updated from `to-rescan` to `to-rework`
- [x] reef-pulse SKILL.md no longer includes `to-rescan` in scan queries (Step 1) — removed the `to-rescan` scan line
- [x] reef-pulse SKILL.md no longer includes `to-rescan` dispatch row (Step 2) — removed the `to-rescan | rescan.md` row from dispatch table
- [x] ORCHESTRATION.md reef-pulse section has no `to-rescan` references — the reef-pulse section (lines 18-48) had none before and still has none; remaining `to-rescan` references in ratify/rescan sections are handled by sibling slices #84 and #86
- [x] `orchestration.test.sh` passes after each commit — 284 tests pass (225 + 37 + 22)

## Ambiguous choices

- **reef-land human message**: updated the tell-the-human message from "create new slices to address them" to "rework them on the existing PR" since the new `to-rework` flow fixes in place rather than creating new slices. This aligns with the plan's core goal of keeping work on the same PR.

## Test results

225 passed, 225 total (orchestration)
37 passed, 37 total
22 passed, 22 total

### 🪼 Pulse metrics

| Phase | Target | Duration | Tokens | Tool uses | Outcome | Date |
| --- | --- | --- | --- | --- | --- | --- |
| implement | #85 | 3m 55s | 50 987 | 52 | ✅ PR created | 2026-04-21 09:16 |

<details><summary><h3>🧿 Inspect review — 2026/04/21 09:25</h3></summary>

## Verification

**Test suite:** 225 passed, 225 total — green.

## Acceptance criteria check

| # | Criterion | Status | Notes |
|---|-----------|--------|-------|
| 1 | reef-land SKILL.md tags `to-rework` (not `to-rescan`) for substantial changes | PASS | Line 181: `--add-label to-rework` confirmed |
| 2 | ORCHESTRATION.md reef-land section shows `to-rework` in the change-requests tracker update | PASS | Line 121: `--add-label to-rework` confirmed |
| 3 | reef-pulse SKILL.md no longer includes `to-rescan` in scan queries (Step 1) | PASS | No `to-rescan` in file |
| 4 | reef-pulse SKILL.md no longer includes `to-rescan` dispatch row (Step 2) | PASS | No `to-rescan` row in dispatch table |
| 5 | ORCHESTRATION.md reef-pulse section has no `to-rescan` references | PASS | Lines 18-48 confirmed clean; remaining `to-rescan` refs are in ratify/rescan sections (covered by sibling slices #84 and #86) |
| 6 | `orchestration.test.sh` passes | PASS | 225/225 |

## Ambiguous choices review

- **Human message update**: Changed from "create new slices to address them" to "rework them on the existing PR". This is a sensible alignment with the `to-rework` flow semantics. Acceptable drift.

## Cleanups

None needed — no debug prints, stale TODOs, or dead code found.

## Verdict

All acceptance criteria met, tests green. Approving for merge.

</details>
| inspect | #85 | 1m 42s | 22 208 | 26 | ✅ passed | 2026-04-21 09:25 |