### PR TITLE
002 Self-perpetuating pulse loop

### DIFF
--- a/ORCHESTRATION.md
+++ b/ORCHESTRATION.md
@@ -47,6 +47,10 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
   - contains: `$SKILL_DIR/{file}`
 - set-variables
   ```sh
+  AUTOMATED_DISPATCHES="{count of automated phases dispatched this iteration}"
+  ```
+- set-variables
+  ```sh
   ISSUE_ID="{from dispatched items}"
   ISSUE_BODY="{current issue body with metrics rows inserted into the table}"
   ```
@@ -63,7 +67,15 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
   ```sh
   gh pr edit "$PLAN_PR_NUMBER" --body "$PLAN_PR_BODY"
   ```
-- release-lock
+- present-human-items — if HITL mode and first iteration
+  - contains: `to-scope`
+  - contains: `to-land`
+  - contains: `first iteration`
+- recurse — if AUTOMATED_DISPATCHES > 0
+  - contains: `/reef-pulse --afk`
+  - contains: `main session`
+  - contains: `never as a sub-agent`
+- release-lock — if AUTOMATED_DISPATCHES == 0
   - contains: `pulse.lock`
   - contains: `delete`
 

--- a/reef-pulse/SKILL.md
+++ b/reef-pulse/SKILL.md
@@ -89,6 +89,12 @@ For each item, spawn a sub-agent with: `"Read and follow $SKILL_DIR/{file}. Targ
 | `to-merge`       | `$SKILL_DIR/merge.md`       |
 | `to-ratify`      | `$SKILL_DIR/ratify.md`      |
 
+After dispatching, record the count of automated phases dispatched this iteration:
+
+```sh
+AUTOMATED_DISPATCHES="{count of automated phases dispatched this iteration}"
+```
+
 ### Step 3. Log phase metrics
 
 After all dispatched agents complete, collect from each: task notification metadata (duration, tokens, tool uses) and the structured handoff variables (`nextPhase`, `planPr`, `summary`). Group results by plan.
@@ -146,11 +152,13 @@ Example:
 | **Total** | | **5m 30s** | **62 359** | **87** | | | |
 ```
 
-### Step 4. Present human (🤿) items (--hitl only)
+### Step 4. Present human (🤿) items (first iteration only)
 
-If running in `--afk` mode, skip this step entirely.
+Skip this step if running in `--afk` mode or if this is a recursive iteration (not the first iteration).
 
-If running in `--hitl` mode, present human-required items immediately without waiting for dispatched agents to complete. Automated agents run in the background — metrics collection (Step 3) happens after agents complete but must not block the human workflow. Present human items as soon as dispatch is done:
+Human items (`to-scope`, `to-land`) are presented only in the first iteration of the pulse, not in recursive AFK calls. This ensures that HITL items are shown once to the user and not repeated as the pulse recurses through automated work.
+
+If running in `--hitl` mode and this is the first iteration, present human-required items immediately without waiting for dispatched agents to complete. Automated agents run in the background — metrics collection (Step 3) happens after agents complete but must not block the human workflow. Present human items as soon as dispatch is done:
 
 | Tag        | Skill         | Presentation                                                              |
 | ---------- | ------------- | ------------------------------------------------------------------------- |
@@ -197,9 +205,17 @@ Check if a durable cron for `/reef-pulse --afk` already exists by calling `CronL
      CronCreate cron="7 * * * *" prompt="/reef-pulse --afk" durable=true
 ```
 
-### Step 6. Release lock
+### Step 6. Recurse or exit
 
-On final exit (nothing left to dispatch), delete the pulse.lock file. The lock must only be released when the pulse is truly done — not between iterations (future: the self-perpetuating loop will keep the lock across iterations).
+After reporting, check whether to recurse or exit.
+
+**If `AUTOMATED_DISPATCHES` > 0**: the pulse dispatched automated work this iteration. After agents return and metrics are logged, recursively invoke `/reef-pulse --afk` on the main session. The recursive call is always `--afk`, even if the first invocation was HITL. The recursive call happens on the main session, never as a sub-agent — this ensures the loop runs sequentially (scan, dispatch, wait, scan again) rather than spawning nested agents. Do NOT release the lock between iterations; the lock persists across the entire recursive chain.
+
+**If `AUTOMATED_DISPATCHES` == 0**: no automated work was dispatched this iteration. The pulse has nothing left to do. Delete the pulse.lock file and exit. The lock must only be released when the pulse is truly done — zero automated dispatches means the loop naturally terminates.
+
+### Step 7. Release lock
+
+This step only runs when `AUTOMATED_DISPATCHES` == 0 (the exit path from Step 6). To release the lock, delete the pulse.lock file.
 
 Exit.
 


### PR DESCRIPTION
closes #99 002 Self-perpetuating pulse loop

## Slice

#99

## Parent

#45

## Acceptance criteria

- [x] After agents return and metrics are logged, pulse recursively calls `/reef-pulse --afk` if any automated work was dispatched this iteration — Step 6 in SKILL.md instructs the pulse to invoke `/reef-pulse --afk` on the main session when `AUTOMATED_DISPATCHES` > 0
- [x] Pulse exits and releases its lock when no automated phases are found to dispatch (zero automated dispatches this iteration) — Step 6/7 in SKILL.md: when `AUTOMATED_DISPATCHES` == 0, the lock is deleted and the pulse exits
- [x] HITL human items (`to-scope`, `to-land`) are presented only in the first iteration, not in recursive AFK calls — Step 4 in SKILL.md now skips if in `--afk` mode or if this is a recursive iteration
- [x] Recursive call happens on the main session, never as a sub-agent — Step 6 explicitly states "on the main session, never as a sub-agent"
- [x] ORCHESTRATION.md is updated with the loop/recursion operations before SKILL.md changes — ORCHESTRATION.md was updated first (RED), then SKILL.md was updated to match (GREEN)

## Ambiguous choices

None — implementation followed the plan exactly.

## Test results

287 tests passed, 0 failed, 0 skipped (228 orchestration + 37 tracker + 22 worktree).

### 🪼 Pulse metrics

| Phase | Target | Duration | Tokens | Tool uses | Outcome | Date |
| --- | --- | --- | --- | --- | --- | --- |
| implement | #99 | 4m 33s | 62 879 | 45 | ✅ PR #103 created | 2026-04-21 17:30 |
| inspect | #99 | 2m 4s | 33 869 | 21 | ✅ passed | 2026-04-21 17:35 |
<!-- end-metrics -->

<details><summary><h3>🧿 Inspect review — 2026/04/21 18:15</h3></summary>

## Verification

**Test suite**: 287 passed (228 orchestration + 37 tracker + 22 worktree), 0 failed.

### Acceptance criteria

| # | Criterion | Verdict | Evidence |
|---|-----------|---------|----------|
| 1 | Recursive `/reef-pulse --afk` after automated dispatches | PASS | SKILL.md Step 6: recurse when `AUTOMATED_DISPATCHES` > 0; ORCHESTRATION.md `recurse` op contains `/reef-pulse --afk` |
| 2 | Exit and release lock on zero automated dispatches | PASS | SKILL.md Step 6/7: delete pulse.lock when `AUTOMATED_DISPATCHES` == 0; ORCHESTRATION.md `release-lock` conditioned on == 0 |
| 3 | HITL items only in first iteration | PASS | SKILL.md Step 4: skip if `--afk` or recursive iteration; ORCHESTRATION.md `present-human-items` conditioned on first iteration |
| 4 | Recursive call on main session, never sub-agent | PASS | SKILL.md Step 6 explicit statement; ORCHESTRATION.md `recurse` contains `never as a sub-agent` |
| 5 | ORCHESTRATION.md updated before SKILL.md | PASS | Both files updated consistently; ORCHESTRATION.md is the test oracle |


### Drift from plan

None detected. Implementation follows the slice description exactly.

### Ambiguous choices

None documented by implementer. None observed during review.

### Cleanups applied

None needed — implementation is clean.

### Gaps

None found.

</details>
