### PR TITLE
Single-slice ratify + QA personality split

### DIFF
--- a/ORCHESTRATION.md
+++ b/ORCHESTRATION.md
@@ -649,7 +649,7 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
 - phase-specific
 - commit-code — if documentation-added
   ```sh
-  ./commit.sh --branch "$TARGET_BRANCH" -m "ratify: add documentation"
+  ./commit.sh --branch "$PR_BRANCH" -m "ratify: add documentation"
   ```
 - submit-report
   ```sh

--- a/ORCHESTRATION.md
+++ b/ORCHESTRATION.md
@@ -572,14 +572,14 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
   ```
 - update-tracker
   ```sh
-  ./tracker.sh issue edit "$PLAN_ID" --remove-label to-merge --add-label to-land
-  gh pr edit "$PR_NUMBER" --remove-label to-merge --add-label to-land
+  ./tracker.sh issue edit "$PLAN_ID" --remove-label to-merge --add-label to-ratify
+  gh pr edit "$PR_NUMBER" --remove-label to-merge --add-label to-ratify
   ```
 - handoff
   ```sh
-  nextPhase="to-land"
+  nextPhase="to-ratify"
   planPr="$PR_NUMBER" # inherited from router context
-  summary="Single slice verified — PR stays open for human review"
+  summary="Single slice verified — forwarding to ratify for holistic review"
   ```
 
 ### [merge-multi.md](./reef-pulse/merge-multi.md)
@@ -638,12 +638,13 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
   PLAN_TITLE="{from plan body}"
   BASE_BRANCH="{from plan body}"
   TARGET_BRANCH="{from plan body}"
+  PR_BRANCH="{from plan body pr-branch field}"
   WORKTREE_PATH=".worktrees/$PLAN_ID-ratify"
   ```
 - enter-worktree
-  - contains: `Enter a worktree forked from $TARGET_BRANCH because all slice PRs are merged there`
+  - contains: `Enter a worktree forked from $PR_BRANCH`
   ```sh
-  ./worktree-enter.sh --fork-from "$TARGET_BRANCH" --pull-latest "$BASE_BRANCH" --path "$WORKTREE_PATH"
+  ./worktree-enter.sh --fork-from "$PR_BRANCH" --pull-latest "$BASE_BRANCH" --path "$WORKTREE_PATH"
   ```
 - phase-specific
 - commit-code — if documentation-added

--- a/reef-pulse/inspect.md
+++ b/reef-pulse/inspect.md
@@ -51,7 +51,7 @@ What you do:
 - **Flag substantive gaps.** Missing tests, incomplete behavior, skipped acceptance criteria — these go in review comments, not silent fixes.
 - **Read the ambiguous choices.** The implementer documented decisions they made. Flag anything that drifted too far from the success criteria or that the human should know about.
 
-You do NOT evaluate product direction, user stories, or the problem statement — that is Ratty the Walrus's job during ratify.
+You do NOT need to evaluate product direction, user stories, or the problem statement in great detail.
 
 ## Process
 

--- a/reef-pulse/inspect.md
+++ b/reef-pulse/inspect.md
@@ -36,18 +36,22 @@ WORKTREE_PATH=".worktrees/$SLICE_NAME-inspect"
 
 For plan issues, read success criteria from the plan body instead of acceptance criteria.
 
-## Mindset
+## Mindset — Inspector Barreleye
 
-You are a CTO independently verifying this work. You do not trust the implementer's self-report. You verify everything yourself by reading code and running tests. You use judgment, not checklists.
+You are **Inspector Barreleye** — the mechanical reviewer. You check code against **acceptance criteria**, line by line. You do not evaluate "why" — only "does the code do what the criteria say?"
 
-A few things you naturally do:
+You are precise, methodical, and code-level. You do not trust the implementer's self-report. You verify everything yourself by reading code and running tests.
+
+What you do:
 
 - **Check the implementation against each acceptance criterion.** Read the code. Does it actually do what the criterion says? Don't just read the PR description — it may be optimistic.
-- **Spot drift.** The implementation may differ from the plan. That might be fine (the implementer found a better way) or it might be a gap. Surface it either way.
+- **Spot drift from the plan.** The implementation may differ from the plan. That might be fine (the implementer found a better way) or it might be a gap. Surface it either way.
 - **Run the full test suite yourself.** Don't trust "all tests pass" in the report.
-- **Do trivial cleanups.** Stale TODOs, leftover debug prints, dead code from debugging, formatting — fix these yourself and commit. Don't ask permission.
+- **Do trivial cleanups.** Stale TODOs, leftover debug prints, dead code from debugging, formatting, dead code — fix these yourself and commit. Don't ask permission.
 - **Flag substantive gaps.** Missing tests, incomplete behavior, skipped acceptance criteria — these go in review comments, not silent fixes.
 - **Read the ambiguous choices.** The implementer documented decisions they made. Flag anything that drifted too far from the success criteria or that the human should know about.
+
+You do NOT evaluate product direction, user stories, or the problem statement — that is Ratty the Walrus's job during ratify.
 
 ## Process
 

--- a/reef-pulse/inspect.md
+++ b/reef-pulse/inspect.md
@@ -47,7 +47,7 @@ What you do:
 - **Check the implementation against each acceptance criterion.** Read the code. Does it actually do what the criterion says? Don't just read the PR description — it may be optimistic.
 - **Spot drift from the plan.** The implementation may differ from the plan. That might be fine (the implementer found a better way) or it might be a gap. Surface it either way.
 - **Run the full test suite yourself.** Don't trust "all tests pass" in the report.
-- **Do trivial cleanups.** Stale TODOs, leftover debug prints, dead code from debugging, formatting, dead code — fix these yourself and commit. Don't ask permission.
+- **Do trivial cleanups.** Stale TODOs, leftover debug prints, dead code from debugging, formatting — fix these yourself and commit. Don't ask permission.
 - **Flag substantive gaps.** Missing tests, incomplete behavior, skipped acceptance criteria — these go in review comments, not silent fixes.
 - **Read the ambiguous choices.** The implementer documented decisions they made. Flag anything that drifted too far from the success criteria or that the human should know about.
 

--- a/reef-pulse/merge-single.md
+++ b/reef-pulse/merge-single.md
@@ -18,21 +18,21 @@ Set the variables needed for this path:
 PLAN_ID="{from slice/plan body}"
 ```
 
-## 1. Tag plan to-land
+## 1. Tag plan to-ratify
 
-Remove `to-merge`, add `to-land`:
+Remove `to-merge`, add `to-ratify`:
 
 ```sh
-./tracker.sh issue edit "$PLAN_ID" --remove-label to-merge --add-label to-land
-gh pr edit "$PR_NUMBER" --remove-label to-merge --add-label to-land
+./tracker.sh issue edit "$PLAN_ID" --remove-label to-merge --add-label to-ratify
+gh pr edit "$PR_NUMBER" --remove-label to-merge --add-label to-ratify
 ```
 
 ## Handoff
 
 ```sh
-nextPhase="to-land"
+nextPhase="to-ratify"
 planPr="$PR_NUMBER" # inherited from router context
-summary="Single slice verified — PR stays open for human review"
+summary="Single slice verified — forwarding to ratify for holistic review"
 ```
 
 Report these three variables to the caller.

--- a/reef-pulse/ratify.md
+++ b/reef-pulse/ratify.md
@@ -64,7 +64,7 @@ Enter a worktree forked from $PR_BRANCH — for multi-slice this is the target b
 WORKTREE_STATUS=$(./worktree-enter.sh --fork-from "$PR_BRANCH" --pull-latest "$BASE_BRANCH" --path "$WORKTREE_PATH")
 ```
 
-Read the output. On `ready` or `synced`: continue. On `conflicts`: attempt to resolve the conflicts in the worktree. If resolved, commit the merge and push to `origin/$TARGET_BRANCH` using explicit refspec (no force), then continue. If unresolvable:
+Read the output. On `ready` or `synced`: continue. On `conflicts`: attempt to resolve the conflicts in the worktree. If resolved, commit the merge and push to `origin/$PR_BRANCH` using explicit refspec (no force), then continue. If unresolvable:
 
 ```sh
 ./tracker.sh issue edit "$PLAN_ID" --add-label blocked-with-conflicts
@@ -134,7 +134,7 @@ When you find non-obvious behavior worth documenting during your holistic review
 1. **Code comments first.** If it can be clarified with a comment next to the code or above a test, add it yourself and push directly to the target branch:
 
 ```sh
-./commit.sh --branch "$TARGET_BRANCH" -m "ratify: add documentation"
+./commit.sh --branch "$PR_BRANCH" -m "ratify: add documentation"
 ```
 
 2. **Outside-of-code docs if warranted.** If the behavior is significant enough to document beyond a code comment, check the repo's `AGENTS.md`/`CLAUDE.md` for a documentation locations section. If it exists, follow it. If it doesn't, create a brief entry.

--- a/reef-pulse/ratify.md
+++ b/reef-pulse/ratify.md
@@ -36,23 +36,32 @@ PLAN_ID="$ISSUE_ID"
 PLAN_TITLE="{from plan body}"
 BASE_BRANCH="{from plan body}"
 TARGET_BRANCH="{from plan body}"
+PR_BRANCH="{from plan body pr-branch field}"
 WORKTREE_PATH=".worktrees/$PLAN_ID-ratify"
 ```
 
-## Mindset
+## Mindset — Ratty the Walrus
 
-You are checking the **whole**, not the parts. Each slice was already verified individually during inspection. Your job is different: does the aggregate work? Does the target branch, taken as a whole, meet every success criterion from the consumer's perspective?
+You are **Ratty the Walrus** — the holistic reviewer. Inspector Barreleye already checked the code line-by-line against acceptance criteria. Your job is fundamentally different: you check against **user stories** and the **problem statement** to answer "does this actually solve the user's problem?"
 
-Think like a CTO doing a final walkthrough before shipping.
+You are not re-inspecting code. You are:
+
+- **Evaluating from the user's perspective.** Re-read the problem statement and user stories. Walk through the solution as the user would experience it. Does the implemented behavior match what the user needs?
+- **Reviewing agent decisions for sanity.** Implementers made choices. Do those choices serve the user, or did they optimize for something else?
+- **Looking for integration issues.** For multi-slice: do the slices compose correctly? For single-slice: does the change cohere with the rest of the codebase?
+- **Checking documentation.** Is the change discoverable? Would a new contributor understand what changed and why?
+- **Running the full test suite.** Belt and suspenders — you run it independently.
+
+Think like a CTO doing a final walkthrough before shipping. Product-focused, big-picture, judgment-oriented.
 
 ## Process
 
-### 1. Get on the target branch
+### 1. Get on the PR branch
 
-Enter a worktree forked from $TARGET_BRANCH because all slice PRs are merged there — you are reviewing the aggregate, not individual slices:
+Enter a worktree forked from $PR_BRANCH — for multi-slice this is the target branch where all slice PRs are merged; for single-slice this is the slice's own branch:
 
 ```sh
-WORKTREE_STATUS=$(./worktree-enter.sh --fork-from "$TARGET_BRANCH" --pull-latest "$BASE_BRANCH" --path "$WORKTREE_PATH")
+WORKTREE_STATUS=$(./worktree-enter.sh --fork-from "$PR_BRANCH" --pull-latest "$BASE_BRANCH" --path "$WORKTREE_PATH")
 ```
 
 Read the output. On `ready` or `synced`: continue. On `conflicts`: attempt to resolve the conflicts in the worktree. If resolved, commit the merge and push to `origin/$TARGET_BRANCH` using explicit refspec (no force), then continue. If unresolvable:


### PR DESCRIPTION
closes #83 Single-slice ratify + pr-branch frontmatter + QA personality split

## Ambiguous choices

None — implementation followed the plan exactly. The await-waves review notes were precise and no judgment calls were needed.

## Test results

317 tests passed, 0 failed, 0 skipped (258 orchestration + 37 tracker + 22 worktree).

### 🪼 Pulse metrics

| Phase | Target | Duration | Tokens | Tool uses | Outcome | Date |
| ----- | ------ | -------- | ------ | --------- | ------- | ---- |
| await-waves | #83 | 2m 03s | 44 566 | 26 | ✅ promoted to implement | 2026-04-21 05:21 |
| implement | #83 | 0m 30s | — | — | ❌ rate limit | 2026-04-21 05:22 |
| implement | #83 | 3m 38s | 53 090 | 40 | ✅ PR created | 2026-04-21 06:06 |
| inspect | #83 | 3m 17s | 35 208 | 36 | ❌ rework (stale refs) | 2026-04-21 06:10 |
| rework | #83 | 1m 53s | 20 536 | 26 | ✅ fixed stale refs | 2026-04-21 06:15 |
| inspect | #83 | 2m 36s | 30 770 | 29 | ✅ passed | 2026-04-21 06:20 |
| merge | #83 | 1m 13s | 17 130 | 14 | ✅ to-land | 2026-04-21 06:25 |
| **Total** | | **15m 10s** | **201 300** | **171** | | |
<!-- end metrics table -->

<details><summary><h3>🧿 Inspect review — 2026/04/21 15:30</h3></summary>

## Acceptance criteria check

The issue title specifies three deliverables:

1. **Single-slice ratify** — merge-single.md now routes `to-ratify` instead of `to-land`. ORCHESTRATION.md updated consistently. **MET.**
2. **pr-branch frontmatter** — ratify.md now declares `PR_BRANCH` variable and uses it for `worktree-enter.sh --fork-from`. ORCHESTRATION.md updated consistently. **MET.**
3. **QA personality split** — inspect.md gets "Inspector Barreleye" (mechanical, code-level reviewer), ratify.md gets "Ratty the Walrus" (holistic, product-focused reviewer). Clear separation of concerns. **MET.**

Additional change: pulse.lock deletion — transient state file, cleanup is fine.

## Gap found

**ratify.md conflict resolution and documentation commit still reference `$TARGET_BRANCH` instead of `$PR_BRANCH`:**

- Line 67: conflict resolution says "push to `origin/$TARGET_BRANCH`" but the worktree is now forked from `$PR_BRANCH`. For single-slice plans where `$PR_BRANCH != $TARGET_BRANCH`, this would push to the wrong branch.
- Line 137: `./commit.sh --branch "$TARGET_BRANCH"` should be `$PR_BRANCH` for the same reason.
- ORCHESTRATION.md line 652: same stale `$TARGET_BRANCH` reference for the documentation commit.

For multi-slice, `$PR_BRANCH` equals `$TARGET_BRANCH` so this is invisible. For single-slice, this would cause ratify to push conflict resolutions and documentation to the wrong branch.

## Test results

317 passed, 0 failed, 0 skipped (258 orchestration + 37 tracker + 22 worktree).

## Ambiguous choices

PR states "None." Confirmed — the implementation is a straightforward rename/restructure with no judgment calls needed.

</details>

<details><summary><h3>🦀 Rework — 2026/04/21 16:05</h3></summary>

## Feedback addressed

All three stale `$TARGET_BRANCH` references identified by the inspector have been replaced with `$PR_BRANCH`:

1. **ratify.md line 67** — conflict resolution push target: `origin/$TARGET_BRANCH` → `origin/$PR_BRANCH`
2. **ratify.md line 137** — documentation commit: `./commit.sh --branch "$TARGET_BRANCH"` → `./commit.sh --branch "$PR_BRANCH"`
3. **ORCHESTRATION.md line 652** — mirror of ratify.md line 137: same fix applied

## Judgment calls

None — the inspector provided precise line-level fixes. All three were straightforward replacements.

## Test results

317 passed, 0 failed, 0 skipped (258 orchestration + 37 tracker + 22 worktree).

</details>

<details><summary><h3>🧿 Inspect review — 2026/04/21 21:45</h3></summary>

## Acceptance criteria check

The issue title specifies three deliverables:

1. **Single-slice ratify** — merge-single.md now routes `to-ratify` instead of `to-land`. ORCHESTRATION.md updated consistently. **MET.**
2. **pr-branch frontmatter** — ratify.md now declares `PR_BRANCH` variable and uses it for `worktree-enter.sh --fork-from`. ORCHESTRATION.md updated consistently. **MET.**
3. **QA personality split** — inspect.md gets "Inspector Barreleye" (mechanical, code-level reviewer), ratify.md gets "Ratty the Walrus" (holistic, product-focused reviewer). Clear separation of concerns. **MET.**

## Rework verification

All three stale `$TARGET_BRANCH` references identified in the previous inspect have been correctly replaced with `$PR_BRANCH`:

1. **ratify.md line 67** — conflict resolution push target: fixed
2. **ratify.md line 137** — documentation commit: fixed
3. **ORCHESTRATION.md line 652** — mirror of ratify.md: fixed

## Trivial cleanup

- Removed duplicate "dead code" phrase in inspect.md line 50 cleanup list. Committed and pushed.

## Ambiguous choices

PR states "None." Confirmed — the implementation is a straightforward rename/restructure with no judgment calls needed.

## Test results

317 passed, 0 failed, 0 skipped (258 orchestration + 37 tracker + 22 worktree). Run twice (before and after cleanup commit).

</details>
