### PR TITLE
blocked-by frontmatter and await-waves update

### DIFF
--- a/ORCHESTRATION.md
+++ b/ORCHESTRATION.md
@@ -491,7 +491,7 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
   ```
 - set-variables
   ```sh
-  DEPENDENCY_ID="{from slice blocked-by list}"
+  DEPENDENCY_ID="{from frontmatter blocked-by field}"
   ```
 - dep-check
   ```sh

--- a/reef-pulse/await-waves.md
+++ b/reef-pulse/await-waves.md
@@ -10,7 +10,7 @@
 
 This skill requires a specific slice: e.g. `#55` or `my-feature/002-token-storage`.
 
-Read the slice. It must have a `blocked-by` list referencing other slices.
+Read the slice. It must have a `blocked-by` frontmatter field referencing other slices (comma-separated issue IDs, e.g. `blocked-by: "#55, #56"`).
 
 Set the pre-fetch variables:
 
@@ -36,19 +36,19 @@ WORKTREE_PATH=".worktrees/$SLICE_NAME-await-waves"
 
 ## 1. Check dependencies
 
-For each dependency in the `blocked-by` list, check if the blocking slice is tagged `done`:
+Parse the `blocked-by` field from the slice's frontmatter. For each dependency ID, check if the blocking slice is tagged `landed`:
 
 ```sh
-DEPENDENCY_ID="{from slice blocked-by list}"
+DEPENDENCY_ID="{from frontmatter blocked-by field}"
 ```
 
 ```sh
 ./tracker.sh issue view "$DEPENDENCY_ID" --json labels
 ```
 
-**If any dependency is NOT done**: this slice stays `to-await-waves`. Skip to the handoff with `nextPhase: "to-await-waves"` and `summary: "still blocked by #N, #M"`.
+**If any dependency does NOT have the `landed` label**: this slice stays `to-await-waves`. Skip to the handoff with `nextPhase: "to-await-waves"` and `summary: "still blocked by #N, #M"`.
 
-**If ALL dependencies are done**: continue to step 2.
+**If ALL dependencies have the `landed` label**: continue to step 2.
 
 ## 2. Re-review the plan
 

--- a/reef-pulse/slice-multi.md
+++ b/reef-pulse/slice-multi.md
@@ -91,6 +91,7 @@ base-branch: $BASE_BRANCH
 target-branch: $TARGET_BRANCH
 pr-branch: —
 type: $PLAN_TYPE
+blocked-by: "#{issue-number}, #{issue-number}"  # omit if no blockers
 
 ---
 
@@ -103,10 +104,6 @@ type: $PLAN_TYPE
 - [ ] {criterion 1}
 - [ ] {criterion 2}
 - [ ] {criterion 3}
-
-## Blocked by
-
-- #{issue-number} {title} (or "None — can start immediately")
 
 ## Success criteria covered
 


### PR DESCRIPTION
closes #107 blocked-by frontmatter and await-waves update

## Ambiguous choices

None — implementation followed the plan exactly.

## Test results

316 tests passed (257 orchestration, 37 tracker, 22 worktree), 0 failed, 0 skipped.

### 🪼 Pulse metrics

| Phase | Target | Duration | Tokens | Tool uses | Outcome | Date |
| ----- | ------ | -------- | ------ | --------- | ------- | ---- |
| implement | #107 | 3m 56s | 46 118 | 48 | ✅ PR created | 2026-04-21 06:25 |
| inspect | #107 | 1m 57s | 23 152 | 23 | ✅ passed | 2026-04-21 06:30 |
| merge | #107 | 1m 58s | 21 287 | 23 | ✅ merged | 2026-04-21 06:34 |
<!-- end metrics table -->

<details><summary><h3>🧿 Inspect review — 2026/04/21 06:35</h3></summary>

**Verdict: PASS**

All 5 acceptance criteria verified:

1. `slice-multi.md` frontmatter now contains `blocked-by:` field (comma-separated issue IDs) — confirmed
2. `slice-multi.md` no longer has `## Blocked by` markdown section — confirmed removed
3. `await-waves.md` parses `blocked-by` from frontmatter, not markdown section — confirmed (lines 13, 39, 42)
4. `await-waves.md` checks for `landed` label instead of `done` — confirmed (lines 39, 49, 51)
5. All existing tests pass — 316/316 (257 orchestration + 37 tracker + 22 worktree)

`ORCHESTRATION.md` also updated consistently (line 494: `DEPENDENCY_ID` sourced from frontmatter).

No ambiguous choices. No drift from plan. No cleanups needed.

</details>