### PR TITLE
Pulse beat generation from saga state

### DIFF
--- a/reef-pulse/SKILL.md
+++ b/reef-pulse/SKILL.md
@@ -69,6 +69,7 @@ This is also where the saga bootstrap behavior lives. Before printing the first 
 
 - Create `.agents/moonjelly-reef/saga/` when it does not already exist.
 - Initialize `world.md` from `$SKILL_DIR/world-template.md` when it does not already exist.
+- Read the current `world.md` contents into a `WORLD_STATE` variable before the session continues. Carry that state through the session by replacing `WORLD_STATE` each time a later lore beat returns an updated world.
 - Treat `world.md` as the persistent world state for later storytelling steps. It must already contain the persistent reef setting, active characters, ongoing threads, overall mood, current act, and a one-line hook for the next beat.
 - Treat `$SKILL_DIR/saga-writer.md` as the storytelling contract that later storytelling steps must use when they generate new beats.
 
@@ -149,7 +150,31 @@ AUTOMATED_DISPATCHES="{count of automated phases dispatched this iteration}"
 
 ### Step 2c. Print lore snippet
 
-After all dispatched agents return, generate a lore snippet. This is a 1-2 sentence story fragment in playful Ghibli ocean vibes. Each lore snippet must read all prior snippets from the session and continues the narrative — the lore forms a continuous story, not isolated fragments. The story should be influenced by what actually happened in the pulse results (e.g., reworks are setbacks, successful inspects are triumphs, long waits are boring). Print it with the elapsed time since dispatch:
+After all dispatched agents return, generate a lore snippet by spawning a storytelling sub-agent. Do not generate lore inline inside the pulse. Use the configured creative model from `$SKILL_DIR/saga-writer.md` (`sonnet` unless the prompt is intentionally updated later). This is still a 1-2 sentence story fragment in playful Ghibli ocean vibes, but the beat now comes from the saga writer contract rather than ad-hoc pulse prose. The lore still reads all prior snippets from the session and continues the narrative.
+
+Pass the storytelling sub-agent:
+
+- The current `WORLD_STATE` loaded at session start and updated after each prior beat
+- The prior lore snippets from the current session, in order
+- Pipeline state for this pulse: dispatched phases, returned transitions, human items, idle items, and any labels still waiting after the pulse
+- The elapsed time since dispatch
+
+Tell the sub-agent: Treat pipeline state as loose DnD-style inspiration and not narrate events 1:1.
+
+The storytelling sub-agent must return exactly:
+
+- `beat:` followed by the lore prose for the dashed lore box
+- `world:` followed by the full updated `world.md` contents with the same section structure preserved
+
+After the sub-agent returns:
+
+- Print `beat:` in the existing dashed lore box format shown below
+- Append the beat text to the session's lore story list
+- Replace `WORLD_STATE` with the returned `world:` content
+- Persist the returned `world:` content back to `$WORLD_FILE` immediately so later pulses continue from the evolved state
+- Leave dispatch lines, metrics tables, and return-result output unchanged
+
+Print the returned beat with the elapsed time since dispatch:
 
 ```
 ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌
@@ -158,7 +183,7 @@ After all dispatched agents return, generate a lore snippet. This is a 1-2 sente
 ╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌╌
 ```
 
-Append the lore snippet to the session's lore story list.
+Append the returned beat to the session's lore story list.
 
 ### Step 2d. Print return results
 

--- a/reef-pulse/saga-writer.md
+++ b/reef-pulse/saga-writer.md
@@ -34,14 +34,18 @@ You will receive:
 - The current `world.md` contents
 - The prior lore beats from this session, in order
 - Pipeline state that summarizes what happened in the pulse and what changed
+  It includes dispatched phases, returned transitions, human items, idle items, and labels that remain after the pulse
+  Treat these details as inspiration only, not as a checklist to narrate one-by-one
 - The elapsed time associated with the beat being written
 
 ## Output contract
 
 Return exactly two parts:
 
-1. `beat` — 1 to 2 sentences of lore prose suitable for the existing dashed lore box
-2. `world` — the full updated `world.md` content, preserving the same section structure while updating only what changed
+1. `beat:` on its own label, followed by 1 to 2 sentences of lore prose suitable for the existing dashed lore box
+2. `world:` on its own label, followed by the full updated `world.md` content, preserving the same section structure while updating only what changed
+
+Do not wrap either part in code fences. The caller needs to parse the response and persist `world:` back to disk after every beat.
 
 ## Anti-patterns
 

--- a/tests/saga-beat-generation.test.sh
+++ b/tests/saga-beat-generation.test.sh
@@ -1,0 +1,117 @@
+#!/bin/sh
+# Contract tests for saga beat generation and world-state persistence
+set -u
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$TESTS_DIR/.." && pwd)"
+PULSE_SKILL="$REPO_ROOT/reef-pulse/SKILL.md"
+SAGA_PROMPT="$REPO_ROOT/reef-pulse/saga-writer.md"
+PASS=0
+FAIL=0
+TOTAL=0
+OUTPUT_BUF=""
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+pass() {
+  PASS=$((PASS + 1))
+  TOTAL=$((TOTAL + 1))
+  OUTPUT_BUF="${OUTPUT_BUF}$(printf "${GREEN}PASS${NC}: %s" "$1")
+"
+}
+
+fail() {
+  FAIL=$((FAIL + 1))
+  TOTAL=$((TOTAL + 1))
+  OUTPUT_BUF="${OUTPUT_BUF}$(printf "${RED}FAIL${NC}: %s" "$1")
+"
+  if [ $# -gt 1 ]; then
+    OUTPUT_BUF="${OUTPUT_BUF}$(printf "  %s" "$2")
+"
+  fi
+}
+
+assert_contains() {
+  file="$1"
+  pattern="$2"
+  label="$3"
+
+  if grep -qF "$pattern" "$file"; then
+    pass "$label"
+  else
+    fail "$label" "missing pattern: $pattern"
+  fi
+}
+
+test_pulse_skill_reads_world_state_at_session_start() {
+  assert_contains "$PULSE_SKILL" 'Read the current `world.md` contents into a `WORLD_STATE` variable' "pulse skill: world state is loaded at session start"
+  assert_contains "$PULSE_SKILL" 'Carry that state through the session' "pulse skill: world state persists across the session"
+}
+
+test_pulse_skill_uses_story_subagent_for_lore() {
+  assert_contains "$PULSE_SKILL" 'generate a lore snippet by spawning a storytelling sub-agent' "pulse skill: lore generation uses a sub-agent"
+  assert_contains "$PULSE_SKILL" 'Do not generate lore inline inside the pulse' "pulse skill: inline lore generation is forbidden"
+  assert_contains "$PULSE_SKILL" '`sonnet` unless the prompt is intentionally updated later' "pulse skill: creative model is called out during beat generation"
+}
+
+test_pulse_skill_passes_required_context_to_story_subagent() {
+  assert_contains "$PULSE_SKILL" 'The current `WORLD_STATE` loaded at session start and updated after each prior beat' "pulse skill: sub-agent receives current world state"
+  assert_contains "$PULSE_SKILL" 'The prior lore snippets from the current session, in order' "pulse skill: sub-agent receives prior beats"
+  assert_contains "$PULSE_SKILL" 'Pipeline state for this pulse: dispatched phases, returned transitions, human items, idle items, and any labels still waiting after the pulse' "pulse skill: sub-agent receives pipeline state"
+  assert_contains "$PULSE_SKILL" 'Treat pipeline state as loose DnD-style inspiration and not narrate events 1:1' "pulse skill: sub-agent gets anti-transcript guidance"
+}
+
+test_pulse_skill_requires_parseable_story_response() {
+  assert_contains "$PULSE_SKILL" '`beat:` followed by the lore prose' "pulse skill: beat response label is documented"
+  assert_contains "$PULSE_SKILL" '`world:` followed by the full updated `world.md` contents' "pulse skill: world response label is documented"
+}
+
+test_pulse_skill_persists_updated_world_state() {
+  assert_contains "$PULSE_SKILL" 'Replace `WORLD_STATE` with the returned `world:` content' "pulse skill: in-memory world state is updated"
+  assert_contains "$PULSE_SKILL" 'Persist the returned `world:` content back to `$WORLD_FILE` immediately' "pulse skill: world state is written to disk after each beat"
+}
+
+test_pulse_skill_keeps_non_lore_output_unchanged() {
+  assert_contains "$PULSE_SKILL" 'Leave dispatch lines, metrics tables, and return-result output unchanged' "pulse skill: non-lore output contract is preserved"
+  assert_contains "$PULSE_SKILL" 'existing dashed lore box format' "pulse skill: lore box format stays the same"
+}
+
+test_saga_prompt_documents_parseable_contract() {
+  assert_contains "$SAGA_PROMPT" 'It includes dispatched phases, returned transitions, human items, idle items, and labels that remain after the pulse' "saga prompt: pipeline state details are documented"
+  assert_contains "$SAGA_PROMPT" 'Treat these details as inspiration only' "saga prompt: pipeline state is framed as inspiration"
+  assert_contains "$SAGA_PROMPT" '`beat:` on its own label' "saga prompt: beat label is documented"
+  assert_contains "$SAGA_PROMPT" '`world:` on its own label' "saga prompt: world label is documented"
+  assert_contains "$SAGA_PROMPT" 'Do not wrap either part in code fences' "saga prompt: parseability rule exists"
+  assert_contains "$SAGA_PROMPT" 'persist `world:` back to disk after every beat' "saga prompt: persistence expectation is documented"
+}
+
+test_world_state_load_happens_before_lore_generation() {
+  skill_lines="$(grep -n 'Read the current `world.md` contents into a `WORLD_STATE` variable\|Print lore snippet' "$PULSE_SKILL")"
+  world_line="$(printf '%s\n' "$skill_lines" | grep 'Read the current `world.md` contents into a `WORLD_STATE` variable' | head -1 | cut -d: -f1)"
+  lore_line="$(printf '%s\n' "$skill_lines" | grep 'Print lore snippet' | head -1 | cut -d: -f1)"
+
+  if [ -n "$world_line" ] && [ -n "$lore_line" ] && [ "$world_line" -lt "$lore_line" ]; then
+    pass "pulse skill: world state is loaded before lore generation"
+  else
+    fail "pulse skill: world state is loaded before lore generation" "world_line=$world_line lore_line=$lore_line"
+  fi
+}
+
+test_pulse_skill_reads_world_state_at_session_start
+test_pulse_skill_uses_story_subagent_for_lore
+test_pulse_skill_passes_required_context_to_story_subagent
+test_pulse_skill_requires_parseable_story_response
+test_pulse_skill_persists_updated_world_state
+test_pulse_skill_keeps_non_lore_output_unchanged
+test_saga_prompt_documents_parseable_contract
+test_world_state_load_happens_before_lore_generation
+
+printf "%b" "$OUTPUT_BUF"
+printf "\n================================\n"
+printf "Results: %s passed, %s total\n" "$PASS" "$TOTAL"
+
+if [ "$FAIL" -ne 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
closes #132 Pulse beat generation from saga state

## Ambiguous choices

- **Parseable saga response**: I made the saga writer return explicit `beat:` and `world:` labels so the pulse can reliably parse the prose and persist the updated `world.md` after each beat. This tightens the contract beyond the slice text, but it is in service of the same persistence requirement rather than a product change.

## Test results

- Full suite passed: 263 + 22 + 28 + 75 assertions, 0 failed.

<details><summary><h3>🧿 Inspect review — 2026/04/22 16:50</h3></summary>

Accepted.

- Verified each acceptance criterion directly in `reef-pulse/SKILL.md`, `reef-pulse/saga-writer.md`, and `tests/saga-beat-generation.test.sh`.
- Confirmed the pulse contract now loads `world.md` into `WORLD_STATE` at session start, passes world state plus prior beats plus pipeline context into a storytelling sub-agent, and requires parseable `beat:` / `world:` output that is persisted back to disk.
- Confirmed the lore box contract stays intact and non-lore pulse output remains unchanged.
- Reviewed the PR's ambiguous choice around explicit `beat:` / `world:` labels and found it aligned with the slice's persistence and parseability requirements.
- Ran the full suite in an isolated review worktree: `./test.sh` passed with `263 + 22 + 28 + 75` assertions and `0` failed.

Verdict: all acceptance criteria met; ready for merge.
</details>
