### PR TITLE
conflict anticipation in reef-scope and ORCHESTRATION.md sync

### DIFF
--- a/ORCHESTRATION.md
+++ b/ORCHESTRATION.md
@@ -25,6 +25,16 @@ Three types of tickets flow through the slice lifecycle phases (implement → in
 
 All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to fork from, commit to, and review.
 
+## Terminal label: `landed`
+
+`landed` is the tracker-agnostic signal that a piece of work has reached its target branch. It is the terminal label in the lifecycle — once applied, the issue is considered complete.
+
+- **reef-land** replaces `to-land` with `landed` before closing an issue (single-slice plans and multi-slice plan PRs)
+- **merge-multi** replaces `to-merge` with `landed` on slice PRs after squash-merging into the target branch
+- **await-waves** checks each dependency for the `landed` label to determine whether a blocked slice can proceed — if all dependencies carry `landed`, the slice is promoted to `to-implement`
+
+This convention works identically across tracker types: GitHub adds a label, the local tracker renames the file tag to `[landed]`, and MCP trackers set the equivalent status field.
+
 ## Skills
 
 ### [/reef-pulse](./reef-pulse/SKILL.md)
@@ -130,6 +140,14 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
   ./tracker.sh issue view "$ISSUE_ID" --json body,title,labels
   ```
 - phase-specific
+- set-variables
+  ```sh
+  BASE_BRANCH="{from branch discussion}"
+  ```
+- conflict-anticipation — scan in-flight issues on same base-branch and surface overlaps
+  ```sh
+  ./tracker.sh issue list --label to-slice,in-progress,to-implement,to-inspect,to-rework,to-merge,to-ratify,to-land,to-await-waves --json number,title,body,labels
+  ```
 - set-variables
   ```sh
   PLAN_ID="$ISSUE_ID"
@@ -493,7 +511,7 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
   ```sh
   DEPENDENCY_ID="{from frontmatter blocked-by field}"
   ```
-- dep-check
+- dep-check — checks each dependency for the `landed` label; if all carry `landed`, slice is promoted
   ```sh
   ./tracker.sh issue view "$DEPENDENCY_ID" --json labels
   ```

--- a/reef-scope/SKILL.md
+++ b/reef-scope/SKILL.md
@@ -66,6 +66,28 @@ Suggest a base branch and a target branch name in a single line. Derive the targ
 
 The user confirms or adjusts. Both values are required before continuing.
 
+## 3b. Conflict anticipation
+
+After the branch discussion, scan for in-flight work that might overlap with this plan. List open issues that share the same `base-branch` and are past `to-scope` (i.e., already in-flight: `to-slice`, `in-progress`, `to-implement`, `to-inspect`, `to-rework`, `to-merge`, `to-ratify`, `to-land`, `to-await-waves`).
+
+```sh
+BASE_BRANCH="{from branch discussion}"
+```
+
+```sh
+./tracker.sh issue list --label to-slice,in-progress,to-implement,to-inspect,to-rework,to-merge,to-ratify,to-land,to-await-waves --json number,title,body,labels
+```
+
+For each returned issue, parse the `base-branch` from its frontmatter. Keep only those whose `base-branch` matches the plan's `$BASE_BRANCH`. Skim each matching issue's plan body to assess whether it touches overlapping areas (same files, same modules, same concepts).
+
+If overlapping in-flight work is found, surface it to the user:
+
+> "From a quick look at current work in progress, this scope might lead to conflicts with #77 and #83. Shall I add them as `blocked-by` in the plan frontmatter so implementation won't start until those land?"
+
+The user confirms or adjusts. If they confirm, the `blocked-by` field will be set in the frontmatter during step 4.
+
+If no overlapping work is found, continue silently.
+
 ## 4. Persist the plan
 
 Set variables from the discussion:


### PR DESCRIPTION
closes #109 conflict anticipation in reef-scope and ORCHESTRATION.md sync

## Ambiguous choices

None — implementation followed the plan exactly.

## Test results

318 tests passed, 0 failed, 0 skipped (259 orchestration + 37 tracker + 22 worktree).

### 🪼 Pulse metrics

| Phase | Target | Duration | Tokens | Tool uses | Outcome | Date |
| ----- | ------ | -------- | ------ | --------- | ------- | ---- |
| implement | #109 | 3m 54s | 46 263 | 47 | ✅ PR created | 2026-04-21 06:40 |
| inspect | #109 | 2m 05s | 32 263 | 23 | ✅ passed | 2026-04-21 06:44 |
<!-- end metrics table -->

<details><summary><h3>🧿 Inspect review — 2026/04/21 06:55</h3></summary>

## Acceptance criteria verification

| # | Criterion | Status | Evidence |
|---|-----------|--------|----------|
| AC1 | reef-scope SKILL.md step 3b scans open issues with matching base-branch past to-scope | PASS | Lines 69-89 of reef-scope/SKILL.md — lists all in-flight labels, parses base-branch from frontmatter |
| AC2 | reef-scope surfaces overlapping in-flight work and suggests blocked-by | PASS | Lines 84-87 — example prompt to user with option to add blocked-by |
| AC3 | ORCHESTRATION.md replaces done with landed for terminal label | PASS | No stale `done` label references remain; only `all-slices-done` condition names (correct) |
| AC4 | ORCHESTRATION.md documents landed as tracker-agnostic dependency signal | PASS | New "Terminal label: landed" section at lines 28-36 |
| AC5 | ORCHESTRATION.md await-waves dep-check documents landed label check | PASS | Line 514 updated with explicit landed description |
| AC6 | SC5 verified: reef-land has remove to-land add landed | PASS | Line 229 confirmed |
| AC7 | All existing tests pass | PASS | 318 passed (259 orchestration + 37 tracker + 22 worktree) |

## Test results

318 tests passed, 0 failed, 0 skipped.

## Drift / observations

- No drift from plan. Implementation is a clean addition of the conflict-anticipation step and landed documentation.
- No ambiguous choices needed — the plan was specific enough.

## Verdict

**PASS** — all acceptance criteria met, test suite green, no gaps found.

</details>