### PR TITLE
Saga foundation and world bootstrap

### DIFF
--- a/reef-pulse/SKILL.md
+++ b/reef-pulse/SKILL.md
@@ -17,6 +17,9 @@ Capture the skill base directory (provided by the harness as "Base directory for
 
 ```sh
 SKILL_DIR="{base directory for this skill}"
+SAGA_DIR=".agents/moonjelly-reef/saga/"
+WORLD_FILE="$SAGA_DIR/world.md"
+SAGA_WRITER_PROMPT="$SKILL_DIR/saga-writer.md"
 ```
 
 ## 0a. Acquire lock
@@ -62,7 +65,14 @@ If this is the first iteration of the pulse (not a recursive call), print the se
 └─────────────────────────────────────────────────────────────┘
 ```
 
-Initialize an empty lore story list to collect lore snippets across the session. Initialize the pulse counter to 0.
+This is also where the saga bootstrap behavior lives. Before printing the first pulse header:
+
+- Create `.agents/moonjelly-reef/saga/` when it does not already exist.
+- Initialize `world.md` from `$SKILL_DIR/world-template.md` when it does not already exist.
+- Treat `world.md` as the persistent world state for later storytelling steps. It must already contain the persistent reef setting, active characters, ongoing threads, overall mood, current act, and a one-line hook for the next beat.
+- Treat `$SKILL_DIR/saga-writer.md` as the storytelling contract that later storytelling steps must use when they generate new beats.
+
+Initialize an empty lore story list to collect lore snippets across the session. This list is the per-session beat buffer while `world.md` holds the persistent world state. Initialize the pulse counter to 0.
 
 ### Step 0d. Print pulse header
 

--- a/reef-pulse/saga-writer.md
+++ b/reef-pulse/saga-writer.md
@@ -1,0 +1,56 @@
+# Saga writer
+
+Model: `sonnet`
+
+This prompt defines the storytelling contract for Moonjelly Reef's lore beats. It is intentionally lightweight and stable so later phases can invoke it consistently.
+
+## Goal
+
+Write the next short lore beat for the current pulse and return an updated persistent world state. The prose should feel like a chapter fragment from the reef's ongoing saga rather than a status report.
+
+## Kishotenketsu guidance
+
+Follow Kishōtenketsu pacing across sessions and within a session when possible:
+
+- **Ki**: re-establish the scene with a small, vivid movement that fits the current world state
+- **Sho**: deepen the situation with one concrete development or emotional turn
+- **Ten**: introduce a surprising but coherent shift, image, or realization
+- **Ketsu**: resolve the beat with a clean landing that points naturally toward what comes next
+
+Do not force all four moves into every single beat. Prefer one or two moves per beat, but make the larger session arc feel cumulative.
+
+## World-building rules
+
+- Respect the persistent reef setting and the established personalities in `world.md`.
+- Let active characters behave consistently, but allow the world state to evolve.
+- Advance ongoing threads in small, memorable ways instead of resetting the scene each time.
+- Keep imagery clear enough to picture. Strange is welcome; incoherent is not.
+- Favor atmosphere, implication, and emotional motion over literal task narration.
+
+## Input contract
+
+You will receive:
+
+- The current `world.md` contents
+- The prior lore beats from this session, in order
+- Pipeline state that summarizes what happened in the pulse and what changed
+- The elapsed time associated with the beat being written
+
+## Output contract
+
+Return exactly two parts:
+
+1. `beat` — 1 to 2 sentences of lore prose suitable for the existing dashed lore box
+2. `world` — the full updated `world.md` content, preserving the same section structure while updating only what changed
+
+## Anti-patterns
+
+- Do not narrate the dispatch log beat-by-beat.
+- Do not merely rename labels, phases, or tool results as if that alone makes them story.
+- Do not dump confused metaphors or overwrite established character voices.
+- Do not explain the orchestration system to the reader.
+- Do not turn every beat into triumph; setbacks and waiting should still feel alive.
+
+## Failure example from issue #128: what NOT to do
+
+Issue #128's failure example is what NOT to do: a flat lore beat that simply restates which agents were sent, what labels changed, or that the moonjelly waited. If the beat reads like a 1:1 event narration of the dispatch log, it has failed even if the facts are technically accurate.

--- a/reef-pulse/world-template.md
+++ b/reef-pulse/world-template.md
@@ -1,0 +1,37 @@
+# Saga world template
+
+Use this file to bootstrap `.agents/moonjelly-reef/saga/world.md` on the first pulse.
+Keep it short, legible, and durable across many sessions.
+
+## Reef setting
+
+Moonjelly Reef is a twilight ocean workshop where the moonjelly orchestrator wakes sleeping creatures, sends them into shifting currents, and then settles back to listen for what changed.
+
+## Active characters
+
+- **Moonjelly**: the patient conductor; curious, watchful, and faintly mischievous
+- **Narwhal**: the slicer; sharp, decisive, delighted by clean fracture lines
+- **Octopus**: the implementer; methodical, inventive, and relentless
+- **Barreleye**: the inspector; suspicious of easy answers, precise in its gaze
+- **Crab**: the reworker; stubborn, practical, and willing to molt for a better fit
+- **Sea turtle**: the merger; steady, careful, and unhurried
+- **Walrus**: the ratifier; ceremonial, heavy with memory, and hard to impress
+- **Diver**: the human partner; the one who scopes, judges, and finally lands the work
+
+## Ongoing threads
+
+- The reef is learning to tell its own history without flattening each pulse into a dry status log.
+- Each creature should feel consistent across sessions while still leaving room for growth and surprise.
+- The reef's work should sound like a lived-in story, not a beat-by-beat transcript of tool activity.
+
+## Mood
+
+Hopeful, salt-worn, and gently uncanny. Small triumphs feel luminous; setbacks sting but do not collapse the world.
+
+## Current act
+
+Act I — the reef has just discovered it can remember itself between pulses.
+
+## Next beat hook
+
+The moonjelly senses a new rhythm under the sand: if the reef can remember, it may soon begin to anticipate.

--- a/tests/saga-foundation.test.sh
+++ b/tests/saga-foundation.test.sh
@@ -1,0 +1,144 @@
+#!/bin/sh
+# Contract tests for the saga foundation prompt and bootstrap instructions
+set -u
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$TESTS_DIR/.." && pwd)"
+PULSE_SKILL="$REPO_ROOT/reef-pulse/SKILL.md"
+SAGA_PROMPT="$REPO_ROOT/reef-pulse/saga-writer.md"
+WORLD_TEMPLATE="$REPO_ROOT/reef-pulse/world-template.md"
+PASS=0
+FAIL=0
+TOTAL=0
+OUTPUT_BUF=""
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+pass() {
+  PASS=$((PASS + 1))
+  TOTAL=$((TOTAL + 1))
+  OUTPUT_BUF="${OUTPUT_BUF}$(printf "${GREEN}PASS${NC}: %s" "$1")
+"
+}
+
+fail() {
+  FAIL=$((FAIL + 1))
+  TOTAL=$((TOTAL + 1))
+  OUTPUT_BUF="${OUTPUT_BUF}$(printf "${RED}FAIL${NC}: %s" "$1")
+"
+  if [ $# -gt 1 ]; then
+    OUTPUT_BUF="${OUTPUT_BUF}$(printf "  %s" "$2")
+"
+  fi
+}
+
+assert_contains() {
+  file="$1"
+  pattern="$2"
+  label="$3"
+
+  if grep -qF "$pattern" "$file"; then
+    pass "$label"
+  else
+    fail "$label" "missing pattern: $pattern"
+  fi
+}
+
+test_pulse_skill_bootstraps_saga_state() {
+  assert_contains "$PULSE_SKILL" '.agents/moonjelly-reef/saga/' "pulse skill: saga directory path is documented"
+  assert_contains "$PULSE_SKILL" 'world.md' "pulse skill: world state file is documented"
+  assert_contains "$PULSE_SKILL" 'Initialize `world.md` from `$SKILL_DIR/world-template.md`' "pulse skill: world bootstrap source is documented"
+}
+
+test_world_template_has_required_story_fields() {
+  assert_contains "$WORLD_TEMPLATE" '## Reef setting' "world template: reef setting section exists"
+  assert_contains "$WORLD_TEMPLATE" '## Active characters' "world template: active characters section exists"
+  assert_contains "$WORLD_TEMPLATE" '## Ongoing threads' "world template: ongoing threads section exists"
+  assert_contains "$WORLD_TEMPLATE" '## Mood' "world template: mood section exists"
+  assert_contains "$WORLD_TEMPLATE" '## Current act' "world template: current act section exists"
+  assert_contains "$WORLD_TEMPLATE" '## Next beat hook' "world template: next beat hook section exists"
+}
+
+test_saga_prompt_contract_is_documented() {
+  assert_contains "$SAGA_PROMPT" 'Model: `sonnet`' "saga prompt: model choice is documented"
+  assert_contains "$SAGA_PROMPT" 'Kishōtenketsu' "saga prompt: Kishotenketsu guidance exists"
+  assert_contains "$SAGA_PROMPT" '## Input contract' "saga prompt: input contract exists"
+  assert_contains "$SAGA_PROMPT" '## Output contract' "saga prompt: output contract exists"
+  assert_contains "$SAGA_PROMPT" 'what NOT to do' "saga prompt: failure example is framed as what NOT to do"
+  assert_contains "$SAGA_PROMPT" 'issue #128' "saga prompt: failure example references the scoped issue"
+  assert_contains "$SAGA_PROMPT" 'Do not narrate the dispatch log beat-by-beat' "saga prompt: anti-pattern for 1:1 narration exists"
+}
+
+test_pulse_skill_uses_saga_prompt() {
+  assert_contains "$PULSE_SKILL" '$SKILL_DIR/saga-writer.md' "pulse skill: saga writer prompt path is documented"
+}
+
+test_pulse_skill_bootstraps_only_once() {
+  assert_contains "$PULSE_SKILL" 'when it does not already exist' "pulse skill: bootstrap is conditional"
+}
+
+test_pulse_skill_preserves_existing_story_collection() {
+  assert_contains "$PULSE_SKILL" 'lore story list' "pulse skill: session beat collection remains in place"
+}
+
+test_pulse_skill_includes_bootstrap_timing() {
+  assert_contains "$PULSE_SKILL" 'first iteration of the pulse' "pulse skill: bootstrap lives at session start"
+}
+
+test_pulse_skill_mentions_persistent_world_state() {
+  assert_contains "$PULSE_SKILL" 'persistent world state' "pulse skill: world state persistence is described"
+}
+
+test_pulse_skill_links_prompt_to_later_phases() {
+  assert_contains "$PULSE_SKILL" 'later storytelling steps' "pulse skill: prompt is framed as a dependency"
+}
+
+test_pulse_skill_mentions_bootstrap_behavior() {
+  assert_contains "$PULSE_SKILL" 'bootstrap behavior' "pulse skill: bootstrap behavior is explicit"
+}
+
+test_pulse_skill_mentions_storytelling_contract() {
+  assert_contains "$PULSE_SKILL" 'storytelling contract' "pulse skill: storytelling contract is explicit"
+}
+
+test_pulse_skill_mentions_characters_threads_and_hook() {
+  assert_contains "$PULSE_SKILL" 'active characters' "pulse skill: active characters are documented"
+  assert_contains "$PULSE_SKILL" 'ongoing threads' "pulse skill: ongoing threads are documented"
+  assert_contains "$PULSE_SKILL" 'one-line hook for the next beat' "pulse skill: next beat hook is documented"
+}
+
+test_pulse_skill_bootstraps_world_template_before_lore() {
+  skill_lines="$(grep -n 'world-template.md\|Print lore snippet' "$PULSE_SKILL")"
+  world_line="$(printf '%s\n' "$skill_lines" | grep 'world-template.md' | head -1 | cut -d: -f1)"
+  lore_line="$(printf '%s\n' "$skill_lines" | grep 'Print lore snippet' | head -1 | cut -d: -f1)"
+
+  if [ -n "$world_line" ] && [ -n "$lore_line" ] && [ "$world_line" -lt "$lore_line" ]; then
+    pass "pulse skill: world bootstrap instructions appear before lore generation"
+  else
+    fail "pulse skill: world bootstrap instructions appear before lore generation" "world_line=$world_line lore_line=$lore_line"
+  fi
+}
+
+test_pulse_skill_bootstraps_saga_state
+test_world_template_has_required_story_fields
+test_saga_prompt_contract_is_documented
+test_pulse_skill_uses_saga_prompt
+test_pulse_skill_bootstraps_only_once
+test_pulse_skill_preserves_existing_story_collection
+test_pulse_skill_includes_bootstrap_timing
+test_pulse_skill_mentions_persistent_world_state
+test_pulse_skill_links_prompt_to_later_phases
+test_pulse_skill_mentions_bootstrap_behavior
+test_pulse_skill_mentions_storytelling_contract
+test_pulse_skill_mentions_characters_threads_and_hook
+test_pulse_skill_bootstraps_world_template_before_lore
+
+printf "%b" "$OUTPUT_BUF"
+printf "\n================================\n"
+printf "Results: %s passed, %s total\n" "$PASS" "$TOTAL"
+
+if [ "$FAIL" -ne 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
closes #131 Saga foundation and world bootstrap

## Ambiguous choices

- **Failure example reference**: I anchored the anti-pattern section to issue #128 and described the bad behavior there, because the scoped plan requires that reference but the exact failing prose is not stored in the repo.

## Test results

- Full suite passed: 263 + 28 + 75 + 22 assertions, 0 failed.

### 🪼 Pulse metrics

| Phase | Target | Duration | Tokens | Tool uses | Outcome | Date |
| ----- | ------ | -------- | ------ | --------- | ------- | ---- |
| implement | #131 | — | — | — | PR created | 2026-04-22 16:18 |
| inspect | #131 | — | — | — | passed: promoted to to-merge | 2026-04-22 16:25 |
<!-- end metrics table -->

<details><summary><h3>🧿 Inspect review — 2026/04/22 16:23</h3></summary>

Suite status: `./test.sh` passed in the inspection worktree (`263 + 28 + 75 + 22` assertions, `0` failed).

Acceptance criteria:
- AC1 passed: the pulse skill now defines first-run creation of `.agents/moonjelly-reef/saga/` before the first pulse header in `reef-pulse/SKILL.md`.
- AC2 passed: `reef-pulse/world-template.md` bootstraps `world.md` with reef setting, active characters, ongoing threads, mood, current act, and next beat hook.
- AC3 passed: `reef-pulse/saga-writer.md` defines Kishōtenketsu guidance, world-building rules, explicit input/output contracts, and anti-patterns for flat event narration.
- AC4 passed: the prompt explicitly frames issue `#128` as the failure example and labels it "what NOT to do".
- AC5 passed: the saga writer contract documents `Model: `sonnet`` for consistent later invocation.

Plan drift and ambiguous choices:
- The PR's choice to reference issue `#128` rather than copying the failure prose into the repo is acceptable and still satisfies the scoped requirement.
- No additional drift from the slice plan found.

Judgment calls:
- None beyond accepting the issue `#128` reference approach described above.
</details>