### PR TITLE
tracker.sh pr merge command

### DIFF
--- a/reef-pulse/tracker.sh
+++ b/reef-pulse/tracker.sh
@@ -13,6 +13,7 @@
 #   tracker.sh pr create    <id> --base X --head Y --body B
 #   tracker.sh pr view      <id> --json body,headRefName,baseRefName
 #   tracker.sh pr edit      <id> [--body "..."] [--add-label X] [--remove-label X]
+#   tracker.sh pr merge     <id> [--squash] [--delete-branch]
 set -eu
 
 # ============================================================
@@ -568,6 +569,52 @@ pr_edit() {
   printf '\n%s' "$_body" >> "$_progress"
 }
 
+pr_merge() {
+  _id="$1"; shift
+  _squash=false
+  _delete_branch=false
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --squash) _squash=true; shift ;;
+      --delete-branch) _delete_branch=true; shift ;;
+      *) echo "Error: unknown argument: $1" >&2; exit 1 ;;
+    esac
+  done
+
+  _progress="$(resolve_progress_file "$_id")" || { echo "Error: progress.md not found for $_id" >&2; exit 1; }
+  if [ -z "$_progress" ]; then
+    echo "Error: progress.md not found for $_id" >&2
+    exit 1
+  fi
+
+  # Read head and base from frontmatter
+  _head="$(sed -n 's/^head: *//p' "$_progress" | head -1)"
+  _base="$(sed -n 's/^base: *//p' "$_progress" | head -1)"
+
+  if [ -z "$_head" ] || [ -z "$_base" ]; then
+    echo "Error: progress.md missing head or base frontmatter" >&2
+    exit 1
+  fi
+
+  # Checkout the base branch
+  git checkout "$_base" >/dev/null 2>&1
+
+  # Perform the merge
+  if [ "$_squash" = true ]; then
+    git merge --squash "$_head" >/dev/null 2>&1
+    git commit -m "Squash merge $_head into $_base" >/dev/null 2>&1
+  else
+    git merge --no-ff "$_head" -m "Merge $_head into $_base" >/dev/null 2>&1
+  fi
+
+  # Delete the head branch if requested
+  if [ "$_delete_branch" = true ]; then
+    git branch -D "$_head" >/dev/null 2>&1 || true
+    git push origin --delete "$_head" >/dev/null 2>&1 || true
+  fi
+}
+
 # ============================================================
 # Main dispatch
 # ============================================================
@@ -627,6 +674,10 @@ case "$CMD_GROUP" in
         if [ "$IS_COMMITTED" = true ]; then committed_enter; fi
         pr_edit "$@"
         if [ "$IS_COMMITTED" = true ]; then committed_exit "tracker: pr edit $1"; fi
+        ;;
+      merge)
+        if [ $# -lt 1 ]; then echo "Error: pr merge requires an ID" >&2; exit 1; fi
+        pr_merge "$@"
         ;;
       *) echo "Error: unknown pr subcommand: $SUBCMD" >&2; exit 1 ;;
     esac

--- a/tests/tracker.test.sh
+++ b/tests/tracker.test.sh
@@ -774,6 +774,177 @@ test_pr_edit_label_noop() {
 }
 
 # ============================================================
+# PR MERGE — #121
+# ============================================================
+
+# Setup helper that creates a git repo with origin, a feature branch with a commit,
+# and a progress.md so pr merge can read head/base.
+setup_merge() {
+  TEST_ROOT="$(mktemp -d)"
+  ORIGIN="$TEST_ROOT/origin.git"
+  REPO="$TEST_ROOT/repo"
+  TRACKER_PATH="$TEST_ROOT/tracker"
+
+  git init --bare "$ORIGIN" >/dev/null 2>&1
+  git clone "$ORIGIN" "$REPO" >/dev/null 2>&1
+  cd "$REPO"
+  git checkout -b main >/dev/null 2>&1
+  echo "init" > README.md
+  git add README.md
+  git commit -m "initial commit" >/dev/null 2>&1
+  git push -u origin main >/dev/null 2>&1
+
+  # Create feature branch with a commit
+  git checkout -b feat/my-feature >/dev/null 2>&1
+  echo "feature work" > feature.txt
+  git add feature.txt
+  git commit -m "add feature" >/dev/null 2>&1
+  git push -u origin feat/my-feature >/dev/null 2>&1
+
+  # Back to main for the merge
+  git checkout main >/dev/null 2>&1
+
+  # Create tracker dir and config
+  mkdir -p "$TRACKER_PATH"
+  mkdir -p "$REPO/.agents/moonjelly-reef"
+  cat > "$REPO/.agents/moonjelly-reef/config.md" <<CONF
+---
+tracker: local-tracker-gitignored
+tracker-path: $TRACKER_PATH
+tracker-branch: —
+---
+CONF
+
+  # Create issue and progress.md
+  mkdir -p "$TRACKER_PATH/1 my-feature"
+  echo "plan content" > "$TRACKER_PATH/1 my-feature/[to-inspect] plan.md"
+  cat > "$TRACKER_PATH/1 my-feature/progress.md" <<PROGRESS
+---
+head: feat/my-feature
+base: main
+---
+
+implementation report
+PROGRESS
+}
+
+test_pr_merge_squash() {
+  setup_merge
+  cd "$REPO"
+
+  t pr merge 1 --squash --delete-branch >/dev/null 2>&1
+
+  # Should be on main with the feature file present
+  current_branch="$(git rev-parse --abbrev-ref HEAD)"
+  if [ "$current_branch" = "main" ]; then
+    pass "pr merge squash: stays on base branch"
+  else
+    fail "pr merge squash: stays on base branch" "on: $current_branch"
+  fi
+
+  if [ -f "feature.txt" ]; then
+    pass "pr merge squash: feature file present after merge"
+  else
+    fail "pr merge squash: feature file present after merge" "feature.txt not found"
+  fi
+
+  # Squash merge should create a single commit (not a merge commit with two parents)
+  parent_count="$(git cat-file -p HEAD | grep -c '^parent' || true)"
+  if [ "$parent_count" -eq 1 ]; then
+    pass "pr merge squash: single parent (squash merge)"
+  else
+    fail "pr merge squash: single parent (squash merge)" "parents: $parent_count"
+  fi
+
+  teardown
+}
+
+test_pr_merge_regular() {
+  setup_merge
+  cd "$REPO"
+
+  t pr merge 1 --delete-branch >/dev/null 2>&1
+
+  if [ -f "feature.txt" ]; then
+    pass "pr merge regular: feature file present after merge"
+  else
+    fail "pr merge regular: feature file present after merge" "feature.txt not found"
+  fi
+
+  # Regular merge should create a merge commit with two parents
+  parent_count="$(git cat-file -p HEAD | grep -c '^parent' || true)"
+  if [ "$parent_count" -eq 2 ]; then
+    pass "pr merge regular: two parents (merge commit)"
+  else
+    fail "pr merge regular: two parents (merge commit)" "parents: $parent_count"
+  fi
+
+  teardown
+}
+
+test_pr_merge_deletes_head_branch_locally() {
+  setup_merge
+  cd "$REPO"
+
+  t pr merge 1 --squash --delete-branch >/dev/null 2>&1
+
+  if git rev-parse --verify feat/my-feature >/dev/null 2>&1; then
+    fail "pr merge: deletes head branch locally" "branch still exists"
+  else
+    pass "pr merge: deletes head branch locally"
+  fi
+
+  teardown
+}
+
+test_pr_merge_deletes_head_branch_from_origin() {
+  setup_merge
+  cd "$REPO"
+
+  t pr merge 1 --squash --delete-branch >/dev/null 2>&1
+
+  git fetch origin --prune >/dev/null 2>&1
+  if git rev-parse --verify origin/feat/my-feature >/dev/null 2>&1; then
+    fail "pr merge: deletes head branch from origin" "remote branch still exists"
+  else
+    pass "pr merge: deletes head branch from origin"
+  fi
+
+  teardown
+}
+
+test_pr_merge_no_progress_fails() {
+  setup
+  cd "$REPO"
+
+  t issue create --title "no-pr" --label to-implement >/dev/null 2>&1
+
+  if t pr merge 1 --squash --delete-branch >/dev/null 2>&1; then
+    fail "pr merge: fails without progress.md" "succeeded"
+  else
+    pass "pr merge: fails without progress.md"
+  fi
+
+  teardown
+}
+
+test_pr_merge_commit_message() {
+  setup_merge
+  cd "$REPO"
+
+  t pr merge 1 --squash --delete-branch >/dev/null 2>&1
+
+  msg="$(git log -1 --format='%s')"
+  if echo "$msg" | grep -q "feat/my-feature"; then
+    pass "pr merge: commit message references head branch"
+  else
+    fail "pr merge: commit message references head branch" "msg: $msg"
+  fi
+
+  teardown
+}
+
+# ============================================================
 # PR DISPATCH — #120
 # ============================================================
 
@@ -834,6 +1005,12 @@ test_pr_view_fields
 test_pr_view_comments_reviews
 test_pr_edit_body
 test_pr_edit_label_noop
+test_pr_merge_squash
+test_pr_merge_regular
+test_pr_merge_deletes_head_branch_locally
+test_pr_merge_deletes_head_branch_from_origin
+test_pr_merge_no_progress_fails
+test_pr_merge_commit_message
 test_pr_dispatch
 
 echo ""


### PR DESCRIPTION
closes #121 tracker.sh pr merge command

## Ambiguous choices

None — implementation followed the plan exactly.

## Test results

62 tests passed, 0 failed, 0 skipped.

6 new tests added:
- pr merge squash: stays on base branch, feature file present, single parent (squash merge)
- pr merge regular: feature file present, two parents (merge commit)
- pr merge: deletes head branch locally
- pr merge: deletes head branch from origin
- pr merge: fails without progress.md
- pr merge: commit message references head branch

### 🪼 Pulse metrics

| Phase | Target | Duration | Tokens | Tool uses | Outcome | Date |
| ----- | ------ | -------- | ------ | --------- | ------- | ---- |
| implement | #121 | 3m 35s | 68 222 | 41 | ✅ PR #126 created | 2026-04-22 03:09 |
| inspect | #121 | 2m 48s | 30 847 | 31 | ✅ passed | 2026-04-22 03:13 |
<!-- end metrics table -->

<details><summary><h3>Inspect review — 2026/04/22 03:30</h3></summary>

**Test suite:** 347 tests passed (263 + 62 + 22), 0 failed.

**Acceptance criteria check:**

| # | Criterion | Verdict |
|---|-----------|---------|
| AC1 | `pr merge` reads head/base from progress.md frontmatter | PASS — `resolve_progress_file` + `sed` parsing at L585-593 |
| AC2 | `git merge --squash` when `--squash` passed, regular merge otherwise | PASS — L604-608: squash vs `--no-ff` branch |
| AC3 | Commits merge with appropriate message | PASS — "Squash merge X into Y" / "Merge X into Y" |
| AC4 | Deletes head branch locally and from origin | PASS — `branch -D` + `push origin --delete` at L612-614 |
| AC5 | Exits with error if progress.md not found | PASS — double guard (subshell exit + empty check) at L585-589 |
| AC6 | Tests cover pr merge with --squash --delete-branch in real git repo | PASS — 6 tests using bare origin + clone setup |

**Drift from plan:** None. Implementation matches the slice exactly.

**Ambiguous choices:** The implementer reported none, and that matches what I see.

**Observations:**
- `pr merge` dispatch correctly omits `committed_enter`/`committed_exit` wrapping since it operates on the working repo, not tracker files.
- Error handling is consistent with `pr_view` and `pr_edit` patterns.
- `|| true` on branch deletion commands is appropriate (graceful when remote is absent).
- No debug artifacts, no TODOs, no trailing whitespace. Code is clean.

**Gaps found:** None.

</details>
