### PR TITLE
PRs should always mention closes $ID $TITLE

### DIFF
--- a/ORCHESTRATION.md
+++ b/ORCHESTRATION.md
@@ -346,6 +346,7 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
   REPORT="{report-content}" # starts with: closes #$SLICE_ID $SLICE_NAME\n\n
   ```
 - pr-create
+  - contains: `closes #$SLICE_ID $SLICE_NAME`
   ```sh
   gh pr create --base "$TARGET_BRANCH" --title "$SLICE_NAME" --body "$REPORT" --label to-inspect
   ```
@@ -651,8 +652,9 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
   ./commit.sh --branch "$TARGET_BRANCH" -m "ratify: add documentation"
   ```
 - submit-report
+  - contains: `closes #$PLAN_ID $PLAN_TITLE`
   ```sh
-  REPORT="{ratify-report}" # <details><summary><h3>🦭 Ratify report — {yyyy/MM/dd HH:mm}</h3></summary>{report-content}</details>
+  REPORT="{ratify-report}" # starts with: closes #$PLAN_ID $PLAN_TITLE\n\n<details><summary><h3>🦭 Ratify report — {yyyy/MM/dd HH:mm}</h3></summary>{report-content}</details>
   # if no PR exists:
   gh pr create --base "$BASE_BRANCH" --head "$TARGET_BRANCH" --title "$PLAN_TITLE" --body "$REPORT" --label to-ratify
   # if PR exists, append:
@@ -660,6 +662,14 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
   PR_BODY=$(gh pr view "$PR_NUMBER" --json body -q .body)
   PR_BODY="$PR_BODY\n\n$REPORT"
   gh pr edit "$PR_NUMBER" --body "$PR_BODY"
+  ```
+- set-variables
+  ```sh
+  PLAN_BODY="{plan body with PR reference and pr-branch updated}"
+  ```
+- update-plan-body
+  ```sh
+  ./tracker.sh issue edit "$PLAN_ID" --body "$PLAN_BODY"
   ```
 - update-tracker
   - pass: `./tracker.sh issue edit "$PLAN_ID" --remove-label to-ratify --add-label to-land` + `gh pr edit "$PR_NUMBER" --remove-label to-ratify --add-label to-land`

--- a/reef-pulse/ratify.md
+++ b/reef-pulse/ratify.md
@@ -178,8 +178,10 @@ Document judgment calls made during this phase on the PR. Only document decision
 
 Format the report as a collapsible block with local timestamp (`yyyy/MM/dd HH:mm`):
 
+The PR body must start with the "closes" reference, followed by the ratify report:
+
 ```sh
-REPORT="{ratify-report}" # <details><summary><h3>🦭 Ratify report — {yyyy/MM/dd HH:mm}</h3></summary>{report-content}</details>
+REPORT="{ratify-report}" # starts with: closes #$PLAN_ID $PLAN_TITLE\n\n<details><summary><h3>🦭 Ratify report — {yyyy/MM/dd HH:mm}</h3></summary>{report-content}</details>
 # if no PR exists:
 gh pr create --base "$BASE_BRANCH" --head "$TARGET_BRANCH" --title "$PLAN_TITLE" --body "$REPORT" --label to-ratify
 # if PR exists, append:
@@ -187,6 +189,13 @@ PR_NUMBER="{from pr create output or existing PR}"
 PR_BODY=$(gh pr view "$PR_NUMBER" --json body -q .body)
 PR_BODY="$PR_BODY\n\n$REPORT"
 gh pr edit "$PR_NUMBER" --body "$PR_BODY"
+```
+
+Persist the PR reference on the plan issue body so downstream phases can find it. Update the `pr-branch` frontmatter field to `$TARGET_BRANCH` (the branch the PR lives on).
+
+```sh
+PLAN_BODY="{plan body with PR reference and pr-branch updated}"
+./tracker.sh issue edit "$PLAN_ID" --body "$PLAN_BODY"
 ```
 
 ### 9. Tag


### PR DESCRIPTION
closes #53 PRs should always mention closes $ID $TITLE

## Ambiguous choices

None — implementation followed the plan exactly.

## Test results

320 tests passed, 0 failed, 0 skipped (261 orchestration + 37 tracker + 22 worktree).

<details><summary><h3>🦀 Rework — 2026/04/21 18:16</h3></summary>

## What was addressed

The original PR #59 was closed and its branch deleted. This rework re-created the implementation on a new branch `fix/053-pr-closes-references` as PR #108.

## Changes

No code changes needed — the implementation from the original PR was correctly re-applied:
- **ratify.md**: Added `closes #$PLAN_ID $PLAN_TITLE` instruction to the PR body template and added plan body frontmatter persistence step
- **ORCHESTRATION.md**: Added `contains: closes #$SLICE_ID $SLICE_NAME` to implement.md pr-create entry and `contains: closes #$PLAN_ID $PLAN_TITLE` to ratify.md submit-report entry, plus the new set-variables/update-plan-body steps

## Judgment calls

None — the re-implementation matches what the original PR delivered.

## Test results

320 tests passed, 0 failed, 0 skipped (261 orchestration + 37 tracker + 22 worktree).

</details>

<details><summary><h3>🧿 Inspect review — 2026/04/21</h3></summary>

## Acceptance criteria check

The issue title says: "PRs should always mention closes $ID $TITLE". Two PR creation paths exist in the system:

1. **implement.md (slice PRs)** — Already had `closes #$SLICE_ID $SLICE_NAME` in the REPORT template on main. This PR adds the corresponding `contains:` assertion to ORCHESTRATION.md so the test suite enforces it. **MET.**
2. **ratify.md (plan PRs)** — Did NOT have the closes reference. This PR adds `closes #$PLAN_ID $PLAN_TITLE` to the REPORT template in ratify.md, adds the `contains:` assertion to ORCHESTRATION.md, and adds the explanatory prose. **MET.**

Additional changes:
- **set-variables / update-plan-body** steps added to ORCHESTRATION.md ratify section — persists PR reference and pr-branch on the plan issue body so downstream phases can find it. Consistent with the same pattern in implement.md.
- **pulse.lock deletion** — transient state file, cleanup is fine.

## Test results

320 passed, 0 failed, 0 skipped (261 orchestration + 37 tracker + 22 worktree).

## Ambiguous choices

PR states "None." Confirmed — the implementation is a mechanical addition of the closes pattern to the only path that was missing it.

## Drift

None detected. The changes are minimal and precisely scoped.

</details>