### PR TITLE
001 Lock guard for pulse

### DIFF
--- a/ORCHESTRATION.md
+++ b/ORCHESTRATION.md
@@ -33,7 +33,12 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
   ```sh
   SKILL_DIR="{base directory for this skill}"
   TRACKER_BRANCH="{from config.md}" # e.g. main
+  LOCK_FILE=".agents/moonjelly-reef/pulse.lock"
   ```
+- acquire-lock
+  - contains: `pulse.lock`
+  - contains: `start timestamp`
+  - contains: `override`
 - checkout-tracker-branch — if local-tracker-committed
   ```sh
   git fetch origin "$TRACKER_BRANCH" && git checkout "$TRACKER_BRANCH" && git pull
@@ -58,6 +63,9 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
   ```sh
   gh pr edit "$PLAN_PR_NUMBER" --body "$PLAN_PR_BODY"
   ```
+- release-lock
+  - contains: `pulse.lock`
+  - contains: `delete`
 
 ### [/reef-scope](./reef-scope/SKILL.md)
 

--- a/reef-pulse/SKILL.md
+++ b/reef-pulse/SKILL.md
@@ -19,13 +19,23 @@ Capture the skill base directory (provided by the harness as "Base directory for
 SKILL_DIR="{base directory for this skill}"
 ```
 
-## 0. Sync tracker branch (local-tracker-committed only)
+## 0a. Acquire lock
 
-If the tracker type in config is `local-tracker-committed`, the tracker files live in a git-tracked directory on a specific branch. Sync it before scanning:
+Before doing anything else, check for an existing pulse.lock file.
 
 ```sh
 TRACKER_BRANCH="{from config.md}" # e.g. main
+LOCK_FILE=".agents/moonjelly-reef/pulse.lock"
 ```
+
+If the pulse.lock file exists, another pulse may already be running (or a previous session crashed without cleaning up).
+
+- If `pulse.lock` exists, read the start timestamp from it, calculate how long the existing pulse has been running, and report this to the user: "A pulse has been running for {elapsed}. This may be from a crashed session. Override?" In AFK mode, override automatically (the lock is stale if we're in a cron). In HITL mode, ask the user.
+- If `pulse.lock` does not exist (or the user chose to override), create it with a start timestamp (ISO 8601 UTC) and continue.
+
+## 0b. Sync tracker branch (local-tracker-committed only)
+
+If the tracker type in config is `local-tracker-committed`, the tracker files live in a git-tracked directory on a specific branch. Sync it before scanning. `TRACKER_BRANCH` was already set in the previous step.
 
 ```sh
 git fetch origin "$TRACKER_BRANCH" && git checkout "$TRACKER_BRANCH" && git pull
@@ -186,6 +196,10 @@ Check if a durable cron for `/reef-pulse --afk` already exists by calling `CronL
   💡 Run this on autopilot:
      CronCreate cron="7 * * * *" prompt="/reef-pulse --afk" durable=true
 ```
+
+### Step 6. Release lock
+
+On final exit (nothing left to dispatch), delete the pulse.lock file. The lock must only be released when the pulse is truly done — not between iterations (future: the self-perpetuating loop will keep the lock across iterations).
 
 Exit.
 


### PR DESCRIPTION
closes #98 001 Lock guard for pulse

## Slice

#98

## Parent

#45

## Acceptance criteria

- [x] Pulse creates `.agents/moonjelly-reef/pulse.lock` containing a start timestamp on startup — ORCHESTRATION.md declares `acquire-lock` with `contains: pulse.lock` and `contains: start timestamp`; SKILL.md section 0a describes creating the file with ISO 8601 UTC timestamp
- [x] Pulse deletes the lockfile on final exit (nothing to dispatch) — ORCHESTRATION.md declares `release-lock` with `contains: pulse.lock` and `contains: delete`; SKILL.md Step 6 describes deleting pulse.lock on final exit
- [x] A second pulse invocation detects the existing lock, reports elapsed time, and offers to override — ORCHESTRATION.md declares `acquire-lock` with `contains: override`; SKILL.md section 0a describes detecting existing lock, reporting elapsed time, and offering override (auto-override in AFK mode)
- [x] ORCHESTRATION.md is updated with the lock acquire/release/detect operations before SKILL.md changes — ORCHESTRATION.md was updated first (RED), then SKILL.md was made to conform (GREEN)

## Ambiguous choices

- **AFK mode auto-override**: chose to auto-override stale locks in AFK mode because a cron-triggered pulse should self-recover from crashed sessions without human intervention. This aligns with the plan's design intent ("On start: if lock exists, report how long it's been running and ask") while adapting for the unattended case.
- **TRACKER_BRANCH placement**: moved `TRACKER_BRANCH` from the sync section to the acquire-lock section's set-variables block. Both variables are needed early and this satisfies the test runner's ordering constraints. The sync step references `TRACKER_BRANCH` but no longer declares it.

## Test results

280 tests passed, 0 failed, 0 skipped (221 orchestration + 37 tracker + 22 worktree).

### 🪼 Pulse metrics

| Phase | Target | Duration | Tokens | Tool uses | Outcome | Date |
| --- | --- | --- | --- | --- | --- | --- |
| implement | #98 | 3m 53s | 63 603 | 43 | ✅ PR #101 created | 2026-04-21 16:21 |
| inspect | #98 | 2m 0s | 31 415 | 19 | ✅ passed | 2026-04-21 17:02 |


<details><summary><h3>🧿 Inspect review — 2026/04/21 17:00</h3></summary>

### Acceptance criteria

| # | Criterion | Verdict |
| - | --------- | ------- |
| 1 | Pulse creates `.agents/moonjelly-reef/pulse.lock` containing a start timestamp on startup | PASS — ORCHESTRATION.md declares `acquire-lock` with `contains: pulse.lock` and `contains: start timestamp`; SKILL.md 0a creates lockfile with ISO 8601 UTC |
| 2 | Pulse deletes the lockfile on final exit | PASS — ORCHESTRATION.md declares `release-lock` with `contains: pulse.lock` and `contains: delete`; SKILL.md Step 6 describes deletion on final exit |
| 3 | Second invocation detects existing lock, reports elapsed time, offers override | PASS — SKILL.md 0a reads timestamp, calculates elapsed, prompts user (auto-override in AFK mode); ORCHESTRATION.md `acquire-lock` has `contains: override` |
| 4 | ORCHESTRATION.md updated before SKILL.md | PASS — ORCHESTRATION.md serves as test oracle; 221 orchestration tests validate SKILL.md conforms to it |

### Ambiguous choices review

- **AFK auto-override**: Appropriate. Cron-triggered pulses must self-recover from stale locks.
- **TRACKER_BRANCH placement**: Clean. Both `TRACKER_BRANCH` and `LOCK_FILE` are needed before any work begins; grouping them in the first set-variables block satisfies test ordering and is logically correct.

### Test results

280 tests passed, 0 failed, 0 skipped (221 orchestration + 37 tracker + 22 worktree).

### Cleanups

None needed — no debug artifacts, stale TODOs, or formatting issues found.

### Verdict

**PASS** — All acceptance criteria met, test suite green, no gaps.

</details>
