### PR TITLE
Self-perpetuating pulse loop with lock guard

### DIFF
--- a/ORCHESTRATION.md
+++ b/ORCHESTRATION.md
@@ -47,6 +47,10 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
   - contains: `$SKILL_DIR/{file}`
 - set-variables
   ```sh
+  AUTOMATED_DISPATCHES="{count of automated phases dispatched this iteration}"
+  ```
+- set-variables
+  ```sh
   ISSUE_ID="{from dispatched items}"
   ISSUE_BODY="{current issue body with metrics rows inserted into the table}"
   ```
@@ -63,7 +67,15 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
   ```sh
   gh pr edit "$PLAN_PR_NUMBER" --body "$PLAN_PR_BODY"
   ```
-- release-lock
+- present-human-items — if HITL mode and first iteration
+  - contains: `to-scope`
+  - contains: `to-land`
+  - contains: `first iteration`
+- recurse — if AUTOMATED_DISPATCHES > 0
+  - contains: `/reef-pulse --afk`
+  - contains: `main session`
+  - contains: `never as a sub-agent`
+- release-lock — if AUTOMATED_DISPATCHES == 0
   - contains: `pulse.lock`
   - contains: `delete`
 

--- a/ORCHESTRATION.md
+++ b/ORCHESTRATION.md
@@ -33,7 +33,12 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
   ```sh
   SKILL_DIR="{base directory for this skill}"
   TRACKER_BRANCH="{from config.md}" # e.g. main
+  LOCK_FILE=".agents/moonjelly-reef/pulse.lock"
   ```
+- acquire-lock
+  - contains: `pulse.lock`
+  - contains: `start timestamp`
+  - contains: `override`
 - checkout-tracker-branch — if local-tracker-committed
   ```sh
   git fetch origin "$TRACKER_BRANCH" && git checkout "$TRACKER_BRANCH" && git pull
@@ -58,6 +63,9 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
   ```sh
   gh pr edit "$PLAN_PR_NUMBER" --body "$PLAN_PR_BODY"
   ```
+- release-lock
+  - contains: `pulse.lock`
+  - contains: `delete`
 
 ### [/reef-scope](./reef-scope/SKILL.md)
 

--- a/ORCHESTRATION.md
+++ b/ORCHESTRATION.md
@@ -43,12 +43,38 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
   ```sh
   git fetch origin "$TRACKER_BRANCH" && git checkout "$TRACKER_BRANCH" && git pull
   ```
+- print-session-header — if first iteration
+  - contains: `MOONJELLY REEF`
+  - contains: `SESSION LOG`
+- print-pulse-header
+  - contains: `PULSE`
+  - contains: `timestamp`
 - phase-specific
   - contains: `$SKILL_DIR/{file}`
+- print-dispatched-agents
+  - contains: `phase emoji`
+  - contains: `𐃆🐋`
+  - contains: `to-slice`
+  - contains: `to-implement`
+  - contains: `to-inspect`
+  - contains: `to-rework`
+  - contains: `to-merge`
+  - contains: `to-ratify`
+  - contains: `to-await-waves`
 - set-variables
   ```sh
   AUTOMATED_DISPATCHES="{count of automated phases dispatched this iteration}"
   ```
+- print-lore-snippet
+  - contains: `lore snippet`
+  - contains: `elapsed time`
+  - contains: `prior snippets`
+  - contains: `continues the narrative`
+  - contains: `Ghibli ocean vibes`
+- print-return-results
+  - contains: `phase emoji`
+  - contains: `›`
+  - contains: `𐃆🐋`
 - set-variables
   ```sh
   ISSUE_ID="{from dispatched items}"
@@ -75,6 +101,16 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
   - contains: `/reef-pulse --afk`
   - contains: `main session`
   - contains: `never as a sub-agent`
+- print-session-complete — if AUTOMATED_DISPATCHES == 0
+  - contains: `SESSION COMPLETE`
+  - contains: `Duration`
+  - contains: `Pulses`
+  - contains: `Agents`
+  - contains: `Landed`
+  - contains: `Human`
+  - contains: `Idle`
+- print-full-story — if AUTOMATED_DISPATCHES == 0
+  - contains: `full collected story`
 - release-lock — if AUTOMATED_DISPATCHES == 0
   - contains: `pulse.lock`
   - contains: `delete`

--- a/reef-pulse/SKILL.md
+++ b/reef-pulse/SKILL.md
@@ -52,6 +52,26 @@ Detect the mode from how this skill was invoked:
 
 ## The pulse
 
+### Step 0c. Print session header (first iteration only)
+
+If this is the first iteration of the pulse (not a recursive call), print the session header:
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│  🪼  MOONJELLY REEF  ·  SESSION LOG                         │
+└─────────────────────────────────────────────────────────────┘
+```
+
+Initialize an empty lore story list to collect lore snippets across the session. Initialize the pulse counter to 0.
+
+### Step 0d. Print pulse header
+
+At the start of each pulse iteration (including recursive calls), increment the pulse counter and print the pulse header with the current timestamp:
+
+```
+── PULSE {N} ──────────────────────────────────────── {HH:MM:SS} ──
+```
+
 ### Step 1. Scan
 
 Read the config to determine the tracker type, then scan for all tagged issues.
@@ -89,10 +109,66 @@ For each item, spawn a sub-agent with: `"Read and follow $SKILL_DIR/{file}. Targ
 | `to-merge`       | `$SKILL_DIR/merge.md`       |
 | `to-ratify`      | `$SKILL_DIR/ratify.md`      |
 
+### Step 2b. Print dispatched agents
+
+Immediately after dispatching, print each dispatched agent with its phase emoji. Use the phase emoji from the README lore for each phase:
+
+| Tag              | Phase emoji |
+| ---------------- | ----------- |
+| `to-slice`       | `𐃆🐋`       |
+| `to-await-waves` | `🪸`        |
+| `to-implement`   | `🐙`        |
+| `to-inspect`     | `🧿`        |
+| `to-rework`      | `🦀`        |
+| `to-merge`       | `🐢`        |
+| `to-ratify`      | `🦭`        |
+
+The narwhal (slice phase) always uses both characters `𐃆🐋`, not just the emoji.
+
+```
+  𐃆🐋  #34  "auth token rotation"
+  🐙  #55  "user profile endpoint"
+  🧿  #53  "db migration safety"
+```
+
 After dispatching, record the count of automated phases dispatched this iteration:
 
 ```sh
 AUTOMATED_DISPATCHES="{count of automated phases dispatched this iteration}"
+```
+
+### Step 2c. Print lore snippet
+
+After all dispatched agents return, generate a lore snippet. This is a 1-2 sentence story fragment in playful Ghibli ocean vibes. Each lore snippet must read all prior snippets from the session and continues the narrative — the lore forms a continuous story, not isolated fragments. The story should be influenced by what actually happened in the pulse results (e.g., reworks are setbacks, successful inspects are triumphs, long waits are boring). Print it with the elapsed time since dispatch:
+
+```
+╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌
+  +8m00s  "The moonjelly sent three creatures into the dark and
+           waited, humming to itself."
+╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌
+```
+
+Append the lore snippet to the session's lore story list.
+
+### Step 2d. Print return results
+
+After agents return, print each result with its phase emoji and a `›` transition arrow showing the phase transition:
+
+```
+  𐃆🐋  #34   3m12s   18k   slice › implement
+  🐙  #55   4m45s   24k   implement › inspect
+  🦀  #53   1m08s    9k   inspect › rework
+```
+
+The narwhal (slice phase) always uses both characters `𐃆🐋`. Each line shows: phase emoji, issue number, duration, token count, and the transition (previous tag `›` next tag from handoff).
+
+Also print human and idle items:
+
+```
+  🤿  #60  to-scope
+  🤿  #48  to-land
+  ·   #57  idle — awaiting #55
+  ·   #56  idle
 ```
 
 ### Step 3. Log phase metrics
@@ -169,33 +245,52 @@ If running in `--hitl` mode and this is the first iteration, present human-requi
 
 > Note: reef-scope and reef-land remain user-facing skills invoked via slash commands. Only the automated (🌊) phases are dispatched via file references.
 
-### Step 5. Report and exit
+### Step 5. Recurse or exit
 
-Print a summary of what was dispatched:
+After metrics are logged, check whether to recurse or exit.
 
-```
-🪼 Pulse complete.
+**If `AUTOMATED_DISPATCHES` > 0**: the pulse dispatched automated work this iteration. After agents return and metrics are logged, recursively invoke `/reef-pulse --afk` on the main session. The recursive call is always `--afk`, even if the first invocation was HITL. The recursive call happens on the main session, never as a sub-agent — this ensures the loop runs sequentially (scan, dispatch, wait, scan again) rather than spawning nested agents. Do NOT release the lock between iterations; the lock persists across the entire recursive chain. Pass the accumulated lore story list and pulse counter to the next iteration.
 
-  Dispatched:
-    🌊 implement.md #55 (auth-endpoint)
-    🌊 implement.md #56 (user-profile)
-    🌊 inspect.md #53 (db-migration)
-    🌊 merge.md #51 (schema-setup)
+**If `AUTOMATED_DISPATCHES` == 0**: no automated work was dispatched this iteration. The pulse has nothing left to do. Continue to Step 6.
 
-  Awaiting human:
-    🤿 to-scope: #60 (new-dashboard-idea)
-    🤿 to-land: #42 (token-auth-migration)
+### Step 6. Print SESSION COMPLETE and full story
 
-  Idle:
-    ⏳ to-await-waves: #57 (legacy-compat) — blocked by #55, #56
-```
+This step only runs when `AUTOMATED_DISPATCHES` == 0 (the exit path from Step 5).
 
-If nothing was actionable:
+First, generate a final lore snippet for the empty pulse (the moonjelly finding nothing left to do). Append it to the lore story list.
+
+Then print the SESSION COMPLETE box with session stats:
 
 ```
-🪼 Pulse complete. Nothing to dispatch.
+┌─────────────────────────────────────────────────────────────┐
+│  SESSION COMPLETE                                            │
+│                                                              │
+│  Duration    17m00s                                          │
+│  Pulses      4                                               │
+│  Agents      7  dispatches across 3 active pulses            │
+│  Landed      #34  #53                                        │
+│  Human       #60  #48                                        │
+│  Idle        #56  #57                                        │
+└─────────────────────────────────────────────────────────────┘
+```
 
-  Run /reef-scope to start something new.
+- **Duration**: total wall-clock time since the session started (from the lock file timestamp)
+- **Pulses**: total number of pulse iterations (including this final empty one)
+- **Agents**: total number of sub-agent dispatches across all active pulses (pulses that dispatched at least one agent)
+- **Landed**: issues that reached `to-land` or `landed` during this session
+- **Human**: issues that need human attention (`to-scope`, `to-land`)
+- **Idle**: issues that are blocked or have no actionable tag
+
+After the SESSION COMPLETE box, print the full collected story as a single block — all lore snippets from the session concatenated into a continuous narrative:
+
+```
+  The moonjelly sent three creatures into the dark and waited,
+  humming to itself. The crab came back sulking — it had dropped
+  a stitch and needed another pass. The octopus just kept working.
+  The barreleye peered through both pieces with its strange glass
+  eyes and — for once — found nothing wrong. The moonjelly found
+  nothing left to chase. It settled onto the reef floor, bells
+  dimming, and listened to the quiet.
 ```
 
 **Autopilot hint** (show only when pulse was triggered manually, not from a cron):
@@ -207,17 +302,9 @@ Check if a durable cron for `/reef-pulse --afk` already exists by calling `CronL
      CronCreate cron="7 * * * *" prompt="/reef-pulse --afk" durable=true
 ```
 
-### Step 6. Recurse or exit
-
-After reporting, check whether to recurse or exit.
-
-**If `AUTOMATED_DISPATCHES` > 0**: the pulse dispatched automated work this iteration. After agents return and metrics are logged, recursively invoke `/reef-pulse --afk` on the main session. The recursive call is always `--afk`, even if the first invocation was HITL. The recursive call happens on the main session, never as a sub-agent — this ensures the loop runs sequentially (scan, dispatch, wait, scan again) rather than spawning nested agents. Do NOT release the lock between iterations; the lock persists across the entire recursive chain.
-
-**If `AUTOMATED_DISPATCHES` == 0**: no automated work was dispatched this iteration. The pulse has nothing left to do. Delete the pulse.lock file and exit. The lock must only be released when the pulse is truly done — zero automated dispatches means the loop naturally terminates.
-
 ### Step 7. Release lock
 
-This step only runs when `AUTOMATED_DISPATCHES` == 0 (the exit path from Step 6). To release the lock, delete the pulse.lock file.
+This step only runs when `AUTOMATED_DISPATCHES` == 0 (the exit path from Step 5). To release the lock, delete the pulse.lock file.
 
 Exit.
 

--- a/reef-pulse/SKILL.md
+++ b/reef-pulse/SKILL.md
@@ -19,13 +19,23 @@ Capture the skill base directory (provided by the harness as "Base directory for
 SKILL_DIR="{base directory for this skill}"
 ```
 
-## 0. Sync tracker branch (local-tracker-committed only)
+## 0a. Acquire lock
 
-If the tracker type in config is `local-tracker-committed`, the tracker files live in a git-tracked directory on a specific branch. Sync it before scanning:
+Before doing anything else, check for an existing pulse.lock file.
 
 ```sh
 TRACKER_BRANCH="{from config.md}" # e.g. main
+LOCK_FILE=".agents/moonjelly-reef/pulse.lock"
 ```
+
+If the pulse.lock file exists, another pulse may already be running (or a previous session crashed without cleaning up).
+
+- If `pulse.lock` exists, read the start timestamp from it, calculate how long the existing pulse has been running, and report this to the user: "A pulse has been running for {elapsed}. This may be from a crashed session. Override?" In AFK mode, override automatically (the lock is stale if we're in a cron). In HITL mode, ask the user.
+- If `pulse.lock` does not exist (or the user chose to override), create it with a start timestamp (ISO 8601 UTC) and continue.
+
+## 0b. Sync tracker branch (local-tracker-committed only)
+
+If the tracker type in config is `local-tracker-committed`, the tracker files live in a git-tracked directory on a specific branch. Sync it before scanning. `TRACKER_BRANCH` was already set in the previous step.
 
 ```sh
 git fetch origin "$TRACKER_BRANCH" && git checkout "$TRACKER_BRANCH" && git pull
@@ -186,6 +196,10 @@ Check if a durable cron for `/reef-pulse --afk` already exists by calling `CronL
   💡 Run this on autopilot:
      CronCreate cron="7 * * * *" prompt="/reef-pulse --afk" durable=true
 ```
+
+### Step 6. Release lock
+
+On final exit (nothing left to dispatch), delete the pulse.lock file. The lock must only be released when the pulse is truly done — not between iterations (future: the self-perpetuating loop will keep the lock across iterations).
 
 Exit.
 

--- a/reef-pulse/SKILL.md
+++ b/reef-pulse/SKILL.md
@@ -89,6 +89,12 @@ For each item, spawn a sub-agent with: `"Read and follow $SKILL_DIR/{file}. Targ
 | `to-merge`       | `$SKILL_DIR/merge.md`       |
 | `to-ratify`      | `$SKILL_DIR/ratify.md`      |
 
+After dispatching, record the count of automated phases dispatched this iteration:
+
+```sh
+AUTOMATED_DISPATCHES="{count of automated phases dispatched this iteration}"
+```
+
 ### Step 3. Log phase metrics
 
 After all dispatched agents complete, collect from each: task notification metadata (duration, tokens, tool uses) and the structured handoff variables (`nextPhase`, `planPr`, `summary`). Group results by plan.
@@ -146,11 +152,13 @@ Example:
 | **Total** | | **5m 30s** | **62 359** | **87** | | | |
 ```
 
-### Step 4. Present human (🤿) items (--hitl only)
+### Step 4. Present human (🤿) items (first iteration only)
 
-If running in `--afk` mode, skip this step entirely.
+Skip this step if running in `--afk` mode or if this is a recursive iteration (not the first iteration).
 
-If running in `--hitl` mode, present human-required items immediately without waiting for dispatched agents to complete. Automated agents run in the background — metrics collection (Step 3) happens after agents complete but must not block the human workflow. Present human items as soon as dispatch is done:
+Human items (`to-scope`, `to-land`) are presented only in the first iteration of the pulse, not in recursive AFK calls. This ensures that HITL items are shown once to the user and not repeated as the pulse recurses through automated work.
+
+If running in `--hitl` mode and this is the first iteration, present human-required items immediately without waiting for dispatched agents to complete. Automated agents run in the background — metrics collection (Step 3) happens after agents complete but must not block the human workflow. Present human items as soon as dispatch is done:
 
 | Tag        | Skill         | Presentation                                                              |
 | ---------- | ------------- | ------------------------------------------------------------------------- |
@@ -197,9 +205,17 @@ Check if a durable cron for `/reef-pulse --afk` already exists by calling `CronL
      CronCreate cron="7 * * * *" prompt="/reef-pulse --afk" durable=true
 ```
 
-### Step 6. Release lock
+### Step 6. Recurse or exit
 
-On final exit (nothing left to dispatch), delete the pulse.lock file. The lock must only be released when the pulse is truly done — not between iterations (future: the self-perpetuating loop will keep the lock across iterations).
+After reporting, check whether to recurse or exit.
+
+**If `AUTOMATED_DISPATCHES` > 0**: the pulse dispatched automated work this iteration. After agents return and metrics are logged, recursively invoke `/reef-pulse --afk` on the main session. The recursive call is always `--afk`, even if the first invocation was HITL. The recursive call happens on the main session, never as a sub-agent — this ensures the loop runs sequentially (scan, dispatch, wait, scan again) rather than spawning nested agents. Do NOT release the lock between iterations; the lock persists across the entire recursive chain.
+
+**If `AUTOMATED_DISPATCHES` == 0**: no automated work was dispatched this iteration. The pulse has nothing left to do. Delete the pulse.lock file and exit. The lock must only be released when the pulse is truly done — zero automated dispatches means the loop naturally terminates.
+
+### Step 7. Release lock
+
+This step only runs when `AUTOMATED_DISPATCHES` == 0 (the exit path from Step 6). To release the lock, delete the pulse.lock file.
 
 Exit.
 


### PR DESCRIPTION
<details><summary><h3>🦭 Ratify report — 2026/04/21 17:09</h3></summary>

## Final Report

### Status: PASS

### Success criteria

- ✓ SC1: Pulse acquires lockfile on start, releases on exit — verified: SKILL.md 0a creates pulse.lock with ISO 8601 UTC timestamp; Step 7 deletes it when AUTOMATED_DISPATCHES == 0
- ✓ SC2: Second pulse detects lock and offers override — verified: SKILL.md 0a reads timestamp, reports elapsed, offers override (auto-override in AFK mode)
- ✓ SC3: Recursive /reef-pulse --afk after agents return — verified: Step 5 recurses when AUTOMATED_DISPATCHES > 0, always --afk, on main session
- ✓ SC4: Exits when no automated phases dispatchable — verified: Step 5 falls through to Step 6/7 when AUTOMATED_DISPATCHES == 0, releases lock and exits
- ✓ SC5: Field notes log format with phase emoji — verified: Steps 0c/0d/2b/2c/2d produce session header, pulse header, dispatched agents, lore snippet, return results with › transitions
- ✓ SC6: Narwhal uses both characters — verified: Steps 2b and 2d explicitly require `𐃆🐋` (not just emoji), phase emoji table maps to-slice to `𐃆🐋`
- ✓ SC7: Lore snippets form continuous story — verified: Step 2c requires reading all prior snippets and continuing the narrative, influenced by actual outcomes
- ✓ SC8: Full story after SESSION COMPLETE — verified: Step 6 prints SESSION COMPLETE box then full collected story as a single block
- ✓ SC9: HITL items only in first iteration — verified: Step 4 skips if --afk mode or recursive iteration

### Agent decisions to review

- **AFK mode auto-override** (slice #98): In AFK mode, stale locks are overridden automatically without prompting. Sensible — cron-triggered pulses must self-recover from crashed sessions.
- **TRACKER_BRANCH placement** (slice #98): Moved from sync section to acquire-lock section. Both variables needed early; satisfies test ordering constraints. No functional drift.
- **Step numbering** (slice #100): New steps use sub-numbering (0c, 0d, 2b, 2c, 2d) to preserve existing step numbers. Clean approach.
- **Old Step 5 replaced** (slice #100): The old plain-text summary replaced by the field notes format. All information preserved across Steps 2b-2d and the SESSION COMPLETE box.
- **Lore state passing** (slice #100): Recursive calls explicitly pass accumulated lore story list and pulse counter. Required because pulse is stateless by design but story must persist.

### Integration notes

No integration issues found. Step numbering is consistent across all three slices. The AUTOMATED_DISPATCHES variable is set in Step 2b (slice #100) and consumed in Steps 5-7 (slice #99) — composition is clean. Lock lifecycle (acquire in 0a from slice #98, release in Step 7 from slice #99) correctly spans the full recursive chain without releasing between iterations.

### Test results

Full suite: 316 passed, 0 failed, 0 skipped (257 orchestration + 37 tracker + 22 worktree).

### Screenshots / video

Not applicable — this is a skill definition (markdown instructions), not a launchable UI.

### Parent plan

https://github.com/mesqueeb/moonjelly-reef/issues/45

</details>

### 🪼 Pulse metrics

| Phase | Target | Duration | Tokens | Tool uses | Outcome | Date |
| --- | --- | --- | --- | --- | --- | --- |
| slice | #45 | 4m 1s | 48 653 | 35 | ✅ 3 slices created | 2026-04-21 16:15 |
| implement | #98 | 3m 53s | 63 603 | 43 | ✅ PR #101 created | 2026-04-21 16:21 |
| inspect | #98 | 2m 0s | 31 415 | 19 | ✅ passed | 2026-04-21 17:02 |
| merge | #98 | 2m 1s | 21 413 | 21 | ✅ merged PR #101 | 2026-04-21 17:10 |
| implement | #99 | 4m 33s | 62 879 | 45 | ✅ PR #103 created | 2026-04-21 17:30 |
| inspect | #99 | 2m 4s | 33 869 | 21 | ✅ passed | 2026-04-21 17:35 |
| merge | #99 | 1m 26s | 20 668 | 17 | ✅ merged PR #103 | 2026-04-21 17:50 |
| implement | #100 | 4m 56s | 78 670 | 52 | ✅ PR #104 created | 2026-04-21 18:10 |
| inspect | #100 | 2m 57s | 42 252 | 30 | ✅ passed | 2026-04-21 18:20 |
| merge | #100 | 1m 38s | 21 165 | 18 | ✅ merged PR #104 | 2026-04-21 18:30 |
| ratify | #45 | 3m 17s | 51 335 | 31 | ✅ ratified | 2026-04-21 18:40 |
| **Total** | | **32m 46s** | **475 922** | **332** | | |
