### PR TITLE
Saga plumbing tests and pulse documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ The single entry point for turning ideas into plans. Determines whether the work
 
 Scans all labelled issues, dispatches the appropriate phase for each as a sub-agent, and exits. Holds no state — labels are the state. Run with `--hitl` (manual, includes 🤿 items) or `--afk` (cron, 🌊 only).
 
+Each pulse also loads the persistent saga from `world.md`, asks `reef-pulse/saga-writer.md` for the next beat, and at session end archives the session into `chapter-NNN.md` while keeping `world.md` as the handoff to the next pulse.
+
 Design principles:
 
 - **Testing at source**: each transition includes verification before tagging.

--- a/reef-pulse/SKILL.md
+++ b/reef-pulse/SKILL.md
@@ -72,6 +72,7 @@ This is also where the saga bootstrap behavior lives. Before printing the first 
 - Read the current `world.md` contents into a `WORLD_STATE` variable before the session continues. Carry that state through the session by replacing `WORLD_STATE` each time a later lore beat returns an updated world.
 - Treat `world.md` as the persistent world state for later storytelling steps. It must already contain the persistent reef setting, active characters, ongoing threads, overall mood, current act, and a one-line hook for the next beat.
 - Treat `$SKILL_DIR/saga-writer.md` as the storytelling contract that later storytelling steps must use when they generate new beats.
+- Treat `chapter-NNN.md` as the session archive: the pulse compiles the accumulated lore story list into a numbered chapter at session end, while `world.md` keeps the persistent handoff for the next pulse.
 
 Initialize an empty lore story list to collect lore snippets across the session. This list is the per-session beat buffer while `world.md` holds the persistent world state. Initialize the pulse counter to 0.
 
@@ -293,6 +294,7 @@ After metrics are logged, check whether to recurse or exit.
 This step only runs when `AUTOMATED_DISPATCHES` == 0 (the exit path from Step 5).
 
 First, generate a final lore snippet for the empty pulse (the moonjelly finding nothing left to do). Append it to the lore story list.
+Then the session's lore story list is compiled into `chapter-NNN.md` with sequential numbering so the archive matches the beats that were printed during the session.
 
 Then print the SESSION COMPLETE box with session stats:
 

--- a/tests/saga-chapter.test.sh
+++ b/tests/saga-chapter.test.sh
@@ -1,0 +1,69 @@
+#!/bin/sh
+# Contract tests for saga chapter compilation and pulse documentation
+set -u
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$TESTS_DIR/.." && pwd)"
+PULSE_SKILL="$REPO_ROOT/reef-pulse/SKILL.md"
+README="$REPO_ROOT/README.md"
+PASS=0
+FAIL=0
+TOTAL=0
+OUTPUT_BUF=""
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+pass() {
+  PASS=$((PASS + 1))
+  TOTAL=$((TOTAL + 1))
+  OUTPUT_BUF="${OUTPUT_BUF}$(printf "${GREEN}PASS${NC}: %s" "$1")
+"
+}
+
+fail() {
+  FAIL=$((FAIL + 1))
+  TOTAL=$((TOTAL + 1))
+  OUTPUT_BUF="${OUTPUT_BUF}$(printf "${RED}FAIL${NC}: %s" "$1")
+"
+  if [ $# -gt 1 ]; then
+    OUTPUT_BUF="${OUTPUT_BUF}$(printf "  %s" "$2")
+"
+  fi
+}
+
+assert_contains() {
+  file="$1"
+  pattern="$2"
+  label="$3"
+
+  if grep -qF "$pattern" "$file"; then
+    pass "$label"
+  else
+    fail "$label" "missing pattern: $pattern"
+  fi
+}
+
+test_pulse_skill_documents_chapter_compilation() {
+  assert_contains "$PULSE_SKILL" 'chapter-NNN.md' "pulse skill: chapter file naming is documented"
+  assert_contains "$PULSE_SKILL" 'compiled into `chapter-NNN.md`' "pulse skill: session-end chapter compilation is documented"
+  assert_contains "$PULSE_SKILL" 'SESSION COMPLETE' "pulse skill: session wrap-up remains tied to the story archive"
+}
+
+test_readme_connects_saga_flow() {
+  assert_contains "$README" 'saga-writer.md' "README: pulse docs point to the saga writer contract"
+  assert_contains "$README" 'world.md' "README: pulse docs mention persistent world state"
+  assert_contains "$README" 'chapter-NNN.md' "README: pulse docs mention session chapter output"
+}
+
+test_pulse_skill_documents_chapter_compilation
+test_readme_connects_saga_flow
+
+printf "%b" "$OUTPUT_BUF"
+printf "\n================================\n"
+printf "Results: %s passed, %s total\n" "$PASS" "$TOTAL"
+
+if [ "$FAIL" -ne 0 ]; then
+  exit 1
+fi


### PR DESCRIPTION
closes #134 Saga plumbing tests and pulse documentation

## Ambiguous choices

None — implementation followed the plan exactly.

## Test results

`./test.sh` passed.

## Screenshots / video

Not applicable.


### 🪼 Pulse metrics

| Phase | Target | Duration | Tokens | Tool uses | Outcome | Date |
| ----- | ------ | -------- | ------ | --------- | ------- | ---- |
| implement | #134 | — | — | — | ✅ PR created | 2026-04-22 17:11 |
| inspect | #134 | — | — | — | ✅ to-merge | 2026-04-22 17:18 |
<!-- end metrics table -->

<details><summary><h3>🧿 Inspect review — 2026/04/22 17:13</h3></summary>

No findings. The PR matches the slice’s acceptance criteria, and the full suite passed (
================================
Results: 208 passed, 208 total
^[[0;32mPASS^[[0m: pulse skill: world state is loaded at session start
^[[0;32mPASS^[[0m: pulse skill: world state persists across the session
^[[0;32mPASS^[[0m: pulse skill: lore generation uses a sub-agent
^[[0;32mPASS^[[0m: pulse skill: inline lore generation is forbidden
^[[0;32mPASS^[[0m: pulse skill: creative model is called out during beat generation
^[[0;32mPASS^[[0m: pulse skill: sub-agent receives current world state
^[[0;32mPASS^[[0m: pulse skill: sub-agent receives prior beats
^[[0;32mPASS^[[0m: pulse skill: sub-agent receives pipeline state
^[[0;32mPASS^[[0m: pulse skill: sub-agent gets anti-transcript guidance
^[[0;32mPASS^[[0m: pulse skill: beat response label is documented
^[[0;32mPASS^[[0m: pulse skill: world response label is documented
^[[0;32mPASS^[[0m: pulse skill: in-memory world state is updated
^[[0;32mPASS^[[0m: pulse skill: world state is written to disk after each beat
^[[0;32mPASS^[[0m: pulse skill: non-lore output contract is preserved
^[[0;32mPASS^[[0m: pulse skill: lore box format stays the same
^[[0;32mPASS^[[0m: saga prompt: pipeline state details are documented
^[[0;32mPASS^[[0m: saga prompt: pipeline state is framed as inspiration
^[[0;32mPASS^[[0m: saga prompt: beat label is documented
^[[0;32mPASS^[[0m: saga prompt: world label is documented
^[[0;32mPASS^[[0m: saga prompt: parseability rule exists
^[[0;32mPASS^[[0m: saga prompt: persistence expectation is documented
^[[0;32mPASS^[[0m: pulse skill: world state is loaded before lore generation

================================
Results: 22 passed, 22 total
^[[0;32mPASS^[[0m: pulse skill: chapter file naming is documented
^[[0;32mPASS^[[0m: pulse skill: session-end chapter compilation is documented
^[[0;32mPASS^[[0m: pulse skill: session wrap-up remains tied to the story archive
^[[0;32mPASS^[[0m: README: pulse docs point to the saga writer contract
^[[0;32mPASS^[[0m: README: pulse docs mention persistent world state
^[[0;32mPASS^[[0m: README: pulse docs mention session chapter output

================================
Results: 6 passed, 6 total
^[[0;32mPASS^[[0m: pulse skill: saga directory path is documented
^[[0;32mPASS^[[0m: pulse skill: world state file is documented
^[[0;32mPASS^[[0m: pulse skill: world bootstrap source is documented
^[[0;32mPASS^[[0m: world template: reef setting section exists
^[[0;32mPASS^[[0m: world template: active characters section exists
^[[0;32mPASS^[[0m: world template: ongoing threads section exists
^[[0;32mPASS^[[0m: world template: mood section exists
^[[0;32mPASS^[[0m: world template: current act section exists
^[[0;32mPASS^[[0m: world template: next beat hook section exists
^[[0;32mPASS^[[0m: saga prompt: model choice is documented
^[[0;32mPASS^[[0m: saga prompt: Kishotenketsu guidance exists
^[[0;32mPASS^[[0m: saga prompt: input contract exists
^[[0;32mPASS^[[0m: saga prompt: output contract exists
^[[0;32mPASS^[[0m: saga prompt: failure example is framed as what NOT to do
^[[0;32mPASS^[[0m: saga prompt: failure example references the scoped issue
^[[0;32mPASS^[[0m: saga prompt: anti-pattern for 1:1 narration exists
^[[0;32mPASS^[[0m: pulse skill: saga writer prompt path is documented
^[[0;32mPASS^[[0m: pulse skill: bootstrap is conditional
^[[0;32mPASS^[[0m: pulse skill: session beat collection remains in place
^[[0;32mPASS^[[0m: pulse skill: bootstrap lives at session start
^[[0;32mPASS^[[0m: pulse skill: world state persistence is described
^[[0;32mPASS^[[0m: pulse skill: prompt is framed as a dependency
^[[0;32mPASS^[[0m: pulse skill: bootstrap behavior is explicit
^[[0;32mPASS^[[0m: pulse skill: storytelling contract is explicit
^[[0;32mPASS^[[0m: pulse skill: active characters are documented
^[[0;32mPASS^[[0m: pulse skill: ongoing threads are documented
^[[0;32mPASS^[[0m: pulse skill: next beat hook is documented
^[[0;32mPASS^[[0m: pulse skill: world bootstrap instructions appear before lore generation

================================
Results: 28 passed, 28 total

================================
Results: 75 passed, 75 total

================================
Results: 22 passed, 22 total).

The added chapter test stays focused on documentation and saga-plumbing contracts rather than asserting story prose, which matches the plan.

</details>

