### PR TITLE
setup.md git-init detection

### DIFF
--- a/reef-pulse/setup.md
+++ b/reef-pulse/setup.md
@@ -10,6 +10,29 @@ printf '\033[36m'; cat reef-pulse/banner.txt; printf '\033[0m'
 
 ## Steps
 
+### 0. Check for git
+
+Worktrees and branches (used by the reef's implement/inspect/merge cycle) require git. Check whether the current project has a git repository:
+
+```sh
+git rev-parse --git-dir 2>/dev/null
+```
+
+- **If git is present** (command succeeds): skip this step silently and continue to step 1.
+- **If git is missing** (command fails): offer to initialize one. Present this message to the user:
+
+> "This project doesn't seem to use git. So I'll treat `{dir}` as the project root folder and init a `.git` folder, is that OK? (It's so the reef can better organise its efforts when multiple tasks are worked on at once)."
+
+Replace `{dir}` with the absolute path to the current working directory.
+
+If the user agrees, run:
+
+```sh
+git init
+```
+
+If the user declines, warn them that the reef cannot function without git and stop setup.
+
 ### 1. Detect issue tracker
 
 Look for clues in the repo:


### PR DESCRIPTION
closes #123 setup.md git-init detection

## Ambiguous choices

None — implementation followed the plan exactly.

## Test results

322 tests passed, 0 failed, 0 skipped. (263 + 37 + 22 across three test suites.)

### 🪼 Pulse metrics

| Phase | Target | Duration | Tokens | Tool uses | Outcome | Date |
| ----- | ------ | -------- | ------ | --------- | ------- | ---- |
| implement | #123 | 3m 47s | 34 901 | 45 | ✅ PR #125 created | 2026-04-22 02:53 |
| inspect | #123 | 2m 13s | 30 279 | 23 | ✅ passed | 2026-04-22 02:56 |
<!-- end metrics table -->

<details><summary><h3>🧿 Inspect review — 2026/04/22 03:10</h3></summary>

**Inspector**: Barreleye  
**Test suite**: 322 passed (263 + 37 + 22), 0 failed  
**Worktree**: clean merge from `local-pr-tracker` — no conflicts

### Acceptance criteria

| # | Criterion | Verdict | Evidence |
|---|-----------|---------|----------|
| 1 | setup.md includes a step that checks for git presence | PASS | Step 0 uses `git rev-parse --git-dir 2>/dev/null` (line 18) |
| 2 | When git is missing, setup.md instructs the agent to offer `git init` with the specified kind message | PASS | Lines 22-24: exact message from spec, lines 28-32: `git init` on acceptance |
| 3 | The message includes the project directory path and explains why git is needed | PASS | `{dir}` placeholder with instruction to replace with cwd (line 26); reason in message text |
| 4 | When git is already present, this step is silently skipped | PASS | Line 21: "skip this step silently and continue to step 1" |

### Drift from plan

None. Implementation follows the issue specification exactly.

### Test coverage note

The change is purely to a markdown agent-instruction file (`setup.md`), not executable code. There is no automated test for the git-init detection step. This is acceptable — testing would require running the setup skill against a non-git directory, which is a behavioral/integration concern outside the unit test suite.

### Cleanups

None needed — diff is clean, no debug artifacts or stale TODOs.

### Verdict

**PASS** — all four acceptance criteria met, test suite green, no drift.

</details>
