### PR TITLE
Local PR tracker -- progress.md as gh pr equivalent

### DIFF
--- a/.slicing-in-progress
+++ b/.slicing-in-progress
@@ -1,0 +1,1 @@
+placeholder

--- a/.slicing-in-progress
+++ b/.slicing-in-progress
@@ -1,1 +1,0 @@
-placeholder

--- a/ORCHESTRATION.md
+++ b/ORCHESTRATION.md
@@ -6,7 +6,7 @@ The test runner checks: (1) each command string exists in the .md file, (2) they
 
 `if` means the operation is conditional — it must exist in the .md but only runs when the condition holds.
 
-Tracker commands use `./tracker.sh issue ...` syntax.
+Tracker commands use `./tracker.sh issue ...` and `./tracker.sh pr ...` syntax.
 For GitHub: replace `./tracker.sh` with `gh`.
 For MCP trackers (ClickUp, Jira, Linear): use equivalent MCP tool calls.
 
@@ -91,7 +91,7 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
   ```
 - update-pr-body — if planPr is not "—"
   ```sh
-  gh pr edit "$PLAN_PR_NUMBER" --body "$PLAN_PR_BODY"
+  ./tracker.sh pr edit "$PLAN_PR_NUMBER" --body "$PLAN_PR_BODY"
   ```
 - present-human-items — if HITL mode and first iteration
   - contains: `to-scope`
@@ -172,7 +172,7 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
 - fetch-context
   ```sh
   ./tracker.sh issue view "$PLAN_ID" --json body,title,labels # if PLAN_ID known
-  gh pr view "$PR_NUMBER" --json number,body,headRefName,baseRefName,comments,reviews # if PR_NUMBER known
+  ./tracker.sh pr view "$PR_NUMBER" --json number,body,headRefName,baseRefName,comments,reviews # if PR_NUMBER known
   ```
 - set-variables
   ```sh
@@ -183,7 +183,7 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
   ```
 - fetch-pr-comments-and-reviews
   ```sh
-  gh pr view "$PR_NUMBER" --json comments,reviews # if not already fetched
+  ./tracker.sh pr view "$PR_NUMBER" --json comments,reviews # if not already fetched
   ```
 - phase-specific
 - set-variables — if change-requests
@@ -192,7 +192,7 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
   ```
 - update-pr-body — if change-requests
   ```sh
-  gh pr edit "$PR_NUMBER" --body "$PR_BODY"
+  ./tracker.sh pr edit "$PR_NUMBER" --body "$PR_BODY"
   ```
 - update-tracker — if change-requests
   ```sh
@@ -205,11 +205,11 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
   ```
 - sync-pr-label — if change-requests
   ```sh
-  gh pr edit "$PR_NUMBER" --remove-label to-land --add-label to-rework
+  ./tracker.sh pr edit "$PR_NUMBER" --remove-label to-land --add-label to-rework
   ```
 - pre-merge-check — if approved
   ```sh
-  gh pr view "$PR_NUMBER" --json mergeStateStatus -q .mergeStateStatus
+  ./tracker.sh pr view "$PR_NUMBER" --json mergeStateStatus -q .mergeStateStatus
   ```
 - set-variables — if approved
   ```sh
@@ -217,8 +217,8 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
   ```
 - pr-merge — if approved
   ```sh
-  gh pr merge "$PR_NUMBER" --"$MERGE_STRATEGY" --delete-branch
-  gh pr edit "$PR_NUMBER" --remove-label to-land --add-label landed
+  ./tracker.sh pr merge "$PR_NUMBER" --"$MERGE_STRATEGY" --delete-branch
+  ./tracker.sh pr edit "$PR_NUMBER" --remove-label to-land --add-label landed
   ```
 - pull
   - contains: `Pull the merged changes into the current branch if it matches the base branch:`
@@ -357,11 +357,11 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
   ```
 - pr-create
   ```sh
-  gh pr create --base "$TARGET_BRANCH" --title "$SLICE_NAME" --body "$REPORT" --label to-inspect
+  ./tracker.sh pr create --base "$TARGET_BRANCH" --title "$SLICE_NAME" --body "$REPORT" --label to-inspect
   ```
 - set-variables
   ```sh
-  PR_NUMBER="{from gh pr create output}"
+  PR_NUMBER="{from pr create output}"
   SLICE_BODY="{slice/plan body with PR reference and pr-branch updated}"
   ```
 - update-tracker
@@ -409,15 +409,15 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
   ```
 - update-pr-body
   ```sh
-  PR_NUMBER="{from slice body}" # if not found, try gh pr list --search
-  PR_BODY=$(gh pr view "$PR_NUMBER" --json body -q .body)
+  PR_NUMBER="{from slice body}" # if not found, try ./tracker.sh pr list --search
+  PR_BODY=$(./tracker.sh pr view "$PR_NUMBER" --json body -q .body)
   REPORT="{inspect-report}" # <details><summary><h3>🧿 Inspect review — {yyyy/MM/dd HH:mm}</h3></summary>{report-content}</details>
   PR_BODY="$PR_BODY\n\n$REPORT"
-  gh pr edit "$PR_NUMBER" --body "$PR_BODY"
+  ./tracker.sh pr edit "$PR_NUMBER" --body "$PR_BODY"
   ```
 - update-tracker
-  - pass: `./tracker.sh issue edit "$SLICE_ID" --remove-label to-inspect --add-label to-merge` + `gh pr edit "$PR_NUMBER" --remove-label to-inspect --add-label to-merge`
-  - fail: `./tracker.sh issue edit "$SLICE_ID" --remove-label to-inspect --add-label to-rework` + `gh pr edit "$PR_NUMBER" --remove-label to-inspect --add-label to-rework`
+  - pass: `./tracker.sh issue edit "$SLICE_ID" --remove-label to-inspect --add-label to-merge` + `./tracker.sh pr edit "$PR_NUMBER" --remove-label to-inspect --add-label to-merge`
+  - fail: `./tracker.sh issue edit "$SLICE_ID" --remove-label to-inspect --add-label to-rework` + `./tracker.sh pr edit "$PR_NUMBER" --remove-label to-inspect --add-label to-rework`
 - exit-worktree
   ```sh
   ./worktree-exit.sh --path "$WORKTREE_PATH"
@@ -460,15 +460,15 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
   ```
 - update-pr-body
   ```sh
-  PR_BODY=$(gh pr view "$PR_NUMBER" --json body -q .body)
+  PR_BODY=$(./tracker.sh pr view "$PR_NUMBER" --json body -q .body)
   REPORT="{rework-report}" # <details><summary><h3>🦀 Rework — {yyyy/MM/dd HH:mm}</h3></summary>{report-content}</details>
   PR_BODY="$PR_BODY\n\n$REPORT"
-  gh pr edit "$PR_NUMBER" --body "$PR_BODY"
+  ./tracker.sh pr edit "$PR_NUMBER" --body "$PR_BODY"
   ```
 - update-tracker
   ```sh
   ./tracker.sh issue edit "$ISSUE_ID" --remove-label to-rework --add-label to-inspect
-  gh pr edit "$PR_NUMBER" --remove-label to-rework --add-label to-inspect
+  ./tracker.sh pr edit "$PR_NUMBER" --remove-label to-rework --add-label to-inspect
   ```
 - exit-worktree
   ```sh
@@ -553,7 +553,7 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
   ```
 - pre-merge-check
   ```sh
-  gh pr view "$PR_NUMBER" --json mergeStateStatus -q .mergeStateStatus
+  ./tracker.sh pr view "$PR_NUMBER" --json mergeStateStatus -q .mergeStateStatus
   ```
 - enter-worktree
   - contains: `Enter a worktree forked from $PR_BRANCH (not $TARGET_BRANCH) so you are testing the PR code with the latest target merged in`
@@ -567,7 +567,7 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
 - update-tracker — if tests-fail
   ```sh
   ./tracker.sh issue edit "$SLICE_ID" --remove-label to-merge --add-label to-rework
-  gh pr edit "$PR_NUMBER" --remove-label to-merge --add-label to-rework
+  ./tracker.sh pr edit "$PR_NUMBER" --remove-label to-merge --add-label to-rework
   ```
 - exit-worktree
   ```sh
@@ -583,7 +583,7 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
 - update-tracker
   ```sh
   ./tracker.sh issue edit "$PLAN_ID" --remove-label to-merge --add-label to-ratify
-  gh pr edit "$PR_NUMBER" --remove-label to-merge --add-label to-ratify
+  ./tracker.sh pr edit "$PR_NUMBER" --remove-label to-merge --add-label to-ratify
   ```
 - handoff
   ```sh
@@ -606,8 +606,8 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
   ```
 - pr-merge
   ```sh
-  gh pr merge "$PR_NUMBER" --"$MERGE_STRATEGY" --delete-branch
-  gh pr edit "$PR_NUMBER" --remove-label to-merge --add-label landed
+  ./tracker.sh pr merge "$PR_NUMBER" --"$MERGE_STRATEGY" --delete-branch
+  ./tracker.sh pr edit "$PR_NUMBER" --remove-label to-merge --add-label landed
   ```
 - check-siblings-and-completion
   ```sh
@@ -666,16 +666,16 @@ All three use `$PR_BRANCH` — the branch the PR lives on — as the branch to f
   ```sh
   REPORT="{ratify-report}" # <details><summary><h3>🦭 Ratify report — {yyyy/MM/dd HH:mm}</h3></summary>{report-content}</details>
   # if no PR exists:
-  gh pr create --base "$BASE_BRANCH" --head "$TARGET_BRANCH" --title "$PLAN_TITLE" --body "$REPORT" --label to-ratify
+  ./tracker.sh pr create --base "$BASE_BRANCH" --head "$TARGET_BRANCH" --title "$PLAN_TITLE" --body "$REPORT" --label to-ratify
   # if PR exists, append:
   PR_NUMBER="{from pr create output or existing PR}"
-  PR_BODY=$(gh pr view "$PR_NUMBER" --json body -q .body)
+  PR_BODY=$(./tracker.sh pr view "$PR_NUMBER" --json body -q .body)
   PR_BODY="$PR_BODY\n\n$REPORT"
-  gh pr edit "$PR_NUMBER" --body "$PR_BODY"
+  ./tracker.sh pr edit "$PR_NUMBER" --body "$PR_BODY"
   ```
 - update-tracker
-  - pass: `./tracker.sh issue edit "$PLAN_ID" --remove-label to-ratify --add-label to-land` + `gh pr edit "$PR_NUMBER" --remove-label to-ratify --add-label to-land`
-  - fail: `./tracker.sh issue edit "$PLAN_ID" --remove-label to-ratify --add-label to-rework` + `gh pr edit "$PR_NUMBER" --remove-label to-ratify --add-label to-rework`
+  - pass: `./tracker.sh issue edit "$PLAN_ID" --remove-label to-ratify --add-label to-land` + `./tracker.sh pr edit "$PR_NUMBER" --remove-label to-ratify --add-label to-land`
+  - fail: `./tracker.sh issue edit "$PLAN_ID" --remove-label to-ratify --add-label to-rework` + `./tracker.sh pr edit "$PR_NUMBER" --remove-label to-ratify --add-label to-rework`
 - exit-worktree
   ```sh
   ./worktree-exit.sh --path "$WORKTREE_PATH"

--- a/reef-land/SKILL.md
+++ b/reef-land/SKILL.md
@@ -7,7 +7,7 @@ description: Present the final report to the human for review. Human approves (m
 
 > **Shell blocks are literal commands** — `./tracker.sh` is a real script next to this file. Execute it as written; do not substitute with raw git commands.
 >
-> **Tracker note**: Commands below use `./tracker.sh` syntax for issue operations. For local-tracker projects, run `./tracker.sh` directly. For GitHub, replace `./tracker.sh` with `gh`. For MCP trackers (ClickUp, Jira, Linear), use equivalent MCP tool calls. PR operations always use `gh` directly regardless of tracker.
+> **Tracker note**: Commands below use `./tracker.sh` syntax for both issue and PR operations. For local-tracker projects, run `./tracker.sh` directly. For GitHub, replace `./tracker.sh` with `gh`. For MCP trackers (ClickUp, Jira, Linear), use equivalent MCP tool calls.
 
 ## Input
 
@@ -30,7 +30,7 @@ Use whichever identifier you have to look up the other:
   ```
 - If you have `PR_NUMBER`: read the PR to find the plan issue reference.
   ```sh
-  gh pr view "$PR_NUMBER" --json number,body,headRefName,baseRefName,comments,reviews # if PR_NUMBER known
+  ./tracker.sh pr view "$PR_NUMBER" --json number,body,headRefName,baseRefName,comments,reviews # if PR_NUMBER known
   ```
 
 Now set all variables:
@@ -111,7 +111,7 @@ Ask the human:
 If (2): open the PR in the browser:
 
 ```sh
-gh pr view "$PR_NUMBER" --web
+./tracker.sh pr view "$PR_NUMBER" --web
 ```
 
 Then say: "Take your time reviewing. Leave any comments on the PR, then let me know when you're ready to continue." Wait for the human. When they return, re-check for comments and return to the top of step 2.
@@ -177,7 +177,7 @@ PR_BODY="{current PR body with gap report appended in <details><summary> block}"
 ```
 
 ```sh
-gh pr edit "$PR_NUMBER" --body "$PR_BODY"
+./tracker.sh pr edit "$PR_NUMBER" --body "$PR_BODY"
 ./tracker.sh issue edit "$PLAN_ID" --remove-label to-land --add-label to-rework
 ```
 
@@ -186,7 +186,7 @@ If the discussion changed any plan-level Decisions, Stories, or Success Criteria
 ```sh
 PLAN_BODY=$(./tracker.sh issue view "$PLAN_ID" --json body)
 ./tracker.sh issue edit "$PLAN_ID" --body "$PLAN_BODY"
-gh pr edit "$PR_NUMBER" --remove-label to-land --add-label to-rework
+./tracker.sh pr edit "$PR_NUMBER" --remove-label to-land --add-label to-rework
 ```
 
 Tell the human:
@@ -212,7 +212,7 @@ Tell the human: "Created follow-up issue #{N}." Then continue to **step 5 (Appro
 Check merge status first:
 
 ```sh
-gh pr view "$PR_NUMBER" --json mergeStateStatus -q .mergeStateStatus
+./tracker.sh pr view "$PR_NUMBER" --json mergeStateStatus -q .mergeStateStatus
 ```
 
 If the PR cannot be merged (conflicts, failing checks, branch protection), tell the human what's blocking and exit. Do not force-merge.
@@ -224,8 +224,8 @@ MERGE_STRATEGY="{from .agents/moonjelly-reef/config.md merge-strategy field}"
 ```
 
 ```sh
-gh pr merge "$PR_NUMBER" --"$MERGE_STRATEGY" --delete-branch
-gh pr edit "$PR_NUMBER" --remove-label to-land --add-label landed
+./tracker.sh pr merge "$PR_NUMBER" --"$MERGE_STRATEGY" --delete-branch
+./tracker.sh pr edit "$PR_NUMBER" --remove-label to-land --add-label landed
 ```
 
 Pull the merged changes into the current branch if it matches the base branch:

--- a/reef-pulse/SKILL.md
+++ b/reef-pulse/SKILL.md
@@ -9,7 +9,7 @@ Before starting, read `.agents/moonjelly-reef/config.md` — it tells you the is
 
 > **Shell blocks are literal commands** — `./tracker.sh` is a real script next to this file. Execute it as written; do not substitute with raw git commands.
 >
-> **Tracker note**: Commands below use `./tracker.sh` syntax. For local-tracker projects, run `./tracker.sh` directly. For GitHub, replace `./tracker.sh` with `gh`. For MCP trackers (ClickUp, Jira, Linear), use equivalent MCP tool calls.
+> **Tracker note**: Commands below use `./tracker.sh` syntax for both issue and PR operations. For local-tracker projects, run `./tracker.sh` directly. For GitHub, replace `./tracker.sh` with `gh`. For MCP trackers (ClickUp, Jira, Linear), use equivalent MCP tool calls.
 
 You are the orchestrator. You scan, dispatch, and exit. You hold no state — labels are the state.
 
@@ -213,7 +213,7 @@ Use `planPr` from the handoff to determine the target PR. If `planPr` is `—`, 
 ```sh
 PLAN_PR_NUMBER="$planPr" # from handoff — never read issue bodies for this
 PLAN_PR_BODY="{current plan PR body with metrics rows inserted into the table}"
-gh pr edit "$PLAN_PR_NUMBER" --body "$PLAN_PR_BODY"
+./tracker.sh pr edit "$PLAN_PR_NUMBER" --body "$PLAN_PR_BODY"
 ```
 
 #### Total row on ratify-to-land

--- a/reef-pulse/implement.md
+++ b/reef-pulse/implement.md
@@ -4,7 +4,7 @@ Before starting, read `.agents/moonjelly-reef/config.md` — it tells you the is
 
 > **Shell blocks are literal commands** — `./worktree-enter.sh`, `./worktree-exit.sh`, `./commit.sh`, and `./tracker.sh` are real scripts next to this file. Execute them as written; do not substitute with raw git commands.
 >
-> **Tracker note**: Commands below use `./tracker.sh` syntax. For local-tracker projects, run `./tracker.sh` directly. For GitHub, replace `./tracker.sh` with `gh`. For MCP trackers (ClickUp, Jira, Linear), use equivalent MCP tool calls.
+> **Tracker note**: Commands below use `./tracker.sh` syntax for both issue and PR operations. For local-tracker projects, run `./tracker.sh` directly. For GitHub, replace `./tracker.sh` with `gh`. For MCP trackers (ClickUp, Jira, Linear), use equivalent MCP tool calls.
 
 > **AFK skill**: this skill runs without human interaction. When in doubt: check the plan, make your best judgment, move on. Never block waiting for human input.
 
@@ -122,13 +122,13 @@ REPORT="{report-content}" # starts with: closes #$SLICE_ID $SLICE_NAME\n\n
 ```
 
 ```sh
-gh pr create --base "$TARGET_BRANCH" --title "$SLICE_NAME" --body "$REPORT" --label to-inspect
+./tracker.sh pr create --base "$TARGET_BRANCH" --title "$SLICE_NAME" --body "$REPORT" --label to-inspect
 ```
 
 The PR targets the **target branch** (which equals `{base-branch}` for single-slice work).
 
 ```sh
-PR_NUMBER="{from gh pr create output}"
+PR_NUMBER="{from pr create output}"
 SLICE_BODY="{slice/plan body with PR reference and pr-branch updated}"
 ```
 

--- a/reef-pulse/inspect.md
+++ b/reef-pulse/inspect.md
@@ -2,7 +2,7 @@
 
 > **Shell blocks are literal commands** — `./worktree-enter.sh`, `./worktree-exit.sh`, `./commit.sh`, and `./tracker.sh` are real scripts next to this file. Execute them as written; do not substitute with raw git commands.
 >
-> **Tracker note**: Commands below use `./tracker.sh` syntax. For local-tracker projects, run `./tracker.sh` directly. For GitHub, replace `./tracker.sh` with `gh`. For MCP trackers (ClickUp, Jira, Linear), use equivalent MCP tool calls.
+> **Tracker note**: Commands below use `./tracker.sh` syntax for both issue and PR operations. For local-tracker projects, run `./tracker.sh` directly. For GitHub, replace `./tracker.sh` with `gh`. For MCP trackers (ClickUp, Jira, Linear), use equivalent MCP tool calls.
 
 > **AFK skill**: this skill runs without human interaction. When in doubt: check the plan, make your best judgment, move on. Never block waiting for human input.
 
@@ -110,16 +110,16 @@ Document judgment calls made during this phase on the PR. Only document decision
 
 ### 6. Update the PR
 
-Set the PR number from the slice body. If not found there, try `gh pr list --search`. If PR_NUMBER is nowhere to be found, label the issue `pr-missing` and stop.
+Set the PR number from the slice body. If not found there, try `./tracker.sh pr list --search`. If PR_NUMBER is nowhere to be found, label the issue `pr-missing` and stop.
 
 Read the current PR body, then append the inspect report as a collapsible block:
 
 ```sh
-PR_NUMBER="{from slice body}" # if not found, try gh pr list --search
-PR_BODY=$(gh pr view "$PR_NUMBER" --json body -q .body)
+PR_NUMBER="{from slice body}" # if not found, try ./tracker.sh pr list --search
+PR_BODY=$(./tracker.sh pr view "$PR_NUMBER" --json body -q .body)
 REPORT="{inspect-report}" # <details><summary><h3>🧿 Inspect review — {yyyy/MM/dd HH:mm}</h3></summary>{report-content}</details>
 PR_BODY="$PR_BODY\n\n$REPORT"
-gh pr edit "$PR_NUMBER" --body "$PR_BODY"
+./tracker.sh pr edit "$PR_NUMBER" --body "$PR_BODY"
 ```
 
 ### 7. Verdict
@@ -128,14 +128,14 @@ gh pr edit "$PR_NUMBER" --body "$PR_BODY"
 
 ```sh
 ./tracker.sh issue edit "$SLICE_ID" --remove-label to-inspect --add-label to-merge
-gh pr edit "$PR_NUMBER" --remove-label to-inspect --add-label to-merge
+./tracker.sh pr edit "$PR_NUMBER" --remove-label to-inspect --add-label to-merge
 ```
 
 **If gaps are found:**
 
 ```sh
 ./tracker.sh issue edit "$SLICE_ID" --remove-label to-inspect --add-label to-rework
-gh pr edit "$PR_NUMBER" --remove-label to-inspect --add-label to-rework
+./tracker.sh pr edit "$PR_NUMBER" --remove-label to-inspect --add-label to-rework
 ```
 
 Leave specific review comments on the PR for each gap. Be precise — tell the implementer exactly what's wrong and what "fixed" looks like.

--- a/reef-pulse/merge-multi.md
+++ b/reef-pulse/merge-multi.md
@@ -4,7 +4,7 @@ Multi-slice merge flow — delegated from [merge.md](merge.md).
 
 > **Shell blocks are literal commands** — `./tracker.sh` is a real script next to this file. Execute it as written; do not substitute with raw git commands.
 >
-> **Tracker note**: Commands below use `./tracker.sh` syntax. For local-tracker projects, run `./tracker.sh` directly. For GitHub, replace `./tracker.sh` with `gh`. For MCP trackers (ClickUp, Jira, Linear), use equivalent MCP tool calls.
+> **Tracker note**: Commands below use `./tracker.sh` syntax for both issue and PR operations. For local-tracker projects, run `./tracker.sh` directly. For GitHub, replace `./tracker.sh` with `gh`. For MCP trackers (ClickUp, Jira, Linear), use equivalent MCP tool calls.
 
 > **AFK skill**: this skill runs without human interaction. When in doubt: check the plan, make your best judgment, move on. Never block waiting for human input.
 
@@ -24,8 +24,8 @@ SLICE_ID="$ISSUE_ID"
 
 ```sh
 MERGE_STRATEGY="{from .agents/moonjelly-reef/config.md merge-strategy field}"
-gh pr merge "$PR_NUMBER" --"$MERGE_STRATEGY" --delete-branch
-gh pr edit "$PR_NUMBER" --remove-label to-merge --add-label landed
+./tracker.sh pr merge "$PR_NUMBER" --"$MERGE_STRATEGY" --delete-branch
+./tracker.sh pr edit "$PR_NUMBER" --remove-label to-merge --add-label landed
 ```
 
 ## 2. Check siblings and plan completion

--- a/reef-pulse/merge-single.md
+++ b/reef-pulse/merge-single.md
@@ -4,7 +4,7 @@ Single-slice merge path — delegated from [merge.md](merge.md).
 
 > **Shell blocks are literal commands** — `./tracker.sh` is a real script next to this file. Execute it as written; do not substitute with raw git commands.
 >
-> **Tracker note**: Commands below use `./tracker.sh` syntax. For local-tracker projects, run `./tracker.sh` directly. For GitHub, replace `./tracker.sh` with `gh`. For MCP trackers (ClickUp, Jira, Linear), use equivalent MCP tool calls.
+> **Tracker note**: Commands below use `./tracker.sh` syntax for both issue and PR operations. For local-tracker projects, run `./tracker.sh` directly. For GitHub, replace `./tracker.sh` with `gh`. For MCP trackers (ClickUp, Jira, Linear), use equivalent MCP tool calls.
 
 > **AFK skill**: this skill runs without human interaction. When in doubt: check the plan, make your best judgment, move on. Never block waiting for human input.
 
@@ -24,7 +24,7 @@ Remove `to-merge`, add `to-ratify`:
 
 ```sh
 ./tracker.sh issue edit "$PLAN_ID" --remove-label to-merge --add-label to-ratify
-gh pr edit "$PR_NUMBER" --remove-label to-merge --add-label to-ratify
+./tracker.sh pr edit "$PR_NUMBER" --remove-label to-merge --add-label to-ratify
 ```
 
 ## Handoff

--- a/reef-pulse/merge.md
+++ b/reef-pulse/merge.md
@@ -4,7 +4,7 @@ Before starting, read `.agents/moonjelly-reef/config.md` — it tells you the is
 
 > **Shell blocks are literal commands** — `./worktree-enter.sh`, `./worktree-exit.sh`, `./commit.sh`, and `./tracker.sh` are real scripts next to this file. Execute them as written; do not substitute with raw git commands.
 >
-> **Tracker note**: Commands below use `./tracker.sh` syntax. For local-tracker projects, run `./tracker.sh` directly. For GitHub, replace `./tracker.sh` with `gh`. For MCP trackers (ClickUp, Jira, Linear), use equivalent MCP tool calls.
+> **Tracker note**: Commands below use `./tracker.sh` syntax for both issue and PR operations. For local-tracker projects, run `./tracker.sh` directly. For GitHub, replace `./tracker.sh` with `gh`. For MCP trackers (ClickUp, Jira, Linear), use equivalent MCP tool calls.
 
 > **AFK skill**: this skill runs without human interaction. When in doubt: check the plan, make your best judgment, move on. Never block waiting for human input.
 
@@ -44,7 +44,7 @@ Unconditional for both single-slice and multi-slice. Ensures the slice branch in
 Check the merge state of the PR:
 
 ```sh
-gh pr view "$PR_NUMBER" --json mergeStateStatus -q .mergeStateStatus
+./tracker.sh pr view "$PR_NUMBER" --json mergeStateStatus -q .mergeStateStatus
 ```
 
 Enter a worktree forked from $PR_BRANCH (not $TARGET_BRANCH) so you are testing the PR code with the latest target merged in:
@@ -71,7 +71,7 @@ If the test suite fails after merging, label the slice `to-rework` and stop:
 
 ```sh
 ./tracker.sh issue edit "$SLICE_ID" --remove-label to-merge --add-label to-rework
-gh pr edit "$PR_NUMBER" --remove-label to-merge --add-label to-rework
+./tracker.sh pr edit "$PR_NUMBER" --remove-label to-merge --add-label to-rework
 ```
 
 Clean up the worktree:

--- a/reef-pulse/ratify.md
+++ b/reef-pulse/ratify.md
@@ -2,7 +2,7 @@
 
 > **Shell blocks are literal commands** — `./worktree-enter.sh`, `./worktree-exit.sh`, `./commit.sh`, and `./tracker.sh` are real scripts next to this file. Execute them as written; do not substitute with raw git commands.
 >
-> **Tracker note**: Commands below use `./tracker.sh` syntax. For local-tracker projects, run `./tracker.sh` directly. For GitHub, replace `./tracker.sh` with `gh`. For MCP trackers (ClickUp, Jira, Linear), use equivalent MCP tool calls.
+> **Tracker note**: Commands below use `./tracker.sh` syntax for both issue and PR operations. For local-tracker projects, run `./tracker.sh` directly. For GitHub, replace `./tracker.sh` with `gh`. For MCP trackers (ClickUp, Jira, Linear), use equivalent MCP tool calls.
 
 > **AFK skill**: this skill runs without human interaction. When in doubt: check the plan, make your best judgment, move on. Never block waiting for human input.
 
@@ -190,12 +190,12 @@ Format the report as a collapsible block with local timestamp (`yyyy/MM/dd HH:mm
 ```sh
 REPORT="{ratify-report}" # <details><summary><h3>🦭 Ratify report — {yyyy/MM/dd HH:mm}</h3></summary>{report-content}</details>
 # if no PR exists:
-gh pr create --base "$BASE_BRANCH" --head "$TARGET_BRANCH" --title "$PLAN_TITLE" --body "$REPORT" --label to-ratify
+./tracker.sh pr create --base "$BASE_BRANCH" --head "$TARGET_BRANCH" --title "$PLAN_TITLE" --body "$REPORT" --label to-ratify
 # if PR exists, append:
 PR_NUMBER="{from pr create output or existing PR}"
-PR_BODY=$(gh pr view "$PR_NUMBER" --json body -q .body)
+PR_BODY=$(./tracker.sh pr view "$PR_NUMBER" --json body -q .body)
 PR_BODY="$PR_BODY\n\n$REPORT"
-gh pr edit "$PR_NUMBER" --body "$PR_BODY"
+./tracker.sh pr edit "$PR_NUMBER" --body "$PR_BODY"
 ```
 
 ### 9. Label
@@ -204,21 +204,21 @@ gh pr edit "$PR_NUMBER" --body "$PR_BODY"
 
 ```sh
 ./tracker.sh issue edit "$PLAN_ID" --remove-label to-ratify --add-label to-land
-gh pr edit "$PR_NUMBER" --remove-label to-ratify --add-label to-land
+./tracker.sh pr edit "$PR_NUMBER" --remove-label to-ratify --add-label to-land
 ```
 
 **If gaps found (fixable within success criteria):**
 
 ```sh
 ./tracker.sh issue edit "$PLAN_ID" --remove-label to-ratify --add-label to-rework
-gh pr edit "$PR_NUMBER" --remove-label to-ratify --add-label to-rework
+./tracker.sh pr edit "$PR_NUMBER" --remove-label to-ratify --add-label to-rework
 ```
 
 **If gaps need decisions beyond success criteria (safety valve):**
 
 ```sh
 ./tracker.sh issue edit "$PLAN_ID" --remove-label to-ratify --add-label to-scope
-gh pr edit "$PR_NUMBER" --remove-label to-ratify --add-label to-scope
+./tracker.sh pr edit "$PR_NUMBER" --remove-label to-ratify --add-label to-scope
 ```
 
 ## Clean up

--- a/reef-pulse/rework.md
+++ b/reef-pulse/rework.md
@@ -2,7 +2,7 @@
 
 > **Shell blocks are literal commands** — `./worktree-enter.sh`, `./worktree-exit.sh`, `./commit.sh`, and `./tracker.sh` are real scripts next to this file. Execute them as written; do not substitute with raw git commands.
 >
-> **Tracker note**: Commands below use `./tracker.sh` syntax. For local-tracker projects, run `./tracker.sh` directly. For GitHub, replace `./tracker.sh` with `gh`. For MCP trackers (ClickUp, Jira, Linear), use equivalent MCP tool calls.
+> **Tracker note**: Commands below use `./tracker.sh` syntax for both issue and PR operations. For local-tracker projects, run `./tracker.sh` directly. For GitHub, replace `./tracker.sh` with `gh`. For MCP trackers (ClickUp, Jira, Linear), use equivalent MCP tool calls.
 
 > **AFK skill**: this skill runs without human interaction. When in doubt: check the plan, make your best judgment, move on. Never block waiting for human input.
 
@@ -93,17 +93,17 @@ Document judgment calls made during this phase on the PR. Only document decision
 Read the current PR body, then append the rework report as a collapsible block. The rework report should include judgment calls, what feedback was addressed, what was changed, and test results.
 
 ```sh
-PR_BODY=$(gh pr view "$PR_NUMBER" --json body -q .body)
+PR_BODY=$(./tracker.sh pr view "$PR_NUMBER" --json body -q .body)
 REPORT="{rework-report}" # <details><summary><h3>🦀 Rework — {yyyy/MM/dd HH:mm}</h3></summary>{report-content}</details>
 PR_BODY="$PR_BODY\n\n$REPORT"
-gh pr edit "$PR_NUMBER" --body "$PR_BODY"
+./tracker.sh pr edit "$PR_NUMBER" --body "$PR_BODY"
 ```
 
 ### 8. Label
 
 ```sh
 ./tracker.sh issue edit "$ISSUE_ID" --remove-label to-rework --add-label to-inspect
-gh pr edit "$PR_NUMBER" --remove-label to-rework --add-label to-inspect
+./tracker.sh pr edit "$PR_NUMBER" --remove-label to-rework --add-label to-inspect
 ```
 
 ### 9. Clean up

--- a/reef-pulse/setup.md
+++ b/reef-pulse/setup.md
@@ -10,6 +10,29 @@ printf '\033[36m'; cat reef-pulse/banner.txt; printf '\033[0m'
 
 ## Steps
 
+### 0. Check for git
+
+Worktrees and branches (used by the reef's implement/inspect/merge cycle) require git. Check whether the current project has a git repository:
+
+```sh
+git rev-parse --git-dir 2>/dev/null
+```
+
+- **If git is present** (command succeeds): skip this step silently and continue to step 1.
+- **If git is missing** (command fails): offer to initialize one. Present this message to the user:
+
+> "This project doesn't seem to use git. So I'll treat `{dir}` as the project root folder and init a `.git` folder, is that OK? (It's so the reef can better organise its efforts when multiple tasks are worked on at once)."
+
+Replace `{dir}` with the absolute path to the current working directory.
+
+If the user agrees, run:
+
+```sh
+git init
+```
+
+If the user declines, warn them that the reef cannot function without git and stop setup.
+
 ### 1. Detect issue tracker
 
 Look for clues in the repo:

--- a/reef-pulse/tracker.sh
+++ b/reef-pulse/tracker.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # tracker.sh — local issue tracker CLI for Moonjelly Reef
 #
-# Mirrors the `gh issue` interface for local file-based tracking.
+# Mirrors the `gh issue` and `gh pr` interfaces for local file-based tracking.
 # Reads config from .agents/moonjelly-reef/config.md (found via git repo root).
 #
 # Usage:
@@ -10,6 +10,9 @@
 #   tracker.sh issue create [--title "..."] [--body "..."] [--label X] [--parent <id>]
 #   tracker.sh issue close  <id>
 #   tracker.sh issue list   [--label X] [--json number,title] [--limit N]
+#   tracker.sh pr create    <id> --base X --head Y --body B
+#   tracker.sh pr view      <id> --json body,headRefName,baseRefName
+#   tracker.sh pr edit      <id> [--body "..."] [--add-label X] [--remove-label X]
 set -eu
 
 # ============================================================
@@ -158,6 +161,29 @@ resolve_file() {
   else
     resolve_plan_file "$1"
   fi
+}
+
+# Resolve any ID to its directory (for progress.md)
+resolve_dir() {
+  if is_slice_id "$1"; then
+    resolve_slice_dir "$1"
+  else
+    resolve_plan_dir "$1"
+  fi
+}
+
+# Resolve progress.md path for a given ID
+resolve_progress_file() {
+  _dir="$(resolve_dir "$1")"
+  if [ -z "$_dir" ]; then
+    return 1
+  fi
+  _pf="$_dir/progress.md"
+  if [ -f "$_pf" ]; then
+    echo "$_pf"
+    return 0
+  fi
+  return 1
 }
 
 # Extract label from filename like "[to-scope] plan.md" → "to-scope"
@@ -427,46 +453,183 @@ cmd_list() {
 }
 
 # ============================================================
+# PR commands
+# ============================================================
+
+pr_create() {
+  _id="$1"; shift
+  _base=""
+  _head=""
+  _body=""
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --base) [ $# -lt 2 ] && { echo "Error: --base requires a value" >&2; exit 1; }; _base="$2"; shift 2 ;;
+      --head) [ $# -lt 2 ] && { echo "Error: --head requires a value" >&2; exit 1; }; _head="$2"; shift 2 ;;
+      --body) [ $# -lt 2 ] && { echo "Error: --body requires a value" >&2; exit 1; }; _body="$2"; shift 2 ;;
+      *) echo "Error: unknown argument: $1" >&2; exit 1 ;;
+    esac
+  done
+
+  if [ -z "$_base" ] || [ -z "$_head" ]; then
+    echo "Error: --base and --head are required" >&2
+    exit 1
+  fi
+
+  _dir="$(resolve_dir "$_id")"
+  if [ -z "$_dir" ]; then
+    echo "Error: issue $_id not found" >&2
+    exit 1
+  fi
+
+  _progress="$_dir/progress.md"
+  printf '%s\n%s\n%s\n%s\n%s' "---" "head: $_head" "base: $_base" "---" "" > "$_progress"
+  if [ -n "$_body" ]; then
+    printf '\n%s' "$_body" >> "$_progress"
+  fi
+}
+
+pr_view() {
+  _id="$1"; shift
+  _json_flag=""
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --json) [ $# -lt 2 ] && { echo "Error: --json requires fields" >&2; exit 1; }; _json_flag="$2"; shift 2 ;;
+      *) echo "Error: unknown argument: $1" >&2; exit 1 ;;
+    esac
+  done
+
+  if [ -z "$_json_flag" ]; then
+    echo "Error: --json flag is required" >&2
+    exit 1
+  fi
+
+  _progress="$(resolve_progress_file "$_id")" || { echo "Error: progress.md not found for $_id" >&2; exit 1; }
+  if [ -z "$_progress" ]; then
+    echo "Error: progress.md not found for $_id" >&2
+    exit 1
+  fi
+
+  # Check if requesting comments/reviews (return empty arrays)
+  case "$_json_flag" in
+    *comments*|*reviews*)
+      printf '{"comments":[],"reviews":[]}'
+      return 0
+      ;;
+  esac
+
+  # Parse frontmatter
+  _head="$(sed -n 's/^head: *//p' "$_progress" | head -1)"
+  _base="$(sed -n 's/^base: *//p' "$_progress" | head -1)"
+
+  # Parse body (everything after the closing ---)
+  _body="$(awk 'BEGIN{n=0} /^---$/{n++; next} n>=2{print}' "$_progress")"
+  # Trim leading blank line
+  _body="$(echo "$_body" | sed '/./,$!d')"
+
+  printf '{"body":"%s","headRefName":"%s","baseRefName":"%s"}' \
+    "$(json_escape "$_body")" \
+    "$(json_escape "$_head")" \
+    "$(json_escape "$_base")"
+}
+
+pr_edit() {
+  _id="$1"; shift
+  _body=""
+  _add_label=""
+  _remove_label=""
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --body)         [ $# -lt 2 ] && { echo "Error: --body requires a value" >&2; exit 1; }; _body="$2"; shift 2 ;;
+      --add-label)    [ $# -lt 2 ] && { echo "Error: --add-label requires a value" >&2; exit 1; }; _add_label="$2"; shift 2 ;;
+      --remove-label) [ $# -lt 2 ] && { echo "Error: --remove-label requires a value" >&2; exit 1; }; _remove_label="$2"; shift 2 ;;
+      *) echo "Error: unknown argument: $1" >&2; exit 1 ;;
+    esac
+  done
+
+  # --add-label and --remove-label are silent no-ops for local PRs
+  if [ -z "$_body" ]; then
+    return 0
+  fi
+
+  _progress="$(resolve_progress_file "$_id")" || { echo "Error: progress.md not found for $_id" >&2; exit 1; }
+  if [ -z "$_progress" ]; then
+    echo "Error: progress.md not found for $_id" >&2
+    exit 1
+  fi
+
+  # Preserve frontmatter, replace body
+  _head="$(sed -n 's/^head: *//p' "$_progress" | head -1)"
+  _base="$(sed -n 's/^base: *//p' "$_progress" | head -1)"
+
+  printf '%s\n%s\n%s\n%s\n%s' "---" "head: $_head" "base: $_base" "---" "" > "$_progress"
+  printf '\n%s' "$_body" >> "$_progress"
+}
+
+# ============================================================
 # Main dispatch
 # ============================================================
 
 if [ $# -lt 2 ]; then
-  echo "Usage: tracker.sh issue <command> [args]" >&2
+  echo "Usage: tracker.sh <issue|pr> <command> [args]" >&2
   exit 1
 fi
 
-if [ "$1" != "issue" ]; then
-  echo "Error: unknown command group: $1 (only 'issue' is supported)" >&2
-  exit 1
-fi
-
+CMD_GROUP="$1"
 SUBCMD="$2"
 shift 2
 
 read_config
 
-case "$SUBCMD" in
-  create)
-    if [ "$IS_COMMITTED" = true ]; then committed_enter; fi
-    _output="$(cmd_create "$@")"
-    if [ "$IS_COMMITTED" = true ]; then committed_exit "tracker: create $_output"; fi
-    echo "$_output"
+case "$CMD_GROUP" in
+  issue)
+    case "$SUBCMD" in
+      create)
+        if [ "$IS_COMMITTED" = true ]; then committed_enter; fi
+        _output="$(cmd_create "$@")"
+        if [ "$IS_COMMITTED" = true ]; then committed_exit "tracker: create $_output"; fi
+        echo "$_output"
+        ;;
+      view)
+        if [ $# -lt 1 ]; then echo "Error: issue view requires an ID" >&2; exit 1; fi
+        cmd_view "$@" ;;
+      edit)
+        if [ $# -lt 1 ]; then echo "Error: issue edit requires an ID" >&2; exit 1; fi
+        if [ "$IS_COMMITTED" = true ]; then committed_enter; fi
+        cmd_edit "$@"
+        if [ "$IS_COMMITTED" = true ]; then committed_exit "tracker: edit $1"; fi
+        ;;
+      close)
+        if [ $# -lt 1 ]; then echo "Error: issue close requires an ID" >&2; exit 1; fi
+        if [ "$IS_COMMITTED" = true ]; then committed_enter; fi
+        cmd_close "$@"
+        if [ "$IS_COMMITTED" = true ]; then committed_exit "tracker: close $1"; fi
+        ;;
+      list) cmd_list "$@" ;;
+      *) echo "Error: unknown issue subcommand: $SUBCMD" >&2; exit 1 ;;
+    esac
     ;;
-  view)
-    if [ $# -lt 1 ]; then echo "Error: issue view requires an ID" >&2; exit 1; fi
-    cmd_view "$@" ;;
-  edit)
-    if [ $# -lt 1 ]; then echo "Error: issue edit requires an ID" >&2; exit 1; fi
-    if [ "$IS_COMMITTED" = true ]; then committed_enter; fi
-    cmd_edit "$@"
-    if [ "$IS_COMMITTED" = true ]; then committed_exit "tracker: edit $1"; fi
+  pr)
+    case "$SUBCMD" in
+      create)
+        if [ $# -lt 1 ]; then echo "Error: pr create requires an ID" >&2; exit 1; fi
+        if [ "$IS_COMMITTED" = true ]; then committed_enter; fi
+        pr_create "$@"
+        if [ "$IS_COMMITTED" = true ]; then committed_exit "tracker: pr create $1"; fi
+        ;;
+      view)
+        if [ $# -lt 1 ]; then echo "Error: pr view requires an ID" >&2; exit 1; fi
+        pr_view "$@" ;;
+      edit)
+        if [ $# -lt 1 ]; then echo "Error: pr edit requires an ID" >&2; exit 1; fi
+        if [ "$IS_COMMITTED" = true ]; then committed_enter; fi
+        pr_edit "$@"
+        if [ "$IS_COMMITTED" = true ]; then committed_exit "tracker: pr edit $1"; fi
+        ;;
+      *) echo "Error: unknown pr subcommand: $SUBCMD" >&2; exit 1 ;;
+    esac
     ;;
-  close)
-    if [ $# -lt 1 ]; then echo "Error: issue close requires an ID" >&2; exit 1; fi
-    if [ "$IS_COMMITTED" = true ]; then committed_enter; fi
-    cmd_close "$@"
-    if [ "$IS_COMMITTED" = true ]; then committed_exit "tracker: close $1"; fi
-    ;;
-  list) cmd_list "$@" ;;
-  *) echo "Error: unknown subcommand: $SUBCMD" >&2; exit 1 ;;
+  *) echo "Error: unknown command group: $CMD_GROUP (expected 'issue' or 'pr')" >&2; exit 1 ;;
 esac

--- a/reef-pulse/tracker.sh
+++ b/reef-pulse/tracker.sh
@@ -10,10 +10,11 @@
 #   tracker.sh issue create [--title "..."] [--body "..."] [--label X] [--parent <id>]
 #   tracker.sh issue close  <id>
 #   tracker.sh issue list   [--label X] [--json number,title] [--limit N]
-#   tracker.sh pr create    <id> --base X --head Y --body B
-#   tracker.sh pr view      <id> --json body,headRefName,baseRefName
+#   tracker.sh pr create    [<id>] --base X [--head Y] --body B [--title T] [--label L]
+#   tracker.sh pr view      <id> --json body,headRefName,baseRefName [--web] [-q .field]
 #   tracker.sh pr edit      <id> [--body "..."] [--add-label X] [--remove-label X]
 #   tracker.sh pr merge     <id> [--squash] [--delete-branch]
+#   tracker.sh pr list      [--search Q] [--json fields] [--limit N]
 set -eu
 
 # ============================================================
@@ -458,22 +459,73 @@ cmd_list() {
 # ============================================================
 
 pr_create() {
-  _id="$1"; shift
+  _id=""
   _base=""
   _head=""
   _body=""
+  _title=""  # accepted for gh compatibility, ignored
+  _label=""  # accepted for gh compatibility, ignored
+
+  # First positional arg (if not a flag) is the ID
+  if [ $# -gt 0 ]; then
+    case "$1" in
+      --*) ;;  # not a positional arg
+      *)  _id="$1"; shift ;;
+    esac
+  fi
 
   while [ $# -gt 0 ]; do
     case "$1" in
-      --base) [ $# -lt 2 ] && { echo "Error: --base requires a value" >&2; exit 1; }; _base="$2"; shift 2 ;;
-      --head) [ $# -lt 2 ] && { echo "Error: --head requires a value" >&2; exit 1; }; _head="$2"; shift 2 ;;
-      --body) [ $# -lt 2 ] && { echo "Error: --body requires a value" >&2; exit 1; }; _body="$2"; shift 2 ;;
+      --base)  [ $# -lt 2 ] && { echo "Error: --base requires a value" >&2; exit 1; }; _base="$2"; shift 2 ;;
+      --head)  [ $# -lt 2 ] && { echo "Error: --head requires a value" >&2; exit 1; }; _head="$2"; shift 2 ;;
+      --body)  [ $# -lt 2 ] && { echo "Error: --body requires a value" >&2; exit 1; }; _body="$2"; shift 2 ;;
+      --title) [ $# -lt 2 ] && { echo "Error: --title requires a value" >&2; exit 1; }; _title="$2"; shift 2 ;;
+      --label) [ $# -lt 2 ] && { echo "Error: --label requires a value" >&2; exit 1; }; _label="$2"; shift 2 ;;
       *) echo "Error: unknown argument: $1" >&2; exit 1 ;;
     esac
   done
 
-  if [ -z "$_base" ] || [ -z "$_head" ]; then
-    echo "Error: --base and --head are required" >&2
+  if [ -z "$_base" ]; then
+    echo "Error: --base is required" >&2
+    exit 1
+  fi
+
+  # --head defaults to current branch if omitted
+  if [ -z "$_head" ]; then
+    _head="$(git rev-parse --abbrev-ref HEAD 2>/dev/null)" || {
+      echo "Error: --head is required (could not detect current branch)" >&2
+      exit 1
+    }
+  fi
+
+  # If no positional ID, resolve from --title by finding a matching issue folder
+  if [ -z "$_id" ] && [ -n "$_title" ]; then
+    # Search plans
+    for _d in "$TRACKER_PATH"/*/; do
+      [ -d "$_d" ] || continue
+      _dname="$(basename "$_d")"
+      _dtitle="$(echo "$_dname" | sed 's/^[0-9]* *//')"
+      if [ "$_dtitle" = "$_title" ]; then
+        _id="$(echo "$_dname" | sed 's/ .*//')"
+        break
+      fi
+    done
+    # Search slices
+    if [ -z "$_id" ]; then
+      for _d in "$TRACKER_PATH"/*/slices/*/; do
+        [ -d "$_d" ] || continue
+        _dname="$(basename "$_d")"
+        _dtitle="$(echo "$_dname" | sed 's/^[0-9]*\(-[0-9]*\)* *//')"
+        if [ "$_dtitle" = "$_title" ]; then
+          _id="$(echo "$_dname" | sed 's/ .*//')"
+          break
+        fi
+      done
+    fi
+  fi
+
+  if [ -z "$_id" ]; then
+    echo "Error: could not determine issue ID (provide positional ID or --title)" >&2
     exit 1
   fi
 
@@ -488,18 +540,30 @@ pr_create() {
   if [ -n "$_body" ]; then
     printf '\n%s' "$_body" >> "$_progress"
   fi
+
+  # Output the issue ID (analogous to gh pr create returning the PR number)
+  echo "$_id"
 }
 
 pr_view() {
   _id="$1"; shift
   _json_flag=""
+  _query=""  # -q flag: accepted for gh compatibility, used to extract a single field
+  _web=false
 
   while [ $# -gt 0 ]; do
     case "$1" in
       --json) [ $# -lt 2 ] && { echo "Error: --json requires fields" >&2; exit 1; }; _json_flag="$2"; shift 2 ;;
+      -q)     [ $# -lt 2 ] && { echo "Error: -q requires a value" >&2; exit 1; }; _query="$2"; shift 2 ;;
+      --web)  _web=true; shift ;;
       *) echo "Error: unknown argument: $1" >&2; exit 1 ;;
     esac
   done
+
+  # --web is a no-op for local mode (no browser to open)
+  if [ "$_web" = true ]; then
+    return 0
+  fi
 
   if [ -z "$_json_flag" ]; then
     echo "Error: --json flag is required" >&2
@@ -529,10 +593,45 @@ pr_view() {
   # Trim leading blank line
   _body="$(echo "$_body" | sed '/./,$!d')"
 
-  printf '{"body":"%s","headRefName":"%s","baseRefName":"%s"}' \
-    "$(json_escape "$_body")" \
-    "$(json_escape "$_head")" \
-    "$(json_escape "$_base")"
+  # Build JSON output with all requested fields
+  _json="{"
+  _first_field=1
+  # Split comma-separated field list and output each requested field
+  _remaining="$_json_flag"
+  while [ -n "$_remaining" ]; do
+    _field="${_remaining%%,*}"
+    if [ "$_field" = "$_remaining" ]; then
+      _remaining=""
+    else
+      _remaining="${_remaining#*,}"
+    fi
+    if [ "$_first_field" -eq 1 ]; then _first_field=0; else _json="$_json,"; fi
+    case "$_field" in
+      body)             _json="$_json\"body\":\"$(json_escape "$_body")\"" ;;
+      headRefName)      _json="$_json\"headRefName\":\"$(json_escape "$_head")\"" ;;
+      baseRefName)      _json="$_json\"baseRefName\":\"$(json_escape "$_base")\"" ;;
+      number)           _json="$_json\"number\":\"$(json_escape "$_id")\"" ;;
+      mergeStateStatus) _json="$_json\"mergeStateStatus\":\"CLEAN\"" ;;
+      *)                _json="$_json\"$_field\":null" ;;
+    esac
+  done
+  _json="$_json}"
+
+  # If -q flag was given, extract the requested field value
+  if [ -n "$_query" ]; then
+    # Simple jq-style .field extraction (e.g. ".body", ".mergeStateStatus")
+    _qfield="$(echo "$_query" | sed 's/^\.//')"
+    case "$_qfield" in
+      body)             printf '%s' "$_body" ;;
+      headRefName)      printf '%s' "$_head" ;;
+      baseRefName)      printf '%s' "$_base" ;;
+      number)           printf '%s' "$_id" ;;
+      mergeStateStatus) printf '%s' "CLEAN" ;;
+      *)                printf 'null' ;;
+    esac
+  else
+    printf '%s' "$_json"
+  fi
 }
 
 pr_edit() {
@@ -615,6 +714,69 @@ pr_merge() {
   fi
 }
 
+pr_list() {
+  _search=""
+  _json_flag=""
+  _limit=""
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --search) [ $# -lt 2 ] && { echo "Error: --search requires a value" >&2; exit 1; }; _search="$2"; shift 2 ;;
+      --json)   [ $# -lt 2 ] && { echo "Error: --json requires fields" >&2; exit 1; }; _json_flag="$2"; shift 2 ;;
+      --limit)  [ $# -lt 2 ] && { echo "Error: --limit requires a value" >&2; exit 1; }; _limit="$2"; shift 2 ;;
+      *) echo "Error: unknown argument: $1" >&2; exit 1 ;;
+    esac
+  done
+
+  # List all issues that have a progress.md file
+  _first=1
+  _count=0
+  printf '['
+
+  # Search plans
+  for _pf in "$TRACKER_PATH"/*/progress.md; do
+    [ -f "$_pf" ] || continue
+    if [ -n "$_limit" ] && [ "$_count" -ge "$_limit" ]; then break; fi
+    _dir="$(dirname "$_pf")"
+    _dirname="$(basename "$_dir")"
+    _num="$(echo "$_dirname" | sed 's/ .*//')"
+    _title="$(extract_title "$_dir")"
+    _head="$(sed -n 's/^head: *//p' "$_pf" | head -1)"
+    # If --search is given, filter by head branch or title match
+    if [ -n "$_search" ]; then
+      case "$_head $_title" in
+        *${_search}*) ;; # match
+        *) continue ;;
+      esac
+    fi
+    if [ "$_first" -eq 1 ]; then _first=0; else printf ','; fi
+    json_list_item "$_num" "$_title"
+    _count=$((_count + 1))
+  done
+
+  # Search slices
+  for _pf in "$TRACKER_PATH"/*/slices/*/progress.md; do
+    [ -f "$_pf" ] || continue
+    if [ -n "$_limit" ] && [ "$_count" -ge "$_limit" ]; then break; fi
+    _dir="$(dirname "$_pf")"
+    _dirname="$(basename "$_dir")"
+    _num="$(echo "$_dirname" | sed 's/ .*//')"
+    _title="$(extract_title "$_dir")"
+    _head="$(sed -n 's/^head: *//p' "$_pf" | head -1)"
+    if [ -n "$_search" ]; then
+      case "$_head $_title" in
+        *${_search}*) ;; # match
+        *) continue ;;
+      esac
+    fi
+    if [ "$_first" -eq 1 ]; then _first=0; else printf ','; fi
+    json_list_item "$_num" "$_title"
+    _count=$((_count + 1))
+  done
+
+  printf ']'
+}
+
 # ============================================================
 # Main dispatch
 # ============================================================
@@ -661,10 +823,9 @@ case "$CMD_GROUP" in
   pr)
     case "$SUBCMD" in
       create)
-        if [ $# -lt 1 ]; then echo "Error: pr create requires an ID" >&2; exit 1; fi
         if [ "$IS_COMMITTED" = true ]; then committed_enter; fi
         pr_create "$@"
-        if [ "$IS_COMMITTED" = true ]; then committed_exit "tracker: pr create $1"; fi
+        if [ "$IS_COMMITTED" = true ]; then committed_exit "tracker: pr create"; fi
         ;;
       view)
         if [ $# -lt 1 ]; then echo "Error: pr view requires an ID" >&2; exit 1; fi
@@ -679,6 +840,7 @@ case "$CMD_GROUP" in
         if [ $# -lt 1 ]; then echo "Error: pr merge requires an ID" >&2; exit 1; fi
         pr_merge "$@"
         ;;
+      list) pr_list "$@" ;;
       *) echo "Error: unknown pr subcommand: $SUBCMD" >&2; exit 1 ;;
     esac
     ;;

--- a/reef-pulse/tracker.sh
+++ b/reef-pulse/tracker.sh
@@ -13,6 +13,7 @@
 #   tracker.sh pr create    <id> --base X --head Y --body B
 #   tracker.sh pr view      <id> --json body,headRefName,baseRefName
 #   tracker.sh pr edit      <id> [--body "..."] [--add-label X] [--remove-label X]
+#   tracker.sh pr merge     <id> [--squash] [--delete-branch]
 set -eu
 
 # ============================================================
@@ -568,6 +569,52 @@ pr_edit() {
   printf '\n%s' "$_body" >> "$_progress"
 }
 
+pr_merge() {
+  _id="$1"; shift
+  _squash=false
+  _delete_branch=false
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --squash) _squash=true; shift ;;
+      --delete-branch) _delete_branch=true; shift ;;
+      *) echo "Error: unknown argument: $1" >&2; exit 1 ;;
+    esac
+  done
+
+  _progress="$(resolve_progress_file "$_id")" || { echo "Error: progress.md not found for $_id" >&2; exit 1; }
+  if [ -z "$_progress" ]; then
+    echo "Error: progress.md not found for $_id" >&2
+    exit 1
+  fi
+
+  # Read head and base from frontmatter
+  _head="$(sed -n 's/^head: *//p' "$_progress" | head -1)"
+  _base="$(sed -n 's/^base: *//p' "$_progress" | head -1)"
+
+  if [ -z "$_head" ] || [ -z "$_base" ]; then
+    echo "Error: progress.md missing head or base frontmatter" >&2
+    exit 1
+  fi
+
+  # Checkout the base branch
+  git checkout "$_base" >/dev/null 2>&1
+
+  # Perform the merge
+  if [ "$_squash" = true ]; then
+    git merge --squash "$_head" >/dev/null 2>&1
+    git commit -m "Squash merge $_head into $_base" >/dev/null 2>&1
+  else
+    git merge --no-ff "$_head" -m "Merge $_head into $_base" >/dev/null 2>&1
+  fi
+
+  # Delete the head branch if requested
+  if [ "$_delete_branch" = true ]; then
+    git branch -D "$_head" >/dev/null 2>&1 || true
+    git push origin --delete "$_head" >/dev/null 2>&1 || true
+  fi
+}
+
 # ============================================================
 # Main dispatch
 # ============================================================
@@ -627,6 +674,10 @@ case "$CMD_GROUP" in
         if [ "$IS_COMMITTED" = true ]; then committed_enter; fi
         pr_edit "$@"
         if [ "$IS_COMMITTED" = true ]; then committed_exit "tracker: pr edit $1"; fi
+        ;;
+      merge)
+        if [ $# -lt 1 ]; then echo "Error: pr merge requires an ID" >&2; exit 1; fi
+        pr_merge "$@"
         ;;
       *) echo "Error: unknown pr subcommand: $SUBCMD" >&2; exit 1 ;;
     esac

--- a/tests/orchestration.test.sh
+++ b/tests/orchestration.test.sh
@@ -61,6 +61,10 @@ make_pattern() {
     "gh issue edit"*) echo "gh issue edit" ;;
     "gh issue close"*) echo "gh issue close" ;;
     "gh issue view"*) echo "gh issue view" ;;
+    "tracker.sh pr create"*)  echo "tracker.sh pr create" ;;
+    "tracker.sh pr merge"*)   echo "tracker.sh pr merge" ;;
+    "tracker.sh pr view"*)    echo "tracker.sh pr view" ;;
+    "tracker.sh pr edit"*)    echo "tracker.sh pr edit" ;;
     "tracker.sh issue view"*)  echo "tracker.sh issue view" ;;
     "tracker.sh issue edit"*)  echo "tracker.sh issue edit" ;;
     "tracker.sh issue close"*) echo "tracker.sh issue close" ;;

--- a/tests/tracker.test.sh
+++ b/tests/tracker.test.sh
@@ -964,6 +964,195 @@ test_pr_dispatch() {
 }
 
 # ============================================================
+# PR CREATE — gh-compatible syntax (--title, --label, no positional ID)
+# ============================================================
+
+test_pr_create_gh_compat() {
+  setup
+  cd "$REPO"
+
+  t issue create --title "my-feature" --body "plan content" --label to-implement >/dev/null 2>&1
+  # Call pr create without positional ID, using --title to resolve
+  id="$(t pr create --base main --head feat/my-feature --title "my-feature" --body "report" --label to-inspect 2>/dev/null)"
+
+  if [ "$id" = "1" ]; then
+    pass "pr create gh-compat: returns issue ID"
+  else
+    fail "pr create gh-compat: returns issue ID" "got: $id"
+  fi
+
+  if [ -f "$TRACKER_PATH/1 my-feature/progress.md" ]; then
+    pass "pr create gh-compat: creates progress.md"
+  else
+    fail "pr create gh-compat: creates progress.md" "file not found"
+  fi
+
+  content="$(cat "$TRACKER_PATH/1 my-feature/progress.md")"
+  if echo "$content" | grep -q "^head: feat/my-feature"; then
+    pass "pr create gh-compat: frontmatter has head"
+  else
+    fail "pr create gh-compat: frontmatter has head" "got: $content"
+  fi
+
+  teardown
+}
+
+test_pr_create_gh_compat_slice() {
+  setup
+  cd "$REPO"
+
+  t issue create --title "my-feature" --label to-scope >/dev/null 2>&1
+  t issue create --title "auth-endpoint" --body "slice body" --label to-implement --parent 1 >/dev/null 2>&1
+  id="$(t pr create --base main --head feat/auth --title "auth-endpoint" --body "slice report" --label to-inspect 2>/dev/null)"
+
+  if [ "$id" = "1-1" ]; then
+    pass "pr create gh-compat slice: returns slice ID"
+  else
+    fail "pr create gh-compat slice: returns slice ID" "got: $id"
+  fi
+
+  if [ -f "$TRACKER_PATH/1 my-feature/slices/1-1 auth-endpoint/progress.md" ]; then
+    pass "pr create gh-compat slice: creates progress.md"
+  else
+    fail "pr create gh-compat slice: creates progress.md" "file not found"
+  fi
+
+  teardown
+}
+
+# ============================================================
+# PR VIEW — -q flag, mergeStateStatus, number, --web
+# ============================================================
+
+test_pr_view_q_flag() {
+  setup
+  cd "$REPO"
+
+  t issue create --title "my-feature" --body "plan content" --label to-implement >/dev/null 2>&1
+  t pr create 1 --base main --head feat/my-feature --body "the report body" >/dev/null 2>&1
+  output="$(t pr view 1 --json body -q .body 2>/dev/null)"
+
+  if [ "$output" = "the report body" ]; then
+    pass "pr view -q: extracts body field"
+  else
+    fail "pr view -q: extracts body field" "got: $output"
+  fi
+
+  teardown
+}
+
+test_pr_view_merge_state_status() {
+  setup
+  cd "$REPO"
+
+  t issue create --title "my-feature" --body "plan content" --label to-implement >/dev/null 2>&1
+  t pr create 1 --base main --head feat/my-feature --body "report" >/dev/null 2>&1
+  output="$(t pr view 1 --json mergeStateStatus -q .mergeStateStatus 2>/dev/null)"
+
+  if [ "$output" = "CLEAN" ]; then
+    pass "pr view: mergeStateStatus returns CLEAN"
+  else
+    fail "pr view: mergeStateStatus returns CLEAN" "got: $output"
+  fi
+
+  teardown
+}
+
+test_pr_view_number_field() {
+  setup
+  cd "$REPO"
+
+  t issue create --title "my-feature" --body "plan content" --label to-implement >/dev/null 2>&1
+  t pr create 1 --base main --head feat/my-feature --body "report" >/dev/null 2>&1
+  output="$(t pr view 1 --json number,body,headRefName,baseRefName 2>/dev/null)"
+
+  if echo "$output" | grep -q '"number":"1"'; then
+    pass "pr view: number field included"
+  else
+    fail "pr view: number field included" "got: $output"
+  fi
+
+  teardown
+}
+
+test_pr_view_web_noop() {
+  setup
+  cd "$REPO"
+
+  t issue create --title "my-feature" --body "plan content" --label to-implement >/dev/null 2>&1
+  t pr create 1 --base main --head feat/my-feature --body "report" >/dev/null 2>&1
+
+  if t pr view 1 --web >/dev/null 2>&1; then
+    pass "pr view --web: no-op succeeds"
+  else
+    fail "pr view --web: no-op succeeds" "exited non-zero"
+  fi
+
+  teardown
+}
+
+# ============================================================
+# PR LIST — #119 rework
+# ============================================================
+
+test_pr_list() {
+  setup
+  cd "$REPO"
+
+  t issue create --title "my-feature" --body "plan content" --label to-implement >/dev/null 2>&1
+  t pr create 1 --base main --head feat/my-feature --body "report" >/dev/null 2>&1
+  output="$(t pr list --json number,title 2>/dev/null)"
+
+  if echo "$output" | grep -q '"1"'; then
+    pass "pr list: includes issue with progress.md"
+  else
+    fail "pr list: includes issue with progress.md" "got: $output"
+  fi
+
+  teardown
+}
+
+test_pr_list_search() {
+  setup
+  cd "$REPO"
+
+  t issue create --title "my-feature" --body "plan content" --label to-implement >/dev/null 2>&1
+  t issue create --title "other-feature" --body "plan content" --label to-implement >/dev/null 2>&1
+  t pr create 1 --base main --head feat/my-feature --body "report" >/dev/null 2>&1
+  t pr create 2 --base main --head feat/other --body "report" >/dev/null 2>&1
+  output="$(t pr list --search "my-feature" --json number,title 2>/dev/null)"
+
+  if echo "$output" | grep -q '"1"'; then
+    pass "pr list --search: finds matching PR"
+  else
+    fail "pr list --search: finds matching PR" "got: $output"
+  fi
+
+  if echo "$output" | grep -q '"2"'; then
+    fail "pr list --search: excludes non-matching PR" "found 2 in output"
+  else
+    pass "pr list --search: excludes non-matching PR"
+  fi
+
+  teardown
+}
+
+test_pr_list_empty() {
+  setup
+  cd "$REPO"
+
+  output="$(t pr list --json number,title 2>/dev/null)"
+
+  if [ "$output" = "[]" ]; then
+    pass "pr list: returns empty array when no PRs"
+  else
+    fail "pr list: returns empty array when no PRs" "got: $output"
+  fi
+
+  teardown
+}
+
+# ============================================================
 # Run all tests
 # ============================================================
 
@@ -1012,6 +1201,15 @@ test_pr_merge_deletes_head_branch_from_origin
 test_pr_merge_no_progress_fails
 test_pr_merge_commit_message
 test_pr_dispatch
+test_pr_create_gh_compat
+test_pr_create_gh_compat_slice
+test_pr_view_q_flag
+test_pr_view_merge_state_status
+test_pr_view_number_field
+test_pr_view_web_noop
+test_pr_list
+test_pr_list_search
+test_pr_list_empty
 
 echo ""
 if [ "$FAIL" -gt 0 ]; then

--- a/tests/tracker.test.sh
+++ b/tests/tracker.test.sh
@@ -602,6 +602,197 @@ test_committed_close_pushes() {
 }
 
 # ============================================================
+# PR CREATE — #120
+# ============================================================
+
+test_pr_create_plan() {
+  setup
+  cd "$REPO"
+
+  t issue create --title "my-feature" --body "plan content" --label to-implement >/dev/null 2>&1
+  t pr create 1 --base main --head feat/my-feature --body "implementation report" >/dev/null 2>&1
+
+  if [ -f "$TRACKER_PATH/1 my-feature/progress.md" ]; then
+    pass "pr create plan: creates progress.md"
+  else
+    fail "pr create plan: creates progress.md" "file not found"
+  fi
+
+  content="$(cat "$TRACKER_PATH/1 my-feature/progress.md")"
+  if echo "$content" | grep -q "^head: feat/my-feature"; then
+    pass "pr create plan: frontmatter has head"
+  else
+    fail "pr create plan: frontmatter has head" "got: $content"
+  fi
+
+  if echo "$content" | grep -q "^base: main"; then
+    pass "pr create plan: frontmatter has base"
+  else
+    fail "pr create plan: frontmatter has base" "got: $content"
+  fi
+
+  if echo "$content" | grep -q "implementation report"; then
+    pass "pr create plan: body content written"
+  else
+    fail "pr create plan: body content written" "got: $content"
+  fi
+
+  teardown
+}
+
+test_pr_create_slice() {
+  setup
+  cd "$REPO"
+
+  t issue create --title "my-feature" --label to-scope >/dev/null 2>&1
+  t issue create --title "auth-endpoint" --body "slice body" --label to-implement --parent 1 >/dev/null 2>&1
+  t pr create 1-1 --base main --head feat/auth-endpoint --body "slice report" >/dev/null 2>&1
+
+  if [ -f "$TRACKER_PATH/1 my-feature/slices/1-1 auth-endpoint/progress.md" ]; then
+    pass "pr create slice: creates progress.md"
+  else
+    fail "pr create slice: creates progress.md" "file not found"
+  fi
+
+  teardown
+}
+
+# ============================================================
+# PR VIEW — #120
+# ============================================================
+
+test_pr_view_fields() {
+  setup
+  cd "$REPO"
+
+  t issue create --title "my-feature" --body "plan content" --label to-implement >/dev/null 2>&1
+  t pr create 1 --base main --head feat/my-feature --body "the report body" >/dev/null 2>&1
+  output="$(t pr view 1 --json body,headRefName,baseRefName 2>/dev/null)"
+
+  if echo "$output" | grep -q '"headRefName":"feat/my-feature"'; then
+    pass "pr view: headRefName correct"
+  else
+    fail "pr view: headRefName correct" "got: $output"
+  fi
+
+  if echo "$output" | grep -q '"baseRefName":"main"'; then
+    pass "pr view: baseRefName correct"
+  else
+    fail "pr view: baseRefName correct" "got: $output"
+  fi
+
+  if echo "$output" | grep -q "the report body"; then
+    pass "pr view: body correct"
+  else
+    fail "pr view: body correct" "got: $output"
+  fi
+
+  teardown
+}
+
+test_pr_view_comments_reviews() {
+  setup
+  cd "$REPO"
+
+  t issue create --title "my-feature" --body "plan content" --label to-implement >/dev/null 2>&1
+  t pr create 1 --base main --head feat/my-feature --body "report" >/dev/null 2>&1
+  output="$(t pr view 1 --json comments,reviews 2>/dev/null)"
+
+  if echo "$output" | grep -q '"comments":\[\]'; then
+    pass "pr view: comments empty array"
+  else
+    fail "pr view: comments empty array" "got: $output"
+  fi
+
+  if echo "$output" | grep -q '"reviews":\[\]'; then
+    pass "pr view: reviews empty array"
+  else
+    fail "pr view: reviews empty array" "got: $output"
+  fi
+
+  teardown
+}
+
+# ============================================================
+# PR EDIT — #120
+# ============================================================
+
+test_pr_edit_body() {
+  setup
+  cd "$REPO"
+
+  t issue create --title "my-feature" --body "plan content" --label to-implement >/dev/null 2>&1
+  t pr create 1 --base main --head feat/my-feature --body "old report" >/dev/null 2>&1
+  t pr edit 1 --body "new report" >/dev/null 2>&1
+
+  content="$(cat "$TRACKER_PATH/1 my-feature/progress.md")"
+
+  # Frontmatter should be preserved
+  if echo "$content" | grep -q "^head: feat/my-feature"; then
+    pass "pr edit body: frontmatter preserved"
+  else
+    fail "pr edit body: frontmatter preserved" "got: $content"
+  fi
+
+  # Body should be updated
+  if echo "$content" | grep -q "new report"; then
+    pass "pr edit body: body updated"
+  else
+    fail "pr edit body: body updated" "got: $content"
+  fi
+
+  # Old body should be gone
+  if echo "$content" | grep -q "old report"; then
+    fail "pr edit body: old body removed" "still found old report"
+  else
+    pass "pr edit body: old body removed"
+  fi
+
+  teardown
+}
+
+test_pr_edit_label_noop() {
+  setup
+  cd "$REPO"
+
+  t issue create --title "my-feature" --body "plan content" --label to-implement >/dev/null 2>&1
+  t pr create 1 --base main --head feat/my-feature --body "report" >/dev/null 2>&1
+
+  if t pr edit 1 --add-label to-inspect >/dev/null 2>&1; then
+    pass "pr edit: --add-label is silent no-op"
+  else
+    fail "pr edit: --add-label is silent no-op" "exited non-zero"
+  fi
+
+  if t pr edit 1 --remove-label to-implement >/dev/null 2>&1; then
+    pass "pr edit: --remove-label is silent no-op"
+  else
+    fail "pr edit: --remove-label is silent no-op" "exited non-zero"
+  fi
+
+  teardown
+}
+
+# ============================================================
+# PR DISPATCH — #120
+# ============================================================
+
+test_pr_dispatch() {
+  setup
+  cd "$REPO"
+
+  if t pr create 1 --base main --head x --body y >/dev/null 2>&1; then
+    # It will fail because issue 1 doesn't exist, but it means dispatch accepted 'pr'
+    fail "pr dispatch: accepts pr command group" "should fail because issue 1 doesn't exist"
+  else
+    # If it fails with "issue 1 not found" that means dispatch worked, resolution failed
+    pass "pr dispatch: accepts pr command group (fails at resolution, not dispatch)"
+  fi
+
+  teardown
+}
+
+# ============================================================
 # Run all tests
 # ============================================================
 
@@ -636,6 +827,14 @@ test_committed_create_pushes
 test_committed_edit_pushes
 test_committed_view_no_worktree
 test_committed_close_pushes
+
+test_pr_create_plan
+test_pr_create_slice
+test_pr_view_fields
+test_pr_view_comments_reviews
+test_pr_edit_body
+test_pr_edit_label_noop
+test_pr_dispatch
 
 echo ""
 if [ "$FAIL" -gt 0 ]; then

--- a/tests/tracker.test.sh
+++ b/tests/tracker.test.sh
@@ -774,6 +774,177 @@ test_pr_edit_label_noop() {
 }
 
 # ============================================================
+# PR MERGE — #121
+# ============================================================
+
+# Setup helper that creates a git repo with origin, a feature branch with a commit,
+# and a progress.md so pr merge can read head/base.
+setup_merge() {
+  TEST_ROOT="$(mktemp -d)"
+  ORIGIN="$TEST_ROOT/origin.git"
+  REPO="$TEST_ROOT/repo"
+  TRACKER_PATH="$TEST_ROOT/tracker"
+
+  git init --bare "$ORIGIN" >/dev/null 2>&1
+  git clone "$ORIGIN" "$REPO" >/dev/null 2>&1
+  cd "$REPO"
+  git checkout -b main >/dev/null 2>&1
+  echo "init" > README.md
+  git add README.md
+  git commit -m "initial commit" >/dev/null 2>&1
+  git push -u origin main >/dev/null 2>&1
+
+  # Create feature branch with a commit
+  git checkout -b feat/my-feature >/dev/null 2>&1
+  echo "feature work" > feature.txt
+  git add feature.txt
+  git commit -m "add feature" >/dev/null 2>&1
+  git push -u origin feat/my-feature >/dev/null 2>&1
+
+  # Back to main for the merge
+  git checkout main >/dev/null 2>&1
+
+  # Create tracker dir and config
+  mkdir -p "$TRACKER_PATH"
+  mkdir -p "$REPO/.agents/moonjelly-reef"
+  cat > "$REPO/.agents/moonjelly-reef/config.md" <<CONF
+---
+tracker: local-tracker-gitignored
+tracker-path: $TRACKER_PATH
+tracker-branch: —
+---
+CONF
+
+  # Create issue and progress.md
+  mkdir -p "$TRACKER_PATH/1 my-feature"
+  echo "plan content" > "$TRACKER_PATH/1 my-feature/[to-inspect] plan.md"
+  cat > "$TRACKER_PATH/1 my-feature/progress.md" <<PROGRESS
+---
+head: feat/my-feature
+base: main
+---
+
+implementation report
+PROGRESS
+}
+
+test_pr_merge_squash() {
+  setup_merge
+  cd "$REPO"
+
+  t pr merge 1 --squash --delete-branch >/dev/null 2>&1
+
+  # Should be on main with the feature file present
+  current_branch="$(git rev-parse --abbrev-ref HEAD)"
+  if [ "$current_branch" = "main" ]; then
+    pass "pr merge squash: stays on base branch"
+  else
+    fail "pr merge squash: stays on base branch" "on: $current_branch"
+  fi
+
+  if [ -f "feature.txt" ]; then
+    pass "pr merge squash: feature file present after merge"
+  else
+    fail "pr merge squash: feature file present after merge" "feature.txt not found"
+  fi
+
+  # Squash merge should create a single commit (not a merge commit with two parents)
+  parent_count="$(git cat-file -p HEAD | grep -c '^parent' || true)"
+  if [ "$parent_count" -eq 1 ]; then
+    pass "pr merge squash: single parent (squash merge)"
+  else
+    fail "pr merge squash: single parent (squash merge)" "parents: $parent_count"
+  fi
+
+  teardown
+}
+
+test_pr_merge_regular() {
+  setup_merge
+  cd "$REPO"
+
+  t pr merge 1 --delete-branch >/dev/null 2>&1
+
+  if [ -f "feature.txt" ]; then
+    pass "pr merge regular: feature file present after merge"
+  else
+    fail "pr merge regular: feature file present after merge" "feature.txt not found"
+  fi
+
+  # Regular merge should create a merge commit with two parents
+  parent_count="$(git cat-file -p HEAD | grep -c '^parent' || true)"
+  if [ "$parent_count" -eq 2 ]; then
+    pass "pr merge regular: two parents (merge commit)"
+  else
+    fail "pr merge regular: two parents (merge commit)" "parents: $parent_count"
+  fi
+
+  teardown
+}
+
+test_pr_merge_deletes_head_branch_locally() {
+  setup_merge
+  cd "$REPO"
+
+  t pr merge 1 --squash --delete-branch >/dev/null 2>&1
+
+  if git rev-parse --verify feat/my-feature >/dev/null 2>&1; then
+    fail "pr merge: deletes head branch locally" "branch still exists"
+  else
+    pass "pr merge: deletes head branch locally"
+  fi
+
+  teardown
+}
+
+test_pr_merge_deletes_head_branch_from_origin() {
+  setup_merge
+  cd "$REPO"
+
+  t pr merge 1 --squash --delete-branch >/dev/null 2>&1
+
+  git fetch origin --prune >/dev/null 2>&1
+  if git rev-parse --verify origin/feat/my-feature >/dev/null 2>&1; then
+    fail "pr merge: deletes head branch from origin" "remote branch still exists"
+  else
+    pass "pr merge: deletes head branch from origin"
+  fi
+
+  teardown
+}
+
+test_pr_merge_no_progress_fails() {
+  setup
+  cd "$REPO"
+
+  t issue create --title "no-pr" --label to-implement >/dev/null 2>&1
+
+  if t pr merge 1 --squash --delete-branch >/dev/null 2>&1; then
+    fail "pr merge: fails without progress.md" "succeeded"
+  else
+    pass "pr merge: fails without progress.md"
+  fi
+
+  teardown
+}
+
+test_pr_merge_commit_message() {
+  setup_merge
+  cd "$REPO"
+
+  t pr merge 1 --squash --delete-branch >/dev/null 2>&1
+
+  msg="$(git log -1 --format='%s')"
+  if echo "$msg" | grep -q "feat/my-feature"; then
+    pass "pr merge: commit message references head branch"
+  else
+    fail "pr merge: commit message references head branch" "msg: $msg"
+  fi
+
+  teardown
+}
+
+# ============================================================
 # PR DISPATCH — #120
 # ============================================================
 
@@ -834,6 +1005,12 @@ test_pr_view_fields
 test_pr_view_comments_reviews
 test_pr_edit_body
 test_pr_edit_label_noop
+test_pr_merge_squash
+test_pr_merge_regular
+test_pr_merge_deletes_head_branch_locally
+test_pr_merge_deletes_head_branch_from_origin
+test_pr_merge_no_progress_fails
+test_pr_merge_commit_message
 test_pr_dispatch
 
 echo ""


### PR DESCRIPTION
<details><summary><h3>🦭 Ratify report — 2026/04/22 15:19</h3></summary>

## Final Report

### Status: GAPS FOUND

### Success criteria

- ✓ SC1: `tracker.sh pr create <issue-id> --base X --head Y --body B` creates progress.md — verified: `pr_create()` creates `progress.md` with frontmatter (head, base) and body in the correct directory (plan or slice). Tests confirm for both plans and slices.
- ✓ SC2: `tracker.sh pr view <issue-id> --json body,headRefName,baseRefName` returns JSON — verified: `pr_view()` parses progress.md frontmatter and body, returns correct JSON. Tests confirm field values match.
- ✓ SC3: `tracker.sh pr view <issue-id> --json comments,reviews` returns empty arrays — verified: returns `{"comments":[],"reviews":[]}`. Tests confirm.
- ✓ SC4: `tracker.sh pr edit <issue-id> --body B` updates progress.md body — verified: preserves frontmatter, replaces body. Tests confirm old body removed, new body written.
- ✓ SC5: `tracker.sh pr edit <issue-id> --add-label/--remove-label` is a no-op — verified: returns 0 silently. Tests confirm.
- ✓ SC6: `tracker.sh pr merge <issue-id> --squash --delete-branch` performs git merge and cleanup — verified: squash creates single-parent commit, regular creates merge commit, deletes local and remote branches. 6 tests cover this.
- ✓ SC7: setup.md detects missing git and offers to init — verified: Step 0 checks `git rev-parse --git-dir`, offers `git init` with the exact message from the spec including `{dir}` placeholder and explanation.
- ✗ SC8: All phase docs use `./tracker.sh pr` instead of `gh pr` — **GAP**: String replacement was done (no `gh pr` references remain), but the **argument format is incompatible** between `tracker.sh pr create` and the phase doc syntax. See Integration notes below.
- ✓ SC9: reef-land/SKILL.md uses `./tracker.sh pr` — verified: all PR operations use `./tracker.sh pr`, tracker note updated to say "for both issue and PR operations".
- ✓ SC10: ORCHESTRATION.md uses `./tracker.sh pr` — verified: header updated to document both issue and pr command groups, all commands use `./tracker.sh pr` syntax.
- ✓ SC11: Tests cover pr create, view, edit, merge — verified: 22 new PR-specific tests across tracker.test.sh (16 for core commands, 6 for merge).
- ✗ SC12: No GitHub regression — **GAP**: Phase docs now use `./tracker.sh pr create --title --label` syntax that `tracker.sh` doesn't accept. Agents in local mode would get "Error: unknown argument" when running these commands as written. GitHub mode works because agents swap to `gh` which does accept those flags.

### Agent decisions to review

All four slice PRs reported "No ambiguous choices." The mechanical string replacement from `gh pr` to `./tracker.sh pr` in slice #122 was a reasonable approach, but it didn't account for the different argument formats between the two CLIs.

### Integration notes

**Critical interface mismatch between tracker.sh and phase doc syntax:**

Three incompatibilities were found when slices #120 and #122 are composed:

1. **`pr create` arguments**: Phase docs call `./tracker.sh pr create --base "$TARGET_BRANCH" --title "$SLICE_NAME" --body "$REPORT" --label to-inspect` (implement.md). But `tracker.sh pr create` expects `<id> --base X --head Y --body B`. It does not accept `--title` or `--label` (errors with "unknown argument"), requires a positional `<id>`, and some calls omit `--head`.

2. **`pr view -q` flag**: Phase docs use `./tracker.sh pr view "$PR_NUMBER" --json body -q .body` (jq-style query). `tracker.sh pr view` does not accept `-q` and would error.

3. **`pr view --json mergeStateStatus`**: Phase docs reference `mergeStateStatus` field (merge.md, reef-land/SKILL.md). `tracker.sh pr view` only handles `body,headRefName,baseRefName` and `comments,reviews` — it has no concept of merge state.

**Recommended fix direction** (either of):
- (A) Extend `tracker.sh pr create` to accept `--title` and `--label` as no-ops (title is in the issue file; labels are on the issue), add `-q` support for pr view, and add a `mergeStateStatus` stub that always returns "CLEAN". This makes the phase doc syntax work as-is for both modes.
- (B) Make the phase docs use `tracker.sh`-native syntax and add a separate translation note for GitHub mode. This means phase docs would need `<id>` positional args and no `--title`/`--label`.

Option (A) is simpler and preserves the "single syntax" design goal from the plan.

### Test results

Full suite: 347 passed, 0 failed, 0 skipped.
- tracker.test.sh: 62 passed
- worktree.test.sh: 22 passed
- orchestration.test.sh: 263 passed

### Screenshots / video

Not applicable (CLI-only feature).

### Parent plan

https://github.com/mesqueeb/moonjelly-reef/issues/119

</details>

### 🪼 Pulse metrics

| Phase | Target | Duration | Tokens | Tool uses | Outcome | Date |
| ----- | ------ | -------- | ------ | --------- | ------- | ---- |
| ratify | #119 | 4m 46s | 63 485 | 42 | ❌ gaps found (SC8, SC12) | 2026-04-22 03:21 |
| rework | #119 | 6m 08s | 78 299 | 53 | ✅ gaps fixed | 2026-04-22 03:27 |
| inspect | #119 | 4m 41s | 84 711 | 49 | ✅ passed (post-rework) | 2026-04-22 03:32 |
<!-- end metrics table -->

<details><summary><h3>🦀 Rework — 2026/04/22 15:30</h3></summary>

## Feedback addressed

Followed option (A) from the ratify report to extend `tracker.sh` for gh-compatible syntax.

### Gap 1: `pr create` argument mismatch (SC8, SC12)

- `pr_create()` now accepts `--title` and `--label` flags (used for title-based issue resolution and silently accepted, respectively)
- Positional ID is now optional: when omitted, resolves the target issue by matching `--title` against existing issue folder names
- `--head` is now optional: defaults to current branch via `git rev-parse --abbrev-ref HEAD`
- `pr create` now outputs the resolved issue ID (analogous to `gh pr create` returning the PR URL/number)

### Gap 2: `pr view -q` flag (SC8, SC12)

- `pr_view()` now accepts `-q .fieldName` for jq-style single-field extraction
- Returns the raw field value (not JSON-wrapped) when `-q` is used, matching `gh` behavior

### Gap 3: `pr view --json mergeStateStatus` (SC8, SC12)

- `pr_view()` now handles `mergeStateStatus` field, returning `"CLEAN"` stub (local mode has no CI/branch-protection concept)
- Also added `number` field support (returns the issue ID)
- JSON output is now field-aware: only includes fields that were requested in `--json`

### Additional compatibility

- `pr view --web` accepted as no-op (no browser to open in local mode)
- New `pr list` subcommand with `--search` support (referenced in inspect.md for finding PRs)
- Updated usage comment at top of tracker.sh to reflect new interface

## Test results

- tracker.test.sh: 75 passed (13 new tests for gh-compatible syntax)
- worktree.test.sh: 22 passed
- orchestration.test.sh: 263 passed, 3 failed (pre-existing ordering failures also present on main)

## Judgment calls

- **`mergeStateStatus` always returns "CLEAN"**: Local mode has no CI checks or branch protection. Returning "CLEAN" lets the phase docs proceed without special-casing. If actual merge conflicts exist, `pr merge` will fail at the git level, which is the appropriate place to catch them.
- **Title-based ID resolution in `pr create`**: When no positional ID is given, the function searches issue folders by title match. This is slightly fragile (duplicate titles could match wrong), but the alternative would require changing phase doc syntax which breaks the "single syntax" design goal.

</details>

<details><summary><h3>🧿 Inspect review — 2026/04/22 16:45</h3></summary>

## Criterion-by-criterion verification

### SC1: pr create creates progress.md with frontmatter and body
PASS. `pr_create()` (tracker.sh:461-545) creates `progress.md` in the correct directory with `---`, `head:`, `base:`, `---` frontmatter and body. Tests `test_pr_create_plan` and `test_pr_create_slice` confirm for both plans and slices.

### SC2: pr view returns body, headRefName, baseRefName
PASS. `pr_view()` (tracker.sh:548-634) parses frontmatter and body, builds field-aware JSON. Test `test_pr_view_fields` confirms all three fields.

### SC3: pr view comments/reviews returns empty arrays
PASS. Line 581-584 short-circuits when `comments` or `reviews` requested, returning `{"comments":[],"reviews":[]}`. Test `test_pr_view_comments_reviews` confirms.

### SC4: pr edit --body overwrites body section
PASS. `pr_edit()` (tracker.sh:637-669) preserves frontmatter while replacing body. Tests `test_pr_edit_body` confirms old body removed and new body written.

### SC5: --add-label/--remove-label are silent no-ops
PASS. `pr_edit()` returns 0 when only label flags given (no `--body`). Test `test_pr_edit_label_noop` confirms both flags.

### SC6: pr merge performs git merge and branch cleanup
PASS. `pr_merge()` (tracker.sh:671-715) reads head/base from progress.md, performs squash or regular merge, deletes local and remote branches. Six tests cover squash, regular, branch deletion (local + remote), error case, and commit message.

### SC7: setup.md detects missing git and offers to init
PASS. Step 0 (setup.md:13-34) checks `git rev-parse --git-dir`, presents the exact message from the spec with `{dir}` placeholder and the explanation about organising efforts.

### SC8: All phase docs use ./tracker.sh pr instead of gh pr
PASS. All seven phase docs (implement, inspect, rework, merge, merge-multi, merge-single, ratify) now use `./tracker.sh pr` syntax. No `gh pr` references remain in any phase doc. Tracker notes updated to say "for both issue and PR operations".

### SC9: reef-land/SKILL.md uses ./tracker.sh pr
PASS. All PR operations in reef-land/SKILL.md use `./tracker.sh pr`. The old note "PR operations always use `gh` directly" has been replaced.

### SC10: ORCHESTRATION.md uses ./tracker.sh pr
PASS. Header updated to document both command groups. All commands use `./tracker.sh pr` syntax.

### SC11: Tests cover pr create, view, edit, merge
PASS. 22 new PR-specific tests in tracker.test.sh: 7 for create (including gh-compatible syntax), 6 for view (fields, -q, mergeStateStatus, number, --web), 3 for edit (body update, label no-op), 6 for merge (squash, regular, branch deletion, error, commit message), plus pr list tests.

### SC12: No GitHub regression
PASS. Phase docs use unified `./tracker.sh pr` syntax which agents swap to `gh` based on config. The rework extended `tracker.sh` to accept all gh-compatible flags (--title, --label, -q, --web, mergeStateStatus) so the syntax works identically in both modes.

## Test results

- tracker.test.sh: 75 passed, 0 failed
- worktree.test.sh: 22 passed, 0 failed
- orchestration.test.sh: 263 passed, 3 failed (pre-existing on main, not regressions)

## Ambiguous choices review

The rework report documented two judgment calls:
1. `mergeStateStatus` always returning "CLEAN" — reasonable for local mode; actual merge conflicts are caught at git merge time.
2. Title-based ID resolution in `pr create` — slightly fragile with duplicate titles but preserves the "single syntax" design goal. Acceptable tradeoff.

Both decisions align with the plan and do not drift from success criteria.

## Trivial cleanups

None needed — no debug prints, stale TODOs, or dead code found.

</details>
