### PR TITLE
003 Playful field notes console log

### DIFF
--- a/ORCHESTRATION.md
+++ b/ORCHESTRATION.md
@@ -43,12 +43,38 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
   ```sh
   git fetch origin "$TRACKER_BRANCH" && git checkout "$TRACKER_BRANCH" && git pull
   ```
+- print-session-header — if first iteration
+  - contains: `MOONJELLY REEF`
+  - contains: `SESSION LOG`
+- print-pulse-header
+  - contains: `PULSE`
+  - contains: `timestamp`
 - phase-specific
   - contains: `$SKILL_DIR/{file}`
+- print-dispatched-agents
+  - contains: `phase emoji`
+  - contains: `𐃆🐋`
+  - contains: `to-slice`
+  - contains: `to-implement`
+  - contains: `to-inspect`
+  - contains: `to-rework`
+  - contains: `to-merge`
+  - contains: `to-ratify`
+  - contains: `to-await-waves`
 - set-variables
   ```sh
   AUTOMATED_DISPATCHES="{count of automated phases dispatched this iteration}"
   ```
+- print-lore-snippet
+  - contains: `lore snippet`
+  - contains: `elapsed time`
+  - contains: `prior snippets`
+  - contains: `continues the narrative`
+  - contains: `Ghibli ocean vibes`
+- print-return-results
+  - contains: `phase emoji`
+  - contains: `›`
+  - contains: `𐃆🐋`
 - set-variables
   ```sh
   ISSUE_ID="{from dispatched items}"
@@ -75,6 +101,16 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
   - contains: `/reef-pulse --afk`
   - contains: `main session`
   - contains: `never as a sub-agent`
+- print-session-complete — if AUTOMATED_DISPATCHES == 0
+  - contains: `SESSION COMPLETE`
+  - contains: `Duration`
+  - contains: `Pulses`
+  - contains: `Agents`
+  - contains: `Landed`
+  - contains: `Human`
+  - contains: `Idle`
+- print-full-story — if AUTOMATED_DISPATCHES == 0
+  - contains: `full collected story`
 - release-lock — if AUTOMATED_DISPATCHES == 0
   - contains: `pulse.lock`
   - contains: `delete`

--- a/reef-pulse/SKILL.md
+++ b/reef-pulse/SKILL.md
@@ -52,6 +52,26 @@ Detect the mode from how this skill was invoked:
 
 ## The pulse
 
+### Step 0c. Print session header (first iteration only)
+
+If this is the first iteration of the pulse (not a recursive call), print the session header:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  🪼  MOONJELLY REEF  ·  SESSION LOG                         │
+└─────────────────────────────────────────────────────────────┘
+```
+
+Initialize an empty lore story list to collect lore snippets across the session. Initialize the pulse counter to 0.
+
+### Step 0d. Print pulse header
+
+At the start of each pulse iteration (including recursive calls), increment the pulse counter and print the pulse header with the current timestamp:
+
+```
+── PULSE {N} ──────────────────────────────────────── {HH:MM:SS} ──
+```
+
 ### Step 1. Scan
 
 Read the config to determine the tracker type, then scan for all tagged issues.
@@ -89,10 +109,66 @@ For each item, spawn a sub-agent with: `"Read and follow $SKILL_DIR/{file}. Targ
 | `to-merge`       | `$SKILL_DIR/merge.md`       |
 | `to-ratify`      | `$SKILL_DIR/ratify.md`      |
 
+### Step 2b. Print dispatched agents
+
+Immediately after dispatching, print each dispatched agent with its phase emoji. Use the phase emoji from the README lore for each phase:
+
+| Tag              | Phase emoji |
+| ---------------- | ----------- |
+| `to-slice`       | `𐃆🐋`       |
+| `to-await-waves` | `🪸`        |
+| `to-implement`   | `🐙`        |
+| `to-inspect`     | `🧿`        |
+| `to-rework`      | `🦀`        |
+| `to-merge`       | `🐢`        |
+| `to-ratify`      | `🦭`        |
+
+The narwhal (slice phase) always uses both characters `𐃆🐋`, not just the emoji.
+
+```
+  𐃆🐋  #34  "auth token rotation"
+  🐙  #55  "user profile endpoint"
+  🧿  #53  "db migration safety"
+```
+
 After dispatching, record the count of automated phases dispatched this iteration:
 
 ```sh
 AUTOMATED_DISPATCHES="{count of automated phases dispatched this iteration}"
+```
+
+### Step 2c. Print lore snippet
+
+After all dispatched agents return, generate a lore snippet. This is a 1-2 sentence story fragment in playful Ghibli ocean vibes. Each lore snippet must read all prior snippets from the session and continues the narrative — the lore forms a continuous story, not isolated fragments. The story should be influenced by what actually happened in the pulse results (e.g., reworks are setbacks, successful inspects are triumphs, long waits are boring). Print it with the elapsed time since dispatch:
+
+```
+╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌
+  +8m00s  "The moonjelly sent three creatures into the dark and
+           waited, humming to itself."
+╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌
+```
+
+Append the lore snippet to the session's lore story list.
+
+### Step 2d. Print return results
+
+After agents return, print each result with its phase emoji and a `›` transition arrow showing the phase transition:
+
+```
+  𐃆🐋  #34   3m12s   18k   slice › implement
+  🐙  #55   4m45s   24k   implement › inspect
+  🦀  #53   1m08s    9k   inspect › rework
+```
+
+The narwhal (slice phase) always uses both characters `𐃆🐋`. Each line shows: phase emoji, issue number, duration, token count, and the transition (previous tag `›` next tag from handoff).
+
+Also print human and idle items:
+
+```
+  🤿  #60  to-scope
+  🤿  #48  to-land
+  ·   #57  idle — awaiting #55
+  ·   #56  idle
 ```
 
 ### Step 3. Log phase metrics
@@ -169,33 +245,52 @@ If running in `--hitl` mode and this is the first iteration, present human-requi
 
 > Note: reef-scope and reef-land remain user-facing skills invoked via slash commands. Only the automated (🌊) phases are dispatched via file references.
 
-### Step 5. Report and exit
+### Step 5. Recurse or exit
 
-Print a summary of what was dispatched:
+After metrics are logged, check whether to recurse or exit.
 
-```
-🪼 Pulse complete.
+**If `AUTOMATED_DISPATCHES` > 0**: the pulse dispatched automated work this iteration. After agents return and metrics are logged, recursively invoke `/reef-pulse --afk` on the main session. The recursive call is always `--afk`, even if the first invocation was HITL. The recursive call happens on the main session, never as a sub-agent — this ensures the loop runs sequentially (scan, dispatch, wait, scan again) rather than spawning nested agents. Do NOT release the lock between iterations; the lock persists across the entire recursive chain. Pass the accumulated lore story list and pulse counter to the next iteration.
 
-  Dispatched:
-    🌊 implement.md #55 (auth-endpoint)
-    🌊 implement.md #56 (user-profile)
-    🌊 inspect.md #53 (db-migration)
-    🌊 merge.md #51 (schema-setup)
+**If `AUTOMATED_DISPATCHES` == 0**: no automated work was dispatched this iteration. The pulse has nothing left to do. Continue to Step 6.
 
-  Awaiting human:
-    🤿 to-scope: #60 (new-dashboard-idea)
-    🤿 to-land: #42 (token-auth-migration)
+### Step 6. Print SESSION COMPLETE and full story
 
-  Idle:
-    ⏳ to-await-waves: #57 (legacy-compat) — blocked by #55, #56
-```
+This step only runs when `AUTOMATED_DISPATCHES` == 0 (the exit path from Step 5).
 
-If nothing was actionable:
+First, generate a final lore snippet for the empty pulse (the moonjelly finding nothing left to do). Append it to the lore story list.
+
+Then print the SESSION COMPLETE box with session stats:
 
 ```
-🪼 Pulse complete. Nothing to dispatch.
+┌─────────────────────────────────────────────────────────────┐
+│  SESSION COMPLETE                                            │
+│                                                              │
+│  Duration    17m00s                                          │
+│  Pulses      4                                               │
+│  Agents      7  dispatches across 3 active pulses            │
+│  Landed      #34  #53                                        │
+│  Human       #60  #48                                        │
+│  Idle        #56  #57                                        │
+└─────────────────────────────────────────────────────────────┘
+```
 
-  Run /reef-scope to start something new.
+- **Duration**: total wall-clock time since the session started (from the lock file timestamp)
+- **Pulses**: total number of pulse iterations (including this final empty one)
+- **Agents**: total number of sub-agent dispatches across all active pulses (pulses that dispatched at least one agent)
+- **Landed**: issues that reached `to-land` or `landed` during this session
+- **Human**: issues that need human attention (`to-scope`, `to-land`)
+- **Idle**: issues that are blocked or have no actionable tag
+
+After the SESSION COMPLETE box, print the full collected story as a single block — all lore snippets from the session concatenated into a continuous narrative:
+
+```
+  The moonjelly sent three creatures into the dark and waited,
+  humming to itself. The crab came back sulking — it had dropped
+  a stitch and needed another pass. The octopus just kept working.
+  The barreleye peered through both pieces with its strange glass
+  eyes and — for once — found nothing wrong. The moonjelly found
+  nothing left to chase. It settled onto the reef floor, bells
+  dimming, and listened to the quiet.
 ```
 
 **Autopilot hint** (show only when pulse was triggered manually, not from a cron):
@@ -207,17 +302,9 @@ Check if a durable cron for `/reef-pulse --afk` already exists by calling `CronL
      CronCreate cron="7 * * * *" prompt="/reef-pulse --afk" durable=true
 ```
 
-### Step 6. Recurse or exit
-
-After reporting, check whether to recurse or exit.
-
-**If `AUTOMATED_DISPATCHES` > 0**: the pulse dispatched automated work this iteration. After agents return and metrics are logged, recursively invoke `/reef-pulse --afk` on the main session. The recursive call is always `--afk`, even if the first invocation was HITL. The recursive call happens on the main session, never as a sub-agent — this ensures the loop runs sequentially (scan, dispatch, wait, scan again) rather than spawning nested agents. Do NOT release the lock between iterations; the lock persists across the entire recursive chain.
-
-**If `AUTOMATED_DISPATCHES` == 0**: no automated work was dispatched this iteration. The pulse has nothing left to do. Delete the pulse.lock file and exit. The lock must only be released when the pulse is truly done — zero automated dispatches means the loop naturally terminates.
-
 ### Step 7. Release lock
 
-This step only runs when `AUTOMATED_DISPATCHES` == 0 (the exit path from Step 6). To release the lock, delete the pulse.lock file.
+This step only runs when `AUTOMATED_DISPATCHES` == 0 (the exit path from Step 5). To release the lock, delete the pulse.lock file.
 
 Exit.
 


### PR DESCRIPTION
closes #100 003 Playful field notes console log

## Slice

#100

## Parent

#45

## Acceptance criteria

- [x] Each pulse prints the field notes log format: pulse header with timestamp, dispatched agents with phase emoji, lore snippet with elapsed time, return results with `›` transitions — Added Steps 0c, 0d, 2b, 2c, 2d to SKILL.md with exact format from the plan's console log spec
- [x] The narwhal (slice phase) always uses both characters `𐃆🐋`, not just the emoji — Explicitly stated in Step 2b and 2d, used in all examples and the phase emoji table
- [x] Lore snippets form a continuous story — each reads prior snippets and continues the narrative, influenced by actual pulse outcomes — Step 2c requires reading all prior snippets, continuing the narrative with Ghibli ocean vibes, influenced by actual results
- [x] On final exit, the SESSION COMPLETE box is printed with session stats, followed by the full collected story as a single block — Step 6 prints the SESSION COMPLETE box with Duration/Pulses/Agents/Landed/Human/Idle stats, followed by the full collected story
- [x] ORCHESTRATION.md is updated with the console log operations before SKILL.md changes — ORCHESTRATION.md was updated first (RED), then SKILL.md was updated to pass (GREEN)

## Ambiguous choices

- **Step numbering**: Steps 0c and 0d were chosen for the session header and pulse header to place them after lock acquisition (0a) and tracker sync (0b) but before scanning (Step 1). Steps 2b, 2c, 2d were chosen for the console log steps within the dispatch flow to keep them adjacent to Step 2 (dispatch). This preserves the existing step numbers for metrics (Step 3), human items (Step 4), and recurse/exit logic.
- **Old Step 5 (report summary) removed**: The old plain-text summary (Step 5 "Report and exit") was replaced by the field notes console log format. The dispatched/human/idle information is now printed in Steps 2b and 2d, and the session summary is printed in the SESSION COMPLETE box (Step 6). The autopilot hint was preserved in Step 6.
- **Lore story list passing**: The recursive call in Step 5 explicitly passes the accumulated lore story list and pulse counter to the next iteration, since the pulse is stateless by design but the story must persist across the session.

## Test results

257 tests passed, 0 failed, 0 skipped.

### 🪼 Pulse metrics

| Phase | Target | Duration | Tokens | Tool uses | Outcome | Date |
| --- | --- | --- | --- | --- | --- | --- |
| implement | #100 | 4m 56s | 78 670 | 52 | ✅ PR #104 created | 2026-04-21 18:10 |
| inspect | #100 | 2m 57s | 42 252 | 30 | ✅ passed | 2026-04-21 18:20 |

<details><summary><h3>🧿 Inspect review — 2026/04/21 17:05</h3></summary>

## Verdict: PASS

All 5 acceptance criteria verified by reading the code and running the full test suite.

### Test suite

316 tests passed (257 orchestration + 37 tracker + 22 worktree), 0 failed.

### Acceptance criteria verification

1. **Field notes log format** — Steps 0c, 0d, 2b, 2c, 2d added to SKILL.md with exact formats (session header, pulse header, dispatched agents, lore snippet, return results). ORCHESTRATION.md entries match with correct `contains` strings.
2. **Narwhal uses both characters** — `𐃆🐋` explicitly stated in Steps 2b and 2d, present in all examples and the phase emoji table. ORCHESTRATION.md `print-dispatched-agents` and `print-return-results` both require `𐃆🐋`.
3. **Continuous lore story** — Step 2c requires reading all prior snippets and continuing the narrative. ORCHESTRATION.md `print-lore-snippet` contains `prior snippets`, `continues the narrative`, `Ghibli ocean vibes`.
4. **SESSION COMPLETE box + full story** — Step 6 prints SESSION COMPLETE box with Duration/Pulses/Agents/Landed/Human/Idle, followed by full collected story. ORCHESTRATION.md has both `print-session-complete` and `print-full-story` entries.
5. **ORCHESTRATION.md updated before SKILL.md** — Single commit, but the test suite uses ORCHESTRATION.md as the oracle, structurally enforcing this relationship.

### Ambiguous choices review

- **Step numbering (0c, 0d, 2b-2d)**: Sensible. Preserves existing step numbers while placing new operations at logical points in the flow.
- **Old Step 5 removed**: The old plain-text summary is fully replaced by the field notes format distributed across Steps 2b-2d and the SESSION COMPLETE box in Step 6. No information lost.
- **Lore story list passing**: Step 5 explicitly passes accumulated lore and pulse counter to recursive calls. This is the right approach given the stateless design.

### Drift

The Step 5/6 swap (recurse moved to 5, SESSION COMPLETE to 6) is a structural improvement — SESSION COMPLETE only matters on exit, so it belongs after the recurse decision. No problematic drift.

No cleanups needed. No gaps found.

</details>
