### PR TITLE
077/001 ratify and rework: absorb rescan logic and add plan-level rework router

### DIFF
--- a/ORCHESTRATION.md
+++ b/ORCHESTRATION.md
@@ -356,7 +356,7 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
   ```sh
   ./tracker.sh issue view "$ISSUE_ID" --json body,title,labels
   ```
-- set-variables
+- set-variables — if slice (has `parent-plan:` in frontmatter)
   ```sh
   SLICE_NAME="{from slice body}"
   SLICE_ID="$ISSUE_ID"
@@ -365,15 +365,34 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
   PR_NUMBER="{from slice body}"
   WORKTREE_PATH=".worktrees/$SLICE_NAME-rework"
   ```
-- enter-worktree
+- set-variables — if plan (no `parent-plan:` in frontmatter)
+  ```sh
+  PLAN_ID="$ISSUE_ID"
+  PLAN_TITLE="{from plan body}"
+  BASE_BRANCH="{from plan body}"
+  TARGET_BRANCH="{from plan body}"
+  PR_NUMBER="{from plan body or PR search}"
+  WORKING_BRANCH="{TARGET_BRANCH for multi-slice, PR head branch for single-slice}"
+  WORKTREE_PATH=".worktrees/$PLAN_ID-rework"
+  ```
+- enter-worktree — if slice
   - contains: `Enter a worktree forked from $SLICE_BRANCH to apply fixes to the existing PR branch`
   ```sh
   ./worktree-enter.sh --fork-from "$SLICE_BRANCH" --pull-latest "$TARGET_BRANCH" --path "$WORKTREE_PATH"
   ```
+- enter-worktree — if plan
+  - contains: `Enter a worktree forked from $WORKING_BRANCH to apply fixes to the existing PR`
+  ```sh
+  ./worktree-enter.sh --fork-from "$WORKING_BRANCH" --pull-latest "$BASE_BRANCH" --path "$WORKTREE_PATH"
+  ```
 - phase-specific
-- commit-code
+- commit-code — if slice
   ```sh
   ./commit.sh --branch "$SLICE_BRANCH" -m "rework: address inspection feedback"
+  ```
+- commit-code — if plan
+  ```sh
+  ./commit.sh --branch "$WORKING_BRANCH" -m "rework: address review feedback"
   ```
 - update-pr-body
   ```sh
@@ -382,9 +401,17 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
   PR_BODY="$PR_BODY\n\n$REPORT"
   gh pr edit "$PR_NUMBER" --body "$PR_BODY"
   ```
-- update-tracker
+- update-tracker — if slice
   ```sh
   ./tracker.sh issue edit "$SLICE_ID" --remove-label to-rework --add-label to-inspect
+  ```
+- update-tracker — if plan single-slice
+  ```sh
+  ./tracker.sh issue edit "$PLAN_ID" --remove-label to-rework --add-label to-inspect
+  ```
+- update-tracker — if plan multi-slice
+  ```sh
+  ./tracker.sh issue edit "$PLAN_ID" --remove-label to-rework --add-label to-ratify
   ```
 - exit-worktree
   ```sh
@@ -392,9 +419,9 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
   ```
 - handoff
   ```sh
-  nextPhase="to-inspect"
+  nextPhase="to-inspect" # single-slice, or "to-ratify" for multi-slice
   planPr="$PR_NUMBER"
-  summary="Rework complete — addressed inspection feedback"
+  summary="Rework complete — addressed review feedback"
   ```
 
 ### [await-waves.md](./reef-pulse/await-waves.md)
@@ -586,14 +613,14 @@ Phase-specific context (PLAN_TITLE for prose, BASE_BRANCH for reading) belongs i
   ```
 - update-tracker
   - pass: `./tracker.sh issue edit "$PLAN_ID" --remove-label to-ratify --add-label to-land`
-  - fail: `./tracker.sh issue edit "$PLAN_ID" --remove-label to-ratify --add-label to-rescan`
+  - fail: `./tracker.sh issue edit "$PLAN_ID" --remove-label to-ratify --add-label to-rework`
 - exit-worktree
   ```sh
   ./worktree-exit.sh --path "$WORKTREE_PATH"
   ```
 - handoff
   ```sh
-  nextPhase="to-land" # or "to-rescan" if gaps found
+  nextPhase="to-land" # or "to-rework" if gaps found, "to-scope" if safety valve
   planPr="$PR_NUMBER"
   summary="Ratify {PASS|GAPS FOUND} — {one-line summary}"
   planIssueMetrics="{metrics rows from plan issue body, or empty if none}"

--- a/reef-pulse/ratify.md
+++ b/reef-pulse/ratify.md
@@ -97,7 +97,28 @@ Look for problems that only appear when slices are composed:
 - Are there any test gaps at the integration boundaries? (Prevents painpoint C3 — mocked-away bugs.)
 - **Terminology inconsistencies**: did different slices use different words for the same concept? If terminology drifted across slices, run `/ubiquitous-language` against the target branch to flag ambiguities and include findings in the report.
 
-### 6. Documentation
+### 6. Plan re-review
+
+Before deciding PASS vs GAPS, re-review the entire plan through the lens of your findings from steps 3-5:
+
+- Re-read the plan top to bottom. With your holistic review findings in mind, are the success criteria still correct and complete?
+- If the review revealed something that SHOULD have been a criterion but wasn't, update the success criteria on the plan issue.
+- Classify each gap found:
+  - **Missing coverage**: a success criterion has no slice addressing it
+  - **Incomplete implementation**: a slice was done but didn't fully satisfy a criterion when composed
+  - **Integration gap**: slices work individually but not together
+  - **Planning gap**: the plan or success criteria were ambiguous or missed something
+
+If you updated the plan's success criteria:
+
+```sh
+PLAN_BODY="{plan body with updated success criteria}"
+./tracker.sh issue edit "$PLAN_ID" --body "$PLAN_BODY"
+```
+
+If any gaps need decisions beyond what success criteria cover (e.g. the plan itself is ambiguous about a design direction), this is a **safety valve** — tag `to-scope` instead of `to-rework` so a new scoping session can resolve the ambiguity.
+
+### 7. Documentation
 
 When you find non-obvious behavior worth documenting during your holistic review:
 
@@ -111,7 +132,7 @@ When you find non-obvious behavior worth documenting during your holistic review
 
 Don't document what's obvious from reading the code.
 
-### 7. Produce the report
+### 8. Produce the report
 
 The report goes on a **PR from the target branch to the base branch** (usually `main`). This PR is what the human will ultimately merge or reject.
 
@@ -168,7 +189,7 @@ PR_BODY="$PR_BODY\n\n$REPORT"
 gh pr edit "$PR_NUMBER" --body "$PR_BODY"
 ```
 
-### 8. Tag
+### 9. Tag
 
 **If all criteria met (PASS):**
 
@@ -176,10 +197,16 @@ gh pr edit "$PR_NUMBER" --body "$PR_BODY"
 ./tracker.sh issue edit "$PLAN_ID" --remove-label to-ratify --add-label to-land
 ```
 
-**If gaps found:**
+**If gaps found (fixable within success criteria):**
 
 ```sh
-./tracker.sh issue edit "$PLAN_ID" --remove-label to-ratify --add-label to-rescan
+./tracker.sh issue edit "$PLAN_ID" --remove-label to-ratify --add-label to-rework
+```
+
+**If gaps need decisions beyond success criteria (safety valve):**
+
+```sh
+./tracker.sh issue edit "$PLAN_ID" --remove-label to-ratify --add-label to-scope
 ```
 
 ## Clean up
@@ -193,7 +220,7 @@ gh pr edit "$PR_NUMBER" --body "$PR_BODY"
 Read the plan issue body for any existing `### 🪼 Pulse metrics` rows (scope and slice metrics). Extract them as `planIssueMetrics`.
 
 ```sh
-nextPhase="to-land" # or "to-rescan" if gaps found
+nextPhase="to-land" # or "to-rework" if gaps found, "to-scope" if safety valve
 planPr="$PR_NUMBER"
 summary="Ratify {PASS|GAPS FOUND} — {one-line summary}"
 planIssueMetrics="{metrics rows from plan issue body, or empty if none}"

--- a/reef-pulse/rework.md
+++ b/reef-pulse/rework.md
@@ -8,9 +8,9 @@
 
 ## Input
 
-This skill requires a specific slice: e.g. `#55` or `my-feature/001-auth-endpoint`.
+This skill requires a specific issue: e.g. `#55` or `my-feature/001-auth-endpoint`.
 
-Read the slice to find the PR reference.
+Read the issue to find the PR reference.
 
 Set the pre-fetch variables:
 
@@ -24,6 +24,15 @@ ISSUE_ID="{issue-id}" # pre-existing and passed or generate
 ./tracker.sh issue view "$ISSUE_ID" --json body,title,labels
 ```
 
+## Router
+
+After fetching the issue body, detect whether this is a **plan** or a **slice** by reading the frontmatter:
+
+- **Slice** (has `parent-plan:` in frontmatter): follow the **Slice-level rework** path below.
+- **Plan** (has `base branch:` and `type:` but no `parent-plan:`): follow the **Plan-level rework** path below.
+
+## Slice-level rework
+
 Set the post-fetch variables (after reading the slice body):
 
 ```sh
@@ -34,8 +43,6 @@ TARGET_BRANCH="{from slice/plan body}"
 PR_NUMBER="{from slice body}"
 WORKTREE_PATH=".worktrees/$SLICE_NAME-rework"
 ```
-
-## Process
 
 ### 1. Git prep
 
@@ -107,12 +114,119 @@ Document judgment calls made during this phase on the PR. Only document decision
 ./worktree-exit.sh --path "$WORKTREE_PATH"
 ```
 
-## Handoff
+### Slice-level handoff
 
 ```sh
 nextPhase="to-inspect"
 planPr="$PR_NUMBER"
 summary="Rework complete — addressed inspection feedback"
+```
+
+Report these three variables to the caller.
+
+## Plan-level rework
+
+Set the post-fetch variables (after reading the plan body):
+
+Determine the working branch based on plan type:
+- **Multi-slice** (has a dedicated target branch different from base branch): use `$TARGET_BRANCH`
+- **Single-slice** (target branch equals base branch): use the PR's head branch
+
+```sh
+PLAN_ID="$ISSUE_ID"
+PLAN_TITLE="{from plan body}"
+BASE_BRANCH="{from plan body}"
+TARGET_BRANCH="{from plan body}"
+PR_NUMBER="{from plan body or PR search}"
+WORKING_BRANCH="{TARGET_BRANCH for multi-slice, PR head branch for single-slice}"
+WORKTREE_PATH=".worktrees/$PLAN_ID-rework"
+```
+
+### 1. Git prep
+
+Enter a worktree forked from $WORKING_BRANCH to apply fixes to the existing PR:
+
+```sh
+WORKTREE_STATUS=$(./worktree-enter.sh --fork-from "$WORKING_BRANCH" --pull-latest "$BASE_BRANCH" --path "$WORKTREE_PATH")
+```
+
+Read the output. On `ready` or `synced`: continue. On `conflicts`: attempt to resolve the conflicts in the worktree. If resolved, commit the merge and push to `origin/$WORKING_BRANCH` using explicit refspec (no force), then continue. If unresolvable:
+
+```sh
+./tracker.sh issue edit "$PLAN_ID" --add-label blocked-with-conflicts
+```
+
+Stop — do not proceed.
+
+### 2. Read all feedback
+
+Read the gap report from the PR body (`<details><summary>` blocks written by ratify or reef-land). Read the full conversation — don't just skim.
+
+Also re-read:
+- The plan's success criteria (for broader context)
+- The gap classification from the ratify report (missing coverage, incomplete implementation, integration gap, planning gap)
+
+### 3. Fix
+
+Address every gap. For each gap in the report:
+
+- Fix it if you can
+- If a gap is unclear, make your best interpretation and note what you assumed
+- Do NOT skip any gap. If a gap requires changes across multiple files or slices, make all the changes needed
+
+### 4. Run the full test suite
+
+Not a subset. The full project test suite must be green.
+
+### 5. Push fixes
+
+```sh
+./commit.sh --branch "$WORKING_BRANCH" -m "rework: address review feedback"
+```
+
+### 6. Update the PR description
+
+Read the current PR body, then append the rework report as a collapsible block. The rework report should include what gaps were addressed, what was changed, and test results.
+
+```sh
+PR_BODY=$(gh pr view "$PR_NUMBER" --json body -q .body)
+REPORT="{rework-report}" # <details><summary><h3>🦀 Rework — {yyyy/MM/dd HH:mm}</h3></summary>{report-content}</details>
+PR_BODY="$PR_BODY\n\n$REPORT"
+gh pr edit "$PR_NUMBER" --body "$PR_BODY"
+```
+
+### 7. Document judgment calls
+
+Document judgment calls made during this phase on the PR. Only document decisions that deviate from the plan, resolve ambiguity, or would surprise the human — not routine implementation choices. If a decision is best explained next to the code it affects, write a code comment instead. If your context was compacted during this session, scan pre-compaction reference files for judgment calls made earlier.
+
+### 8. Tag
+
+Exit tag depends on plan type:
+
+**Single-slice** (re-enters slice lifecycle for verification):
+
+```sh
+./tracker.sh issue edit "$PLAN_ID" --remove-label to-rework --add-label to-inspect
+```
+
+**Multi-slice** (holistic re-check on target branch):
+
+```sh
+./tracker.sh issue edit "$PLAN_ID" --remove-label to-rework --add-label to-ratify
+```
+
+### 9. Clean up
+
+```sh
+./worktree-exit.sh --path "$WORKTREE_PATH"
+```
+
+### Plan-level handoff
+
+```sh
+nextPhase="to-inspect" # single-slice, or "to-ratify" for multi-slice
+planPr="$PR_NUMBER"
+summary="Rework complete — addressed review feedback"
 ```
 
 Report these three variables to the caller.


### PR DESCRIPTION
closes #84 077/001 ratify and rework: absorb rescan logic and add plan-level rework router

## Slice

#84

## Parent

#77

## Acceptance criteria

- [x] ratify.md includes a plan re-review step (re-read plan, classify gaps, update success criteria) between the holistic review and the verdict -- added as step 6 "Plan re-review" between integration checks (step 5) and documentation (step 7)
- [x] ratify.md tags `to-rework` (not `to-rescan`) when gaps are found -- changed step 9 tag section and handoff
- [x] ratify.md tags `to-scope` when gaps need decisions beyond success criteria (safety valve) -- added as separate tag path in step 9 with explanation in step 6
- [x] ORCHESTRATION.md ratify section shows `to-rework` in the fail tracker update -- changed `tracker-fail` line from `to-rescan` to `to-rework`
- [x] rework.md has a router that detects plan vs slice from `parent-plan:` in frontmatter -- added Router section after fetch context
- [x] rework.md plan-level path reads gap report from PR body and plan success criteria -- plan-level step 2 reads `<details><summary>` blocks and plan success criteria
- [x] rework.md plan-level path uses target branch for multi-slice, PR head branch for single-slice -- `WORKING_BRANCH` variable set based on plan type
- [x] rework.md plan-level path exits to `to-inspect` (single) or `to-ratify` (multi) -- branching tag section in plan-level step 8
- [x] ORCHESTRATION.md rework section shows plan-level variables and branching exit tags -- added conditional set-variables, enter-worktree, commit-code, and update-tracker entries for plan path
- [x] `orchestration.test.sh` passes after each commit -- 237 passed, 0 failed

## Ambiguous choices

None -- implementation followed the plan exactly.

## Test results

237 tests passed, 0 failed, 0 skipped.

### 🪼 Pulse metrics

| Phase | Target | Duration | Tokens | Tool uses | Outcome | Date |
| --- | --- | --- | --- | --- | --- | --- |
| implement | #84 | 5m 49s | 67 224 | 61 | ✅ PR created | 2026-04-21 09:16 |

<details><summary><h3>🧿 Inspect review — 2026/04/21 09:30</h3></summary>

## Verification

### Acceptance criteria

- ✓ ratify.md includes plan re-review step (step 6) between integration checks (step 5) and documentation (step 7) — re-reads plan, classifies gaps into 4 categories, updates success criteria
- ✓ ratify.md tags `to-rework` (not `to-rescan`) when gaps found — step 9, confirmed
- ✓ ratify.md tags `to-scope` when gaps need decisions beyond success criteria — safety valve path in step 9, confirmed
- ✓ ORCHESTRATION.md ratify section shows `to-rework` in fail tracker update — `--add-label to-rework` confirmed
- ✓ rework.md router detects plan vs slice from `parent-plan:` in frontmatter — Router section present after fetch context
- ✓ rework.md plan-level path reads gap report from PR body (`<details><summary>` blocks) and plan success criteria — plan-level step 2
- ✓ rework.md plan-level path uses target branch for multi-slice, PR head branch for single-slice — `WORKING_BRANCH` variable
- ✓ rework.md plan-level path exits `to-inspect` (single) or `to-ratify` (multi) — plan-level step 8
- ✓ ORCHESTRATION.md rework section shows plan-level variables and branching exit tags — conditional set-variables, enter-worktree, commit-code, update-tracker entries
- ✓ Tests pass: 296 total (237 + 37 + 22), 0 failures

### Drift from plan

None — implementation followed the plan exactly as stated in the PR description. No ambiguous choices were needed.

### Code quality

No debug prints, stale TODOs, or dead code found. No cleanup needed.

### Test results

296 tests passed, 0 failed, 0 skipped.

</details>
| inspect | #84 | 2m 44s | 32 924 | 30 | ✅ passed | 2026-04-21 09:25 |