### PR TITLE
Phase docs switch to tracker.sh pr syntax

### DIFF
--- a/ORCHESTRATION.md
+++ b/ORCHESTRATION.md
@@ -6,7 +6,7 @@ The test runner checks: (1) each command string exists in the .md file, (2) they
 
 `if` means the operation is conditional — it must exist in the .md but only runs when the condition holds.
 
-Tracker commands use `./tracker.sh issue ...` syntax.
+Tracker commands use `./tracker.sh issue ...` and `./tracker.sh pr ...` syntax.
 For GitHub: replace `./tracker.sh` with `gh`.
 For MCP trackers (ClickUp, Jira, Linear): use equivalent MCP tool calls.
 
@@ -91,7 +91,7 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
   ```
 - update-pr-body — if planPr is not "—"
   ```sh
-  gh pr edit "$PLAN_PR_NUMBER" --body "$PLAN_PR_BODY"
+  ./tracker.sh pr edit "$PLAN_PR_NUMBER" --body "$PLAN_PR_BODY"
   ```
 - present-human-items — if HITL mode and first iteration
   - contains: `to-scope`
@@ -172,7 +172,7 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
 - fetch-context
   ```sh
   ./tracker.sh issue view "$PLAN_ID" --json body,title,labels # if PLAN_ID known
-  gh pr view "$PR_NUMBER" --json number,body,headRefName,baseRefName,comments,reviews # if PR_NUMBER known
+  ./tracker.sh pr view "$PR_NUMBER" --json number,body,headRefName,baseRefName,comments,reviews # if PR_NUMBER known
   ```
 - set-variables
   ```sh
@@ -183,7 +183,7 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
   ```
 - fetch-pr-comments-and-reviews
   ```sh
-  gh pr view "$PR_NUMBER" --json comments,reviews # if not already fetched
+  ./tracker.sh pr view "$PR_NUMBER" --json comments,reviews # if not already fetched
   ```
 - phase-specific
 - set-variables — if change-requests
@@ -192,7 +192,7 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
   ```
 - update-pr-body — if change-requests
   ```sh
-  gh pr edit "$PR_NUMBER" --body "$PR_BODY"
+  ./tracker.sh pr edit "$PR_NUMBER" --body "$PR_BODY"
   ```
 - update-tracker — if change-requests
   ```sh
@@ -205,11 +205,11 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
   ```
 - sync-pr-label — if change-requests
   ```sh
-  gh pr edit "$PR_NUMBER" --remove-label to-land --add-label to-rework
+  ./tracker.sh pr edit "$PR_NUMBER" --remove-label to-land --add-label to-rework
   ```
 - pre-merge-check — if approved
   ```sh
-  gh pr view "$PR_NUMBER" --json mergeStateStatus -q .mergeStateStatus
+  ./tracker.sh pr view "$PR_NUMBER" --json mergeStateStatus -q .mergeStateStatus
   ```
 - set-variables — if approved
   ```sh
@@ -217,8 +217,8 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
   ```
 - pr-merge — if approved
   ```sh
-  gh pr merge "$PR_NUMBER" --"$MERGE_STRATEGY" --delete-branch
-  gh pr edit "$PR_NUMBER" --remove-label to-land --add-label landed
+  ./tracker.sh pr merge "$PR_NUMBER" --"$MERGE_STRATEGY" --delete-branch
+  ./tracker.sh pr edit "$PR_NUMBER" --remove-label to-land --add-label landed
   ```
 - pull
   - contains: `Pull the merged changes into the current branch if it matches the base branch:`
@@ -357,11 +357,11 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
   ```
 - pr-create
   ```sh
-  gh pr create --base "$TARGET_BRANCH" --title "$SLICE_NAME" --body "$REPORT" --label to-inspect
+  ./tracker.sh pr create --base "$TARGET_BRANCH" --title "$SLICE_NAME" --body "$REPORT" --label to-inspect
   ```
 - set-variables
   ```sh
-  PR_NUMBER="{from gh pr create output}"
+  PR_NUMBER="{from pr create output}"
   SLICE_BODY="{slice/plan body with PR reference and pr-branch updated}"
   ```
 - update-tracker
@@ -409,15 +409,15 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
   ```
 - update-pr-body
   ```sh
-  PR_NUMBER="{from slice body}" # if not found, try gh pr list --search
-  PR_BODY=$(gh pr view "$PR_NUMBER" --json body -q .body)
+  PR_NUMBER="{from slice body}" # if not found, try ./tracker.sh pr list --search
+  PR_BODY=$(./tracker.sh pr view "$PR_NUMBER" --json body -q .body)
   REPORT="{inspect-report}" # <details><summary><h3>🧿 Inspect review — {yyyy/MM/dd HH:mm}</h3></summary>{report-content}</details>
   PR_BODY="$PR_BODY\n\n$REPORT"
-  gh pr edit "$PR_NUMBER" --body "$PR_BODY"
+  ./tracker.sh pr edit "$PR_NUMBER" --body "$PR_BODY"
   ```
 - update-tracker
-  - pass: `./tracker.sh issue edit "$SLICE_ID" --remove-label to-inspect --add-label to-merge` + `gh pr edit "$PR_NUMBER" --remove-label to-inspect --add-label to-merge`
-  - fail: `./tracker.sh issue edit "$SLICE_ID" --remove-label to-inspect --add-label to-rework` + `gh pr edit "$PR_NUMBER" --remove-label to-inspect --add-label to-rework`
+  - pass: `./tracker.sh issue edit "$SLICE_ID" --remove-label to-inspect --add-label to-merge` + `./tracker.sh pr edit "$PR_NUMBER" --remove-label to-inspect --add-label to-merge`
+  - fail: `./tracker.sh issue edit "$SLICE_ID" --remove-label to-inspect --add-label to-rework` + `./tracker.sh pr edit "$PR_NUMBER" --remove-label to-inspect --add-label to-rework`
 - exit-worktree
   ```sh
   ./worktree-exit.sh --path "$WORKTREE_PATH"
@@ -460,15 +460,15 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
   ```
 - update-pr-body
   ```sh
-  PR_BODY=$(gh pr view "$PR_NUMBER" --json body -q .body)
+  PR_BODY=$(./tracker.sh pr view "$PR_NUMBER" --json body -q .body)
   REPORT="{rework-report}" # <details><summary><h3>🦀 Rework — {yyyy/MM/dd HH:mm}</h3></summary>{report-content}</details>
   PR_BODY="$PR_BODY\n\n$REPORT"
-  gh pr edit "$PR_NUMBER" --body "$PR_BODY"
+  ./tracker.sh pr edit "$PR_NUMBER" --body "$PR_BODY"
   ```
 - update-tracker
   ```sh
   ./tracker.sh issue edit "$ISSUE_ID" --remove-label to-rework --add-label to-inspect
-  gh pr edit "$PR_NUMBER" --remove-label to-rework --add-label to-inspect
+  ./tracker.sh pr edit "$PR_NUMBER" --remove-label to-rework --add-label to-inspect
   ```
 - exit-worktree
   ```sh
@@ -553,7 +553,7 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
   ```
 - pre-merge-check
   ```sh
-  gh pr view "$PR_NUMBER" --json mergeStateStatus -q .mergeStateStatus
+  ./tracker.sh pr view "$PR_NUMBER" --json mergeStateStatus -q .mergeStateStatus
   ```
 - enter-worktree
   - contains: `Enter a worktree forked from $PR_BRANCH (not $TARGET_BRANCH) so you are testing the PR code with the latest target merged in`
@@ -567,7 +567,7 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
 - update-tracker — if tests-fail
   ```sh
   ./tracker.sh issue edit "$SLICE_ID" --remove-label to-merge --add-label to-rework
-  gh pr edit "$PR_NUMBER" --remove-label to-merge --add-label to-rework
+  ./tracker.sh pr edit "$PR_NUMBER" --remove-label to-merge --add-label to-rework
   ```
 - exit-worktree
   ```sh
@@ -583,7 +583,7 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
 - update-tracker
   ```sh
   ./tracker.sh issue edit "$PLAN_ID" --remove-label to-merge --add-label to-ratify
-  gh pr edit "$PR_NUMBER" --remove-label to-merge --add-label to-ratify
+  ./tracker.sh pr edit "$PR_NUMBER" --remove-label to-merge --add-label to-ratify
   ```
 - handoff
   ```sh
@@ -606,8 +606,8 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
   ```
 - pr-merge
   ```sh
-  gh pr merge "$PR_NUMBER" --"$MERGE_STRATEGY" --delete-branch
-  gh pr edit "$PR_NUMBER" --remove-label to-merge --add-label landed
+  ./tracker.sh pr merge "$PR_NUMBER" --"$MERGE_STRATEGY" --delete-branch
+  ./tracker.sh pr edit "$PR_NUMBER" --remove-label to-merge --add-label landed
   ```
 - check-siblings-and-completion
   ```sh
@@ -666,16 +666,16 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
   ```sh
   REPORT="{ratify-report}" # <details><summary><h3>🦭 Ratify report — {yyyy/MM/dd HH:mm}</h3></summary>{report-content}</details>
   # if no PR exists:
-  gh pr create --base "$BASE_BRANCH" --head "$TARGET_BRANCH" --title "$PLAN_TITLE" --body "$REPORT" --label to-ratify
+  ./tracker.sh pr create --base "$BASE_BRANCH" --head "$TARGET_BRANCH" --title "$PLAN_TITLE" --body "$REPORT" --label to-ratify
   # if PR exists, append:
   PR_NUMBER="{from pr create output or existing PR}"
-  PR_BODY=$(gh pr view "$PR_NUMBER" --json body -q .body)
+  PR_BODY=$(./tracker.sh pr view "$PR_NUMBER" --json body -q .body)
   PR_BODY="$PR_BODY\n\n$REPORT"
-  gh pr edit "$PR_NUMBER" --body "$PR_BODY"
+  ./tracker.sh pr edit "$PR_NUMBER" --body "$PR_BODY"
   ```
 - update-tracker
-  - pass: `./tracker.sh issue edit "$PLAN_ID" --remove-label to-ratify --add-label to-land` + `gh pr edit "$PR_NUMBER" --remove-label to-ratify --add-label to-land`
-  - fail: `./tracker.sh issue edit "$PLAN_ID" --remove-label to-ratify --add-label to-rework` + `gh pr edit "$PR_NUMBER" --remove-label to-ratify --add-label to-rework`
+  - pass: `./tracker.sh issue edit "$PLAN_ID" --remove-label to-ratify --add-label to-land` + `./tracker.sh pr edit "$PR_NUMBER" --remove-label to-ratify --add-label to-land`
+  - fail: `./tracker.sh issue edit "$PLAN_ID" --remove-label to-ratify --add-label to-rework` + `./tracker.sh pr edit "$PR_NUMBER" --remove-label to-ratify --add-label to-rework`
 - exit-worktree
   ```sh
   ./worktree-exit.sh --path "$WORKTREE_PATH"

--- a/reef-land/SKILL.md
+++ b/reef-land/SKILL.md
@@ -7,7 +7,7 @@ description: Present the final report to the human for review. Human approves (m
 
 > **Shell blocks are literal commands** — `./tracker.sh` is a real script next to this file. Execute it as written; do not substitute with raw git commands.
 >
-> **Tracker note**: Commands below use `./tracker.sh` syntax for issue operations. For local-tracker projects, run `./tracker.sh` directly. For GitHub, replace `./tracker.sh` with `gh`. For MCP trackers (ClickUp, Jira, Linear), use equivalent MCP tool calls. PR operations always use `gh` directly regardless of tracker.
+> **Tracker note**: Commands below use `./tracker.sh` syntax for both issue and PR operations. For local-tracker projects, run `./tracker.sh` directly. For GitHub, replace `./tracker.sh` with `gh`. For MCP trackers (ClickUp, Jira, Linear), use equivalent MCP tool calls.
 
 ## Input
 
@@ -30,7 +30,7 @@ Use whichever identifier you have to look up the other:
   ```
 - If you have `PR_NUMBER`: read the PR to find the plan issue reference.
   ```sh
-  gh pr view "$PR_NUMBER" --json number,body,headRefName,baseRefName,comments,reviews # if PR_NUMBER known
+  ./tracker.sh pr view "$PR_NUMBER" --json number,body,headRefName,baseRefName,comments,reviews # if PR_NUMBER known
   ```
 
 Now set all variables:
@@ -111,7 +111,7 @@ Ask the human:
 If (2): open the PR in the browser:
 
 ```sh
-gh pr view "$PR_NUMBER" --web
+./tracker.sh pr view "$PR_NUMBER" --web
 ```
 
 Then say: "Take your time reviewing. Leave any comments on the PR, then let me know when you're ready to continue." Wait for the human. When they return, re-check for comments and return to the top of step 2.
@@ -177,7 +177,7 @@ PR_BODY="{current PR body with gap report appended in <details><summary> block}"
 ```
 
 ```sh
-gh pr edit "$PR_NUMBER" --body "$PR_BODY"
+./tracker.sh pr edit "$PR_NUMBER" --body "$PR_BODY"
 ./tracker.sh issue edit "$PLAN_ID" --remove-label to-land --add-label to-rework
 ```
 
@@ -186,7 +186,7 @@ If the discussion changed any plan-level Decisions, Stories, or Success Criteria
 ```sh
 PLAN_BODY=$(./tracker.sh issue view "$PLAN_ID" --json body)
 ./tracker.sh issue edit "$PLAN_ID" --body "$PLAN_BODY"
-gh pr edit "$PR_NUMBER" --remove-label to-land --add-label to-rework
+./tracker.sh pr edit "$PR_NUMBER" --remove-label to-land --add-label to-rework
 ```
 
 Tell the human:
@@ -212,7 +212,7 @@ Tell the human: "Created follow-up issue #{N}." Then continue to **step 5 (Appro
 Check merge status first:
 
 ```sh
-gh pr view "$PR_NUMBER" --json mergeStateStatus -q .mergeStateStatus
+./tracker.sh pr view "$PR_NUMBER" --json mergeStateStatus -q .mergeStateStatus
 ```
 
 If the PR cannot be merged (conflicts, failing checks, branch protection), tell the human what's blocking and exit. Do not force-merge.
@@ -224,8 +224,8 @@ MERGE_STRATEGY="{from .agents/moonjelly-reef/config.md merge-strategy field}"
 ```
 
 ```sh
-gh pr merge "$PR_NUMBER" --"$MERGE_STRATEGY" --delete-branch
-gh pr edit "$PR_NUMBER" --remove-label to-land --add-label landed
+./tracker.sh pr merge "$PR_NUMBER" --"$MERGE_STRATEGY" --delete-branch
+./tracker.sh pr edit "$PR_NUMBER" --remove-label to-land --add-label landed
 ```
 
 Pull the merged changes into the current branch if it matches the base branch:

--- a/reef-pulse/SKILL.md
+++ b/reef-pulse/SKILL.md
@@ -9,7 +9,7 @@ Before starting, read `.agents/moonjelly-reef/config.md` — it tells you the is
 
 > **Shell blocks are literal commands** — `./tracker.sh` is a real script next to this file. Execute it as written; do not substitute with raw git commands.
 >
-> **Tracker note**: Commands below use `./tracker.sh` syntax. For local-tracker projects, run `./tracker.sh` directly. For GitHub, replace `./tracker.sh` with `gh`. For MCP trackers (ClickUp, Jira, Linear), use equivalent MCP tool calls.
+> **Tracker note**: Commands below use `./tracker.sh` syntax for both issue and PR operations. For local-tracker projects, run `./tracker.sh` directly. For GitHub, replace `./tracker.sh` with `gh`. For MCP trackers (ClickUp, Jira, Linear), use equivalent MCP tool calls.
 
 You are the orchestrator. You scan, dispatch, and exit. You hold no state — labels are the state.
 
@@ -213,7 +213,7 @@ Use `planPr` from the handoff to determine the target PR. If `planPr` is `—`, 
 ```sh
 PLAN_PR_NUMBER="$planPr" # from handoff — never read issue bodies for this
 PLAN_PR_BODY="{current plan PR body with metrics rows inserted into the table}"
-gh pr edit "$PLAN_PR_NUMBER" --body "$PLAN_PR_BODY"
+./tracker.sh pr edit "$PLAN_PR_NUMBER" --body "$PLAN_PR_BODY"
 ```
 
 #### Total row on ratify-to-land

--- a/reef-pulse/implement.md
+++ b/reef-pulse/implement.md
@@ -4,7 +4,7 @@ Before starting, read `.agents/moonjelly-reef/config.md` — it tells you the is
 
 > **Shell blocks are literal commands** — `./worktree-enter.sh`, `./worktree-exit.sh`, `./commit.sh`, and `./tracker.sh` are real scripts next to this file. Execute them as written; do not substitute with raw git commands.
 >
-> **Tracker note**: Commands below use `./tracker.sh` syntax. For local-tracker projects, run `./tracker.sh` directly. For GitHub, replace `./tracker.sh` with `gh`. For MCP trackers (ClickUp, Jira, Linear), use equivalent MCP tool calls.
+> **Tracker note**: Commands below use `./tracker.sh` syntax for both issue and PR operations. For local-tracker projects, run `./tracker.sh` directly. For GitHub, replace `./tracker.sh` with `gh`. For MCP trackers (ClickUp, Jira, Linear), use equivalent MCP tool calls.
 
 > **AFK skill**: this skill runs without human interaction. When in doubt: check the plan, make your best judgment, move on. Never block waiting for human input.
 
@@ -122,13 +122,13 @@ REPORT="{report-content}" # starts with: closes #$SLICE_ID $SLICE_NAME\n\n
 ```
 
 ```sh
-gh pr create --base "$TARGET_BRANCH" --title "$SLICE_NAME" --body "$REPORT" --label to-inspect
+./tracker.sh pr create --base "$TARGET_BRANCH" --title "$SLICE_NAME" --body "$REPORT" --label to-inspect
 ```
 
 The PR targets the **target branch** (which equals `{base-branch}` for single-slice work).
 
 ```sh
-PR_NUMBER="{from gh pr create output}"
+PR_NUMBER="{from pr create output}"
 SLICE_BODY="{slice/plan body with PR reference and pr-branch updated}"
 ```
 

--- a/reef-pulse/inspect.md
+++ b/reef-pulse/inspect.md
@@ -2,7 +2,7 @@
 
 > **Shell blocks are literal commands** — `./worktree-enter.sh`, `./worktree-exit.sh`, `./commit.sh`, and `./tracker.sh` are real scripts next to this file. Execute them as written; do not substitute with raw git commands.
 >
-> **Tracker note**: Commands below use `./tracker.sh` syntax. For local-tracker projects, run `./tracker.sh` directly. For GitHub, replace `./tracker.sh` with `gh`. For MCP trackers (ClickUp, Jira, Linear), use equivalent MCP tool calls.
+> **Tracker note**: Commands below use `./tracker.sh` syntax for both issue and PR operations. For local-tracker projects, run `./tracker.sh` directly. For GitHub, replace `./tracker.sh` with `gh`. For MCP trackers (ClickUp, Jira, Linear), use equivalent MCP tool calls.
 
 > **AFK skill**: this skill runs without human interaction. When in doubt: check the plan, make your best judgment, move on. Never block waiting for human input.
 
@@ -110,16 +110,16 @@ Document judgment calls made during this phase on the PR. Only document decision
 
 ### 6. Update the PR
 
-Set the PR number from the slice body. If not found there, try `gh pr list --search`. If PR_NUMBER is nowhere to be found, label the issue `pr-missing` and stop.
+Set the PR number from the slice body. If not found there, try `./tracker.sh pr list --search`. If PR_NUMBER is nowhere to be found, label the issue `pr-missing` and stop.
 
 Read the current PR body, then append the inspect report as a collapsible block:
 
 ```sh
-PR_NUMBER="{from slice body}" # if not found, try gh pr list --search
-PR_BODY=$(gh pr view "$PR_NUMBER" --json body -q .body)
+PR_NUMBER="{from slice body}" # if not found, try ./tracker.sh pr list --search
+PR_BODY=$(./tracker.sh pr view "$PR_NUMBER" --json body -q .body)
 REPORT="{inspect-report}" # <details><summary><h3>🧿 Inspect review — {yyyy/MM/dd HH:mm}</h3></summary>{report-content}</details>
 PR_BODY="$PR_BODY\n\n$REPORT"
-gh pr edit "$PR_NUMBER" --body "$PR_BODY"
+./tracker.sh pr edit "$PR_NUMBER" --body "$PR_BODY"
 ```
 
 ### 7. Verdict
@@ -128,14 +128,14 @@ gh pr edit "$PR_NUMBER" --body "$PR_BODY"
 
 ```sh
 ./tracker.sh issue edit "$SLICE_ID" --remove-label to-inspect --add-label to-merge
-gh pr edit "$PR_NUMBER" --remove-label to-inspect --add-label to-merge
+./tracker.sh pr edit "$PR_NUMBER" --remove-label to-inspect --add-label to-merge
 ```
 
 **If gaps are found:**
 
 ```sh
 ./tracker.sh issue edit "$SLICE_ID" --remove-label to-inspect --add-label to-rework
-gh pr edit "$PR_NUMBER" --remove-label to-inspect --add-label to-rework
+./tracker.sh pr edit "$PR_NUMBER" --remove-label to-inspect --add-label to-rework
 ```
 
 Leave specific review comments on the PR for each gap. Be precise — tell the implementer exactly what's wrong and what "fixed" looks like.

--- a/reef-pulse/merge-multi.md
+++ b/reef-pulse/merge-multi.md
@@ -4,7 +4,7 @@ Multi-slice merge flow — delegated from [merge.md](merge.md).
 
 > **Shell blocks are literal commands** — `./tracker.sh` is a real script next to this file. Execute it as written; do not substitute with raw git commands.
 >
-> **Tracker note**: Commands below use `./tracker.sh` syntax. For local-tracker projects, run `./tracker.sh` directly. For GitHub, replace `./tracker.sh` with `gh`. For MCP trackers (ClickUp, Jira, Linear), use equivalent MCP tool calls.
+> **Tracker note**: Commands below use `./tracker.sh` syntax for both issue and PR operations. For local-tracker projects, run `./tracker.sh` directly. For GitHub, replace `./tracker.sh` with `gh`. For MCP trackers (ClickUp, Jira, Linear), use equivalent MCP tool calls.
 
 > **AFK skill**: this skill runs without human interaction. When in doubt: check the plan, make your best judgment, move on. Never block waiting for human input.
 
@@ -24,8 +24,8 @@ SLICE_ID="$ISSUE_ID"
 
 ```sh
 MERGE_STRATEGY="{from .agents/moonjelly-reef/config.md merge-strategy field}"
-gh pr merge "$PR_NUMBER" --"$MERGE_STRATEGY" --delete-branch
-gh pr edit "$PR_NUMBER" --remove-label to-merge --add-label landed
+./tracker.sh pr merge "$PR_NUMBER" --"$MERGE_STRATEGY" --delete-branch
+./tracker.sh pr edit "$PR_NUMBER" --remove-label to-merge --add-label landed
 ```
 
 ## 2. Check siblings and plan completion

--- a/reef-pulse/merge-single.md
+++ b/reef-pulse/merge-single.md
@@ -4,7 +4,7 @@ Single-slice merge path — delegated from [merge.md](merge.md).
 
 > **Shell blocks are literal commands** — `./tracker.sh` is a real script next to this file. Execute it as written; do not substitute with raw git commands.
 >
-> **Tracker note**: Commands below use `./tracker.sh` syntax. For local-tracker projects, run `./tracker.sh` directly. For GitHub, replace `./tracker.sh` with `gh`. For MCP trackers (ClickUp, Jira, Linear), use equivalent MCP tool calls.
+> **Tracker note**: Commands below use `./tracker.sh` syntax for both issue and PR operations. For local-tracker projects, run `./tracker.sh` directly. For GitHub, replace `./tracker.sh` with `gh`. For MCP trackers (ClickUp, Jira, Linear), use equivalent MCP tool calls.
 
 > **AFK skill**: this skill runs without human interaction. When in doubt: check the plan, make your best judgment, move on. Never block waiting for human input.
 
@@ -24,7 +24,7 @@ Remove `to-merge`, add `to-ratify`:
 
 ```sh
 ./tracker.sh issue edit "$PLAN_ID" --remove-label to-merge --add-label to-ratify
-gh pr edit "$PR_NUMBER" --remove-label to-merge --add-label to-ratify
+./tracker.sh pr edit "$PR_NUMBER" --remove-label to-merge --add-label to-ratify
 ```
 
 ## Handoff

--- a/reef-pulse/merge.md
+++ b/reef-pulse/merge.md
@@ -4,7 +4,7 @@ Before starting, read `.agents/moonjelly-reef/config.md` — it tells you the is
 
 > **Shell blocks are literal commands** — `./worktree-enter.sh`, `./worktree-exit.sh`, `./commit.sh`, and `./tracker.sh` are real scripts next to this file. Execute them as written; do not substitute with raw git commands.
 >
-> **Tracker note**: Commands below use `./tracker.sh` syntax. For local-tracker projects, run `./tracker.sh` directly. For GitHub, replace `./tracker.sh` with `gh`. For MCP trackers (ClickUp, Jira, Linear), use equivalent MCP tool calls.
+> **Tracker note**: Commands below use `./tracker.sh` syntax for both issue and PR operations. For local-tracker projects, run `./tracker.sh` directly. For GitHub, replace `./tracker.sh` with `gh`. For MCP trackers (ClickUp, Jira, Linear), use equivalent MCP tool calls.
 
 > **AFK skill**: this skill runs without human interaction. When in doubt: check the plan, make your best judgment, move on. Never block waiting for human input.
 
@@ -44,7 +44,7 @@ Unconditional for both single-slice and multi-slice. Ensures the slice branch in
 Check the merge state of the PR:
 
 ```sh
-gh pr view "$PR_NUMBER" --json mergeStateStatus -q .mergeStateStatus
+./tracker.sh pr view "$PR_NUMBER" --json mergeStateStatus -q .mergeStateStatus
 ```
 
 Enter a worktree forked from $PR_BRANCH (not $TARGET_BRANCH) so you are testing the PR code with the latest target merged in:
@@ -71,7 +71,7 @@ If the test suite fails after merging, label the slice `to-rework` and stop:
 
 ```sh
 ./tracker.sh issue edit "$SLICE_ID" --remove-label to-merge --add-label to-rework
-gh pr edit "$PR_NUMBER" --remove-label to-merge --add-label to-rework
+./tracker.sh pr edit "$PR_NUMBER" --remove-label to-merge --add-label to-rework
 ```
 
 Clean up the worktree:

--- a/reef-pulse/ratify.md
+++ b/reef-pulse/ratify.md
@@ -2,7 +2,7 @@
 
 > **Shell blocks are literal commands** — `./worktree-enter.sh`, `./worktree-exit.sh`, `./commit.sh`, and `./tracker.sh` are real scripts next to this file. Execute them as written; do not substitute with raw git commands.
 >
-> **Tracker note**: Commands below use `./tracker.sh` syntax. For local-tracker projects, run `./tracker.sh` directly. For GitHub, replace `./tracker.sh` with `gh`. For MCP trackers (ClickUp, Jira, Linear), use equivalent MCP tool calls.
+> **Tracker note**: Commands below use `./tracker.sh` syntax for both issue and PR operations. For local-tracker projects, run `./tracker.sh` directly. For GitHub, replace `./tracker.sh` with `gh`. For MCP trackers (ClickUp, Jira, Linear), use equivalent MCP tool calls.
 
 > **AFK skill**: this skill runs without human interaction. When in doubt: check the plan, make your best judgment, move on. Never block waiting for human input.
 
@@ -190,12 +190,12 @@ Format the report as a collapsible block with local timestamp (`yyyy/MM/dd HH:mm
 ```sh
 REPORT="{ratify-report}" # <details><summary><h3>🦭 Ratify report — {yyyy/MM/dd HH:mm}</h3></summary>{report-content}</details>
 # if no PR exists:
-gh pr create --base "$BASE_BRANCH" --head "$TARGET_BRANCH" --title "$PLAN_TITLE" --body "$REPORT" --label to-ratify
+./tracker.sh pr create --base "$BASE_BRANCH" --head "$TARGET_BRANCH" --title "$PLAN_TITLE" --body "$REPORT" --label to-ratify
 # if PR exists, append:
 PR_NUMBER="{from pr create output or existing PR}"
-PR_BODY=$(gh pr view "$PR_NUMBER" --json body -q .body)
+PR_BODY=$(./tracker.sh pr view "$PR_NUMBER" --json body -q .body)
 PR_BODY="$PR_BODY\n\n$REPORT"
-gh pr edit "$PR_NUMBER" --body "$PR_BODY"
+./tracker.sh pr edit "$PR_NUMBER" --body "$PR_BODY"
 ```
 
 ### 9. Label
@@ -204,21 +204,21 @@ gh pr edit "$PR_NUMBER" --body "$PR_BODY"
 
 ```sh
 ./tracker.sh issue edit "$PLAN_ID" --remove-label to-ratify --add-label to-land
-gh pr edit "$PR_NUMBER" --remove-label to-ratify --add-label to-land
+./tracker.sh pr edit "$PR_NUMBER" --remove-label to-ratify --add-label to-land
 ```
 
 **If gaps found (fixable within success criteria):**
 
 ```sh
 ./tracker.sh issue edit "$PLAN_ID" --remove-label to-ratify --add-label to-rework
-gh pr edit "$PR_NUMBER" --remove-label to-ratify --add-label to-rework
+./tracker.sh pr edit "$PR_NUMBER" --remove-label to-ratify --add-label to-rework
 ```
 
 **If gaps need decisions beyond success criteria (safety valve):**
 
 ```sh
 ./tracker.sh issue edit "$PLAN_ID" --remove-label to-ratify --add-label to-scope
-gh pr edit "$PR_NUMBER" --remove-label to-ratify --add-label to-scope
+./tracker.sh pr edit "$PR_NUMBER" --remove-label to-ratify --add-label to-scope
 ```
 
 ## Clean up

--- a/reef-pulse/rework.md
+++ b/reef-pulse/rework.md
@@ -2,7 +2,7 @@
 
 > **Shell blocks are literal commands** — `./worktree-enter.sh`, `./worktree-exit.sh`, `./commit.sh`, and `./tracker.sh` are real scripts next to this file. Execute them as written; do not substitute with raw git commands.
 >
-> **Tracker note**: Commands below use `./tracker.sh` syntax. For local-tracker projects, run `./tracker.sh` directly. For GitHub, replace `./tracker.sh` with `gh`. For MCP trackers (ClickUp, Jira, Linear), use equivalent MCP tool calls.
+> **Tracker note**: Commands below use `./tracker.sh` syntax for both issue and PR operations. For local-tracker projects, run `./tracker.sh` directly. For GitHub, replace `./tracker.sh` with `gh`. For MCP trackers (ClickUp, Jira, Linear), use equivalent MCP tool calls.
 
 > **AFK skill**: this skill runs without human interaction. When in doubt: check the plan, make your best judgment, move on. Never block waiting for human input.
 
@@ -93,17 +93,17 @@ Document judgment calls made during this phase on the PR. Only document decision
 Read the current PR body, then append the rework report as a collapsible block. The rework report should include judgment calls, what feedback was addressed, what was changed, and test results.
 
 ```sh
-PR_BODY=$(gh pr view "$PR_NUMBER" --json body -q .body)
+PR_BODY=$(./tracker.sh pr view "$PR_NUMBER" --json body -q .body)
 REPORT="{rework-report}" # <details><summary><h3>🦀 Rework — {yyyy/MM/dd HH:mm}</h3></summary>{report-content}</details>
 PR_BODY="$PR_BODY\n\n$REPORT"
-gh pr edit "$PR_NUMBER" --body "$PR_BODY"
+./tracker.sh pr edit "$PR_NUMBER" --body "$PR_BODY"
 ```
 
 ### 8. Label
 
 ```sh
 ./tracker.sh issue edit "$ISSUE_ID" --remove-label to-rework --add-label to-inspect
-gh pr edit "$PR_NUMBER" --remove-label to-rework --add-label to-inspect
+./tracker.sh pr edit "$PR_NUMBER" --remove-label to-rework --add-label to-inspect
 ```
 
 ### 9. Clean up

--- a/tests/orchestration.test.sh
+++ b/tests/orchestration.test.sh
@@ -61,6 +61,10 @@ make_pattern() {
     "gh issue edit"*) echo "gh issue edit" ;;
     "gh issue close"*) echo "gh issue close" ;;
     "gh issue view"*) echo "gh issue view" ;;
+    "tracker.sh pr create"*)  echo "tracker.sh pr create" ;;
+    "tracker.sh pr merge"*)   echo "tracker.sh pr merge" ;;
+    "tracker.sh pr view"*)    echo "tracker.sh pr view" ;;
+    "tracker.sh pr edit"*)    echo "tracker.sh pr edit" ;;
     "tracker.sh issue view"*)  echo "tracker.sh issue view" ;;
     "tracker.sh issue edit"*)  echo "tracker.sh issue edit" ;;
     "tracker.sh issue close"*) echo "tracker.sh issue close" ;;


### PR DESCRIPTION
closes #122 Phase docs switch to tracker.sh pr syntax

## Ambiguous choices

None — implementation followed the plan exactly.

## Test results

263 passed (orchestration), 53 passed (tracker), 22 passed (worktree) — 338 total, 0 failed, 0 skipped.

### 🪼 Pulse metrics

| Phase | Target | Duration | Tokens | Tool uses | Outcome | Date |
| ----- | ------ | -------- | ------ | --------- | ------- | ---- |
| implement | #122 | 8m 17s | 88 158 | 108 | ✅ PR #127 created | 2026-04-22 03:10 |
| inspect | #122 | 2m 51s | 56 264 | 49 | ✅ passed | 2026-04-22 03:13 |
<!-- end metrics table -->

<details><summary><h3>🧿 Inspect review — 2026/04/22 15:15</h3></summary>

## Acceptance criteria

- [x] AC1: implement.md uses `./tracker.sh pr create` — verified at line 125
- [x] AC2: inspect.md uses `./tracker.sh pr view` and `./tracker.sh pr edit` — verified at lines 113, 118-122, 131, 138
- [x] AC3: rework.md uses `./tracker.sh pr view` and `./tracker.sh pr edit` — verified at lines 96, 99, 106
- [x] AC4: merge.md uses `./tracker.sh pr view` and `./tracker.sh pr edit` — verified at lines 47, 74
- [x] AC5: merge-single.md uses `./tracker.sh pr edit` — verified at line 27
- [x] AC6: merge-multi.md uses `./tracker.sh pr merge` and `./tracker.sh pr edit` — verified at lines 27-28
- [x] AC7: ratify.md uses `./tracker.sh pr create`, `./tracker.sh pr view`, and `./tracker.sh pr edit` — verified at lines 193, 196, 198, 207, 214, 221
- [x] AC8: reef-land/SKILL.md uses `./tracker.sh pr` for all PR operations, tracker note updated to cover PR commands — verified; note says "for both issue and PR operations"
- [x] AC9: ORCHESTRATION.md uses `./tracker.sh pr` for all PR operations — verified; header at lines 9-11 documents the convention
- [x] AC10: No behavioral regression — 338 tests pass (263 orchestration + 53 tracker + 22 worktree); tracker note in every file preserves "For GitHub, replace `./tracker.sh` with `gh`" instruction

## Drift from plan

None detected. All changes are mechanical replacements as specified.

## Ambiguous choices review

The implementer reported "None — implementation followed the plan exactly." Confirmed: the changes are purely syntactic replacements of `gh pr` to `./tracker.sh pr` and tracker note updates. No judgment calls were needed.

## Notes

- `gh api graphql` and `gh repo view` calls in reef-land/SKILL.md are correctly left as-is. These are direct GitHub API calls for fetching PR review threads via GraphQL, not `gh pr` subcommands. The tracker abstraction covers `issue` and `pr` subcommands only.
- Files without PR operations (await-waves.md, slice.md, slice-single.md, slice-multi.md) correctly retain the shorter tracker note without "for both issue and PR operations."
- The only remaining `gh pr` references in the repo are in tracker.sh (comment explaining it mirrors the `gh pr` interface) and orchestration.test.sh (test mocks simulating GitHub behavior) — both correct and expected.

## Test results

338 total: 263 passed (orchestration), 53 passed (tracker), 22 passed (worktree). 0 failed, 0 skipped.

## Verdict

**PASS** — all acceptance criteria met, test suite green, no drift from plan.

</details>
