### PR TITLE
Formal dependency graph: blocked-by frontmatter, conflict anticipation, landed tag

### DIFF
--- a/ORCHESTRATION.md
+++ b/ORCHESTRATION.md
@@ -491,7 +491,7 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
   ```
 - set-variables
   ```sh
-  DEPENDENCY_ID="{from slice blocked-by list}"
+  DEPENDENCY_ID="{from frontmatter blocked-by field}"
   ```
 - dep-check
   ```sh

--- a/ORCHESTRATION.md
+++ b/ORCHESTRATION.md
@@ -25,6 +25,16 @@ Three types of tickets flow through the slice lifecycle phases (implement → in
 
 All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to fork from, commit to, and review.
 
+## Terminal label: `landed`
+
+`landed` is the tracker-agnostic signal that a piece of work has reached its target branch. It is the terminal label in the lifecycle — once applied, the issue is considered complete.
+
+- **reef-land** replaces `to-land` with `landed` before closing an issue (single-slice plans and multi-slice plan PRs)
+- **merge-multi** replaces `to-merge` with `landed` on slice PRs after squash-merging into the target branch
+- **await-waves** checks each dependency for the `landed` label to determine whether a blocked slice can proceed — if all dependencies carry `landed`, the slice is promoted to `to-implement`
+
+This convention works identically across tracker types: GitHub adds a label, the local tracker renames the file tag to `[landed]`, and MCP trackers set the equivalent status field.
+
 ## Skills
 
 ### [/reef-pulse](./reef-pulse/SKILL.md)
@@ -130,6 +140,14 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
   ./tracker.sh issue view "$ISSUE_ID" --json body,title,labels
   ```
 - phase-specific
+- set-variables
+  ```sh
+  BASE_BRANCH="{from branch discussion}"
+  ```
+- conflict-anticipation — scan in-flight issues on same base-branch and surface overlaps
+  ```sh
+  ./tracker.sh issue list --label to-slice,in-progress,to-implement,to-inspect,to-rework,to-merge,to-ratify,to-land,to-await-waves --json number,title,body,labels
+  ```
 - set-variables
   ```sh
   PLAN_ID="$ISSUE_ID"
@@ -493,7 +511,7 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
   ```sh
   DEPENDENCY_ID="{from frontmatter blocked-by field}"
   ```
-- dep-check
+- dep-check — checks each dependency for the `landed` label; if all carry `landed`, slice is promoted
   ```sh
   ./tracker.sh issue view "$DEPENDENCY_ID" --json labels
   ```

--- a/ORCHESTRATION.md
+++ b/ORCHESTRATION.md
@@ -25,16 +25,6 @@ Three types of tickets flow through the slice lifecycle phases (implement → in
 
 All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to fork from, commit to, and review.
 
-## Terminal label: `landed`
-
-`landed` is the tracker-agnostic signal that a piece of work has reached its target branch. It is the terminal label in the lifecycle — once applied, the issue is considered complete.
-
-- **reef-land** replaces `to-land` with `landed` before closing an issue (single-slice plans and multi-slice plan PRs)
-- **merge-multi** replaces `to-merge` with `landed` on slice PRs after squash-merging into the target branch
-- **await-waves** checks each dependency for the `landed` label to determine whether a blocked slice can proceed — if all dependencies carry `landed`, the slice is promoted to `to-implement`
-
-This convention works identically across tracker types: GitHub adds a label, the local tracker renames the file tag to `[landed]`, and MCP trackers set the equivalent status field.
-
 ## Skills
 
 ### [/reef-pulse](./reef-pulse/SKILL.md)
@@ -146,7 +136,9 @@ This convention works identically across tracker types: GitHub adds a label, the
   ```
 - conflict-anticipation — scan in-flight issues on same base-branch and surface overlaps
   ```sh
-  ./tracker.sh issue list --label to-slice,in-progress,to-implement,to-inspect,to-rework,to-merge,to-ratify,to-land,to-await-waves --json number,title,body,labels
+  for LABEL in to-slice in-progress to-implement to-inspect to-rework to-merge to-ratify to-land to-await-waves; do
+    ./tracker.sh issue list --label "$LABEL" --json number,title,body,labels
+  done
   ```
 - set-variables
   ```sh
@@ -627,6 +619,7 @@ This convention works identically across tracker types: GitHub adds a label, the
   ```
 - update-tracker
   ```sh
+  ./tracker.sh issue edit "$SLICE_ID" --remove-label to-merge --add-label landed
   ./tracker.sh issue close "$SLICE_ID"
   ```
 - update-tracker — if all-slices-done
@@ -635,7 +628,7 @@ This convention works identically across tracker types: GitHub adds a label, the
   ```
 - handoff
   ```sh
-  nextPhase="to-ratify" # or "in-progress" if not all slices done
+  nextPhase="to-ratify" # or "in-progress" if not all slices tagged 'landed'
   planPr="—" # multi-slice: no plan PR yet
   summary="Slice {name} merged — {N} of {total} slices complete"
   ```

--- a/UBIQUITOUS_LANGUAGE.md
+++ b/UBIQUITOUS_LANGUAGE.md
@@ -61,9 +61,10 @@ Three types of tickets flow through the slice lifecycle phases (implement → in
 
 ## Tags
 
-| Term    | Definition                                                             | Aliases to avoid                                                   |
-| ------- | ---------------------------------------------------------------------- | ------------------------------------------------------------------ |
-| **tag** | A label on an issue that represents its current state in the lifecycle | status, state, label (though "label" is the GitHub implementation) |
+| Term       | Definition                                                                                                                                                   | Aliases to avoid                                                   |
+| ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------ |
+| **tag**    | A label on an issue that represents its current state in the lifecycle                                                                                       | status, state, label (though "label" is the GitHub implementation) |
+| **landed** | The terminal tag — tracker-agnostic signal that a piece of work has reached its target branch. Once applied, the issue is considered complete and is closed. | done, completed, merged, finished                                  |
 
 ## Relationships
 

--- a/reef-pulse/await-waves.md
+++ b/reef-pulse/await-waves.md
@@ -10,7 +10,7 @@
 
 This skill requires a specific slice: e.g. `#55` or `my-feature/002-token-storage`.
 
-Read the slice. It must have a `blocked-by` list referencing other slices.
+Read the slice. It must have a `blocked-by` frontmatter field referencing other slices (comma-separated issue IDs, e.g. `blocked-by: "#55, #56"`).
 
 Set the pre-fetch variables:
 
@@ -36,19 +36,19 @@ WORKTREE_PATH=".worktrees/$SLICE_NAME-await-waves"
 
 ## 1. Check dependencies
 
-For each dependency in the `blocked-by` list, check if the blocking slice is tagged `done`:
+Parse the `blocked-by` field from the slice's frontmatter. For each dependency ID, check if the blocking slice is tagged `landed`:
 
 ```sh
-DEPENDENCY_ID="{from slice blocked-by list}"
+DEPENDENCY_ID="{from frontmatter blocked-by field}"
 ```
 
 ```sh
 ./tracker.sh issue view "$DEPENDENCY_ID" --json labels
 ```
 
-**If any dependency is NOT done**: this slice stays `to-await-waves`. Skip to the handoff with `nextPhase: "to-await-waves"` and `summary: "still blocked by #N, #M"`.
+**If any dependency does NOT have the `landed` label**: this slice stays `to-await-waves`. Skip to the handoff with `nextPhase: "to-await-waves"` and `summary: "still blocked by #N, #M"`.
 
-**If ALL dependencies are done**: continue to step 2.
+**If ALL dependencies have the `landed` label**: continue to step 2.
 
 ## 2. Re-review the plan
 

--- a/reef-pulse/merge-multi.md
+++ b/reef-pulse/merge-multi.md
@@ -50,17 +50,17 @@ Fetch its labels:
 
 For any sibling tagged `to-await-waves`, check their `blocked-by` list. If this merged slice was the last blocker, leave them as `to-await-waves` — the next pulse will dispatch the await-waves phase to re-review their plan before promoting.
 
-Check: are ALL slices for the plan now tagged `done`? If all slices are done, change the plan label from `in-progress` to `to-ratify` (step 4). If not all done, do nothing — more slices are still in progress.
+Check: are ALL slices for the plan now tagged `landed`? If all slices are landed, change the plan label from `in-progress` to `to-ratify` (step 4). If not all landed, do nothing — more slices are still in progress.
 
 ## 3. Close the slice
 
-Close the slice issue. Add label `done`. Remove `to-merge`:
+Close the slice issue. Add label `landed`. Remove `to-merge`:
 
 ```sh
 ./tracker.sh issue close "$SLICE_ID"
 ```
 
-## 4. Update plan tag — if all slices done
+## 4. Update plan tag — if all slices landed
 
 ```sh
 ./tracker.sh issue edit "$PLAN_ID" --remove-label in-progress --add-label to-ratify
@@ -73,7 +73,7 @@ Document judgment calls made during this phase on the PR. Only document decision
 ## Handoff
 
 ```sh
-nextPhase="to-ratify" # or "in-progress" if not all slices done
+nextPhase="to-ratify" # or "in-progress" if not all slices landed
 planPr="—" # multi-slice: no plan PR yet
 summary="Slice {name} merged — {N} of {total} slices complete"
 ```

--- a/reef-pulse/merge-multi.md
+++ b/reef-pulse/merge-multi.md
@@ -54,13 +54,14 @@ Check: are ALL slices for the plan now tagged `landed`? If all slices are landed
 
 ## 3. Close the slice
 
-Close the slice issue. Add label `landed`. Remove `to-merge`:
+Close the slice issue and update its labels:
 
 ```sh
+./tracker.sh issue edit "$SLICE_ID" --remove-label to-merge --add-label landed
 ./tracker.sh issue close "$SLICE_ID"
 ```
 
-## 4. Update plan tag — if all slices landed
+## 4. Update plan tag — if all slices tagged 'landed'
 
 ```sh
 ./tracker.sh issue edit "$PLAN_ID" --remove-label in-progress --add-label to-ratify
@@ -73,7 +74,7 @@ Document judgment calls made during this phase on the PR. Only document decision
 ## Handoff
 
 ```sh
-nextPhase="to-ratify" # or "in-progress" if not all slices landed
+nextPhase="to-ratify" # or "in-progress" if not all slices tagged 'landed'
 planPr="—" # multi-slice: no plan PR yet
 summary="Slice {name} merged — {N} of {total} slices complete"
 ```

--- a/reef-pulse/slice-multi.md
+++ b/reef-pulse/slice-multi.md
@@ -91,6 +91,7 @@ base-branch: $BASE_BRANCH
 target-branch: $TARGET_BRANCH
 pr-branch: —
 type: $PLAN_TYPE
+blocked-by: "#{issue-number}, #{issue-number}"  # omit if no blockers
 
 ---
 
@@ -103,10 +104,6 @@ type: $PLAN_TYPE
 - [ ] {criterion 1}
 - [ ] {criterion 2}
 - [ ] {criterion 3}
-
-## Blocked by
-
-- #{issue-number} {title} (or "None — can start immediately")
 
 ## Success criteria covered
 

--- a/reef-pulse/tracker.sh
+++ b/reef-pulse/tracker.sh
@@ -375,7 +375,7 @@ cmd_close() {
   _tag="$(extract_tag "$_file")"
   _dir="$(dirname "$_file")"
   _basename="$(basename "$_file")"
-  _new_basename="$(echo "$_basename" | sed "s/\\[$_tag\\]/[done]/")"
+  _new_basename="$(echo "$_basename" | sed "s/\\[$_tag\\]/[landed]/")"
   mv "$_file" "$_dir/$_new_basename"
 }
 

--- a/reef-scope/SKILL.md
+++ b/reef-scope/SKILL.md
@@ -66,6 +66,28 @@ Suggest a base branch and a target branch name in a single line. Derive the targ
 
 The user confirms or adjusts. Both values are required before continuing.
 
+## 3b. Conflict anticipation
+
+After the branch discussion, scan for in-flight work that might overlap with this plan. List open issues that share the same `base-branch` and are past `to-scope` (i.e., already in-flight: `to-slice`, `in-progress`, `to-implement`, `to-inspect`, `to-rework`, `to-merge`, `to-ratify`, `to-land`, `to-await-waves`).
+
+```sh
+BASE_BRANCH="{from branch discussion}"
+```
+
+```sh
+./tracker.sh issue list --label to-slice,in-progress,to-implement,to-inspect,to-rework,to-merge,to-ratify,to-land,to-await-waves --json number,title,body,labels
+```
+
+For each returned issue, parse the `base-branch` from its frontmatter. Keep only those whose `base-branch` matches the plan's `$BASE_BRANCH`. Skim each matching issue's plan body to assess whether it touches overlapping areas (same files, same modules, same concepts).
+
+If overlapping in-flight work is found, surface it to the user:
+
+> "From a quick look at current work in progress, this scope might lead to conflicts with #77 and #83. Shall I add them as `blocked-by` in the plan frontmatter so implementation won't start until those land?"
+
+The user confirms or adjusts. If they confirm, the `blocked-by` field will be set in the frontmatter during step 4.
+
+If no overlapping work is found, continue silently.
+
 ## 4. Persist the plan
 
 Set variables from the discussion:

--- a/reef-scope/SKILL.md
+++ b/reef-scope/SKILL.md
@@ -75,7 +75,9 @@ BASE_BRANCH="{from branch discussion}"
 ```
 
 ```sh
-./tracker.sh issue list --label to-slice,in-progress,to-implement,to-inspect,to-rework,to-merge,to-ratify,to-land,to-await-waves --json number,title,body,labels
+for LABEL in to-slice in-progress to-implement to-inspect to-rework to-merge to-ratify to-land to-await-waves; do
+  ./tracker.sh issue list --label "$LABEL" --json number,title,body,labels
+done
 ```
 
 For each returned issue, parse the `base-branch` from its frontmatter. Keep only those whose `base-branch` matches the plan's `$BASE_BRANCH`. Skim each matching issue's plan body to assess whether it touches overlapping areas (same files, same modules, same concepts).

--- a/tests/tracker.test.sh
+++ b/tests/tracker.test.sh
@@ -400,10 +400,10 @@ test_close_plan() {
   t issue create --title "my-feature" --label to-land >/dev/null 2>&1
   t issue close 1 >/dev/null 2>&1
 
-  if [ -f "$TRACKER_PATH/1 my-feature/[done] plan.md" ]; then
-    pass "close plan: renames tag to done"
+  if [ -f "$TRACKER_PATH/1 my-feature/[landed] plan.md" ]; then
+    pass "close plan: renames tag to landed"
   else
-    fail "close plan: renames tag to done" "file not found"
+    fail "close plan: renames tag to landed" "file not found"
   fi
 
   teardown
@@ -417,10 +417,10 @@ test_close_slice() {
   t issue create --title "auth" --label to-merge --parent 1 >/dev/null 2>&1
   t issue close 1-1 >/dev/null 2>&1
 
-  if [ -f "$TRACKER_PATH/1 my-feature/slices/1-1 auth/[done] slice.md" ]; then
-    pass "close slice: renames tag to done"
+  if [ -f "$TRACKER_PATH/1 my-feature/slices/1-1 auth/[landed] slice.md" ]; then
+    pass "close slice: renames tag to landed"
   else
-    fail "close slice: renames tag to done" "file not found"
+    fail "close slice: renames tag to landed" "file not found"
   fi
 
   teardown


### PR DESCRIPTION
closes #87

<details><summary><h3>🦭 Ratify report — 2026/04/21 15:30</h3></summary>

## Final Report

### Status: PASS

### Success criteria

- ✓ SC1: `tracker.sh close` renames tags to `[landed]` instead of `[done]` — verified: `cmd_close` sed replacement at line 378 uses `[landed]`
- ✓ SC2: `test_close_plan` and `test_close_slice` pass with `[landed]` — verified: both assertions updated and 37 tracker tests pass
- ✓ SC3: Slice body template in `slice-multi.md` has `blocked-by` in frontmatter — verified: frontmatter field at line 94, old `## Blocked by` section removed
- ✓ SC4: `await-waves.md` parses `blocked-by` from frontmatter and checks for `landed` label — verified: lines 13, 39, 42, 49, 51 all reference frontmatter parsing and `landed` check
- ✓ SC5: `reef-land` replaces `to-land` with `landed` before closing — verified: already in place at reef-land/SKILL.md line 228 (no change needed)
- ✓ SC6: `reef-scope` step 3b scans in-flight issues on same base-branch and surfaces overlaps — verified: new section at reef-scope/SKILL.md lines 69-89
- ✓ SC7: ORCHESTRATION.md documents `landed` as the tracker-agnostic dependency signal — verified: new "Terminal label: landed" section and updated await-waves/reef-scope references
- ✓ SC8: All existing tests still pass — verified: 318 tests pass (259 orchestration + 37 tracker + 22 worktree)

### Agent decisions to review

All implementation decisions aligned with the plan. All three slice PRs reported no ambiguous choices.

One bonus cleanup: the implementation of #106 removed an accidentally committed `.agents/moonjelly-reef/pulse.lock` runtime artifact from the repo. This is a good change.

### Integration notes

- Minor terminology inconsistency: a few places in `await-waves.md` (line 7), `slice-multi.md` (line 123), `merge-multi.md` (line 73 comment), and `README.md` still use natural-language "done" when describing the concept now formalized as `landed`. These are prose descriptions (not label references), so they are not bugs, but could be tightened in a future pass.
- ORCHESTRATION.md has a `BASE_BRANCH` variable set twice in the reef-scope section (lines 145 and 154) — the first from the conflict-anticipation addition, the second from the pre-existing flow. Not harmful since ORCHESTRATION.md describes sequential steps, but worth noting.
- No naming conflicts, duplicate definitions, or inconsistent patterns between slices.

### Test results

Full suite: 318 passed, 0 failed, 0 skipped (259 orchestration + 37 tracker + 22 worktree).

### Screenshots / video

Not applicable — changes are to agent skill instructions and shell scripts, not a visible UI.

### Parent plan

#87

</details>

### 🪼 Pulse metrics

| Phase | Target | Duration | Tokens | Tool uses | Outcome | Date |
| ----- | ------ | -------- | ------ | --------- | ------- | ---- |
| scope | #87 | 15m 22s | — | — | plan created | 2026-04-20 20:47 |
| slice | #87 | 4m 10s | 63 690 | 40 | ✅ 3 slices created | 2026-04-21 05:21 |
| await-waves | #109 | 0m 17s | 13 314 | 4 | · still blocked | 2026-04-21 05:22 |
| await-waves | #107 | 0m 17s | 13 085 | 3 | · still blocked | 2026-04-21 05:22 |
| implement | #106 | 0m 40s | — | — | ❌ rate limit | 2026-04-21 05:22 |
| ratify | #87 | 2m 53s | 31 944 | 32 | ✅ pass | 2026-04-21 06:51 |
| rework | #87 | 3m 54s | 56 645 | 49 | ✅ rework complete | 2026-04-22 01:00 |
| inspect | #87 | 3m 15s | 47 817 | 37 | ✅ passed | 2026-04-22 01:06 |
| merge | #87 | 2m 50s | 24 812 | 24 | ✅ squash-merged | 2026-04-22 01:10 |
| **Total** | | **33m 38s** | **251 307** | **189** | | |
<!-- end metrics table -->

<details>
<summary><h3>📝 Change requests from human review — 2026/04/22 18:30</h3></summary>

### Gaps

- **Gap 1**: merge-multi.md label operations must use explicit `./tracker.sh issue edit` commands — maps to repo-wide convention

  > Original comment (reef-pulse/merge-multi.md:60): "we should never mention manually to add and remove labels but always always use `./tracker.sh` syntax. can you do a scan on the entire repo if that is the case?"

  Context: The prose at line 57 says "Add label `landed`. Remove `to-merge`" but the command is only `./tracker.sh issue close` which doesn't explicitly handle label transitions. All label add/remove operations must be expressed as `./tracker.sh issue edit --add-label X --remove-label Y` commands. Scan the entire repo for any phase files that mention adding/removing labels in prose without corresponding `./tracker.sh` (or `gh`) commands, and fix them.

- **Gap 2**: merge-multi.md heading wording — trivial

  > Original comment (reef-pulse/merge-multi.md:63): suggestion to change to `## 4. Update plan tag — if all slices tagged 'landed'`

  Context: Use "tagged 'landed'" instead of just "landed" for consistency.

- **Gap 3**: merge-multi.md handoff comment wording — trivial

  > Original comment (reef-pulse/merge-multi.md:76): suggestion to change to `nextPhase="to-ratify" # or "in-progress" if not all slices tagged 'landed'`

  Context: Same wording consistency fix as Gap 2.

- **Gap 4**: Remove `landed` documentation block from ORCHESTRATION.md, add to UBIQUITOUS_LANGUAGE.md — maps to SC7

  > Original comment (ORCHESTRATION.md:36): "let's keep documentation like this as short as possible"

  Context: The 3-paragraph "Terminal label: landed" section in ORCHESTRATION.md should be removed entirely. The term `landed` should be defined in UBIQUITOUS_LANGUAGE.md instead (it's not there yet). ORCHESTRATION.md shouldn't re-explain terms that belong in the ubiquitous language glossary.

- **Gap 5**: Conflict-anticipation command uses comma-separated `--label` which `tracker.sh` doesn't support — maps to SC6

  > Original comment (ORCHESTRATION.md:149): "is this supported by our tracker.sh script as well?"

  Context: `tracker.sh issue list --label` only supports a single label (does a literal glob match). The conflict-anticipation step in `reef-scope/SKILL.md` and `ORCHESTRATION.md` uses `--label to-slice,in-progress,...` which won't work with the local tracker. Fix by issuing separate `tracker.sh issue list --label X` calls per label (or a loop), then merging results.

### New or updated success criteria (if any)

- [ ] All label add/remove operations across all phase files use explicit `./tracker.sh` commands (no prose-only label instructions)
- [ ] `landed` definition exists in UBIQUITOUS_LANGUAGE.md
- [ ] `landed` documentation block removed from ORCHESTRATION.md
- [ ] Conflict-anticipation in reef-scope works with single-label `tracker.sh` (no comma-separated `--label`)

</details>

<details><summary><h3>🦀 Rework — 2026/04/22 19:15</h3></summary>

## Feedback addressed

### Gap 1: merge-multi.md prose-only label operations
- Added explicit `./tracker.sh issue edit "$SLICE_ID" --remove-label to-merge --add-label landed` before the `./tracker.sh issue close` command in merge-multi.md step 3
- Updated the corresponding ORCHESTRATION.md merge-multi section to match
- Scanned the entire repo for prose-only label mentions: only slice-multi.md line 123 remains, which is descriptive prose for the command that immediately follows it (line 130) — no fix needed

### Gap 2: merge-multi.md heading wording
- Changed heading from "if all slices landed" to "if all slices tagged 'landed'"

### Gap 3: merge-multi.md handoff comment wording
- Changed handoff comment from "if not all slices landed" to "if not all slices tagged 'landed'"
- Updated matching line in ORCHESTRATION.md

### Gap 4: Move landed documentation from ORCHESTRATION.md to UBIQUITOUS_LANGUAGE.md
- Removed the 3-paragraph "Terminal label: landed" section from ORCHESTRATION.md
- Added `landed` as an entry in the Tags table in UBIQUITOUS_LANGUAGE.md with definition and aliases to avoid (done, completed, merged, finished)

### Gap 5: Conflict-anticipation single-label tracker.sh compatibility
- Changed comma-separated `--label` call in reef-scope/SKILL.md to a `for` loop issuing one `./tracker.sh issue list --label "$LABEL"` call per label
- Applied the same fix to the ORCHESTRATION.md conflict-anticipation spec

## Test results

Full suite: 322 passed, 0 failed, 0 skipped (263 orchestration + 37 tracker + 22 worktree)

## Judgment calls

None — all changes directly map to explicit review feedback.

</details>

<details><summary><h3>🧿 Inspect review — 2026/04/22 21:45</h3></summary>

## Verdict: PASS

All 8 success criteria verified. Full test suite green (322 passed, 0 failed).

### Success criteria verification

| SC | Criterion | Status | Evidence |
| --- | --- | --- | --- |
| SC1 | `tracker.sh close` renames tags to `[landed]` | PASS | `cmd_close` sed at line 378 uses `[landed]` |
| SC2 | `test_close_plan` and `test_close_slice` pass | PASS | Both assertions updated, 37 tracker tests pass |
| SC3 | Slice template has `blocked-by` in frontmatter | PASS | Frontmatter field at slice-multi.md line 94, old `## Blocked by` section removed |
| SC4 | await-waves parses frontmatter and checks `landed` | PASS | Lines 13, 39, 42, 49, 51 reference frontmatter and `landed` |
| SC5 | reef-land replaces `to-land` with `landed` | PASS | reef-land/SKILL.md line 228 (pre-existing, no change needed) |
| SC6 | reef-scope scans in-flight issues | PASS | New step 3b at reef-scope/SKILL.md lines 69-91, uses per-label for-loop |
| SC7 | ORCHESTRATION.md documents `landed` | PASS | References updated; `landed` term in UBIQUITOUS_LANGUAGE.md |
| SC8 | All existing tests pass | PASS | 322 passed (263 orchestration + 37 tracker + 22 worktree) |

### Rework criteria verification

| Criterion | Status | Evidence |
| --- | --- | --- |
| All label ops use explicit tracker commands | PASS | merge-multi.md has explicit `--remove-label to-merge --add-label landed` before close |
| `landed` in UBIQUITOUS_LANGUAGE.md | PASS | Tags table entry with definition and aliases |
| `landed` block removed from ORCHESTRATION.md | PASS | No "Terminal label" or "tracker-agnostic" prose remains |
| Conflict anticipation uses single-label calls | PASS | for-loop in reef-scope/SKILL.md and ORCHESTRATION.md |

### Observations

- No stale references to `[done]` remain in any skill file or test.
- No debug prints, stale TODOs, or commented-out code found.
- Minor: ORCHESTRATION.md sets `BASE_BRANCH` twice in the reef-scope section (lines 135 and 146). Harmless since the steps are sequential, but noted for awareness. Already flagged in the ratify report.
- No cleanups needed. Codebase is clean.

### Test results

```
263 orchestration tests passed
 37 tracker tests passed
 22 worktree tests passed
322 total, 0 failures
```

</details>
