### PR TITLE
add reef-scope route picker and persist route bearings

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,15 @@ stateDiagram-v2
 <details>
 <summary>🤿 <b><code>reef-scope</code></b> — scope an issue</summary>
 
-The single entry point for turning ideas into plans. Determines whether the work is a feature, refactor, or bug, interviews the diver if needed, writes a plan with **success criteria**, and labels `to-slice`.
+The single entry point for turning ideas into plans. It always shows a route picker, recommends a route from issue text when an issue is passed in, writes a plan with **success criteria**, and labels `to-slice`.
+
+The route picker always offers these five options:
+
+- `scope a feature`
+- `scope a refactor`
+- `triage a bug`
+- `I'm feeling lucky (hand over to the reef)`
+- `deep research`
 
 | source file | [`reef-scope/SKILL.md`](reef-scope/SKILL.md) |
 | :---------- | :------------------------------------------- |

--- a/reef-scope/SKILL.md
+++ b/reef-scope/SKILL.md
@@ -52,11 +52,33 @@ Wait for the user's response before continuing.
 
 ## 3. Write the plan
 
-Read the issue and any existing decision record. Assess: is this a **feature**, **refactor**, or **bug**? Then follow the type-specific guide.
+Every `reef-scope` run must show a route picker before you start the interview or write the plan.
+
+The route picker always offers exactly these five options:
+
+- `scope a feature`
+- `scope a refactor`
+- `triage a bug`
+- `I'm feeling lucky (hand over to the reef)`
+- `deep research`
+
+If `ISSUE_ID` was provided, `reef-scope` reads only the issue title and body before showing the picker. From that issue text alone, recommend the single best route. The picker marks exactly one route as `(recommended)`.
+
+Persist the selected route as `bearing` using one of these exact values:
+
+- bearing: `feature`
+- bearing: `refactor`
+- bearing: `bug`
+- bearing: `feeling-lucky`
+- bearing: `deep-research`
+
+Then follow the route-specific guide:
 
 - **Feature**: see [scope-feature.md](scope-feature.md)
 - **Refactor**: see [scope-refactor.md](scope-refactor.md)
 - **Bug**: see [triage-issue.md](triage-issue.md)
+- **Feeling lucky**: skip the normal scoping interview, stamp only the minimal routing metadata, and persist `bearing: "feeling-lucky"`.
+- **Deep research**: see [scope-deep-research.md](scope-deep-research.md)
 
 ## 4. Branches
 
@@ -99,6 +121,7 @@ The plan issue body starts with frontmatter that downstream phases will read:
 ---
 base-branch: $BASE_BRANCH
 pr-branch: $PR_BRANCH
+bearing: "{selected bearing}"
 ---
 ```
 

--- a/reef-scope/scope-deep-research.md
+++ b/reef-scope/scope-deep-research.md
@@ -1,0 +1,31 @@
+# Scoping deep research
+
+Use this route when the main task is to investigate, compare, or answer a question rather than jump straight into implementation.
+
+## Interview
+
+Grill the user until the research target is sharp enough for downstream phases to execute without guessing.
+
+Ask the questions one at a time and make progress without waiting on unnecessary follow-ups.
+
+You must explicitly capture:
+
+- what they want researched
+- why it matters
+- what end goal they want answered
+
+If the issue already contains strong answers, confirm them briefly instead of re-asking verbatim.
+
+## Process
+
+### 1. Clarify the research target
+
+Figure out the core question, what uncertainty needs to be reduced, and what would count as a useful outcome.
+
+### 2. Define the research artifact
+
+Plan for a durable Markdown deliverable in the repo. If external research will be needed, plan to keep lightweight `Sources:` links near the related findings.
+
+### 3. Write the plan
+
+Write the scoped issue so the success criteria describe what must be answered, clarified, or persisted, not what code must be written.

--- a/tests/reef-scope.test.sh
+++ b/tests/reef-scope.test.sh
@@ -1,0 +1,113 @@
+#!/bin/sh
+# Behavioral tests for reef-scope route selection instructions.
+set -u
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$TESTS_DIR/.." && pwd)"
+SKILL_FILE="$REPO_ROOT/reef-scope/SKILL.md"
+DEEP_RESEARCH_FILE="$REPO_ROOT/reef-scope/scope-deep-research.md"
+README_FILE="$REPO_ROOT/README.md"
+PASS=0
+FAIL=0
+TOTAL=0
+OUTPUT_BUF=""
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+pass() {
+  PASS=$((PASS + 1))
+  TOTAL=$((TOTAL + 1))
+  OUTPUT_BUF="${OUTPUT_BUF}$(printf "${GREEN}PASS${NC}: %s" "$1")
+"
+}
+
+fail() {
+  FAIL=$((FAIL + 1))
+  TOTAL=$((TOTAL + 1))
+  OUTPUT_BUF="${OUTPUT_BUF}$(printf "${RED}FAIL${NC}: %s" "$1")
+"
+  if [ $# -gt 1 ]; then
+    OUTPUT_BUF="${OUTPUT_BUF}$(printf "  %s" "$2")
+"
+  fi
+}
+
+assert_contains() {
+  file="$1"
+  pattern="$2"
+  label="$3"
+
+  if grep -qF "$pattern" "$file"; then
+    pass "$label"
+  else
+    fail "$label" "expected pattern: $pattern"
+  fi
+}
+
+test_route_picker_lists_exact_routes() {
+  routes=$(grep '^- `' "$SKILL_FILE" | sed 's/^- //')
+  printf 'DIAGNOSTIC: reef-scope currently lists these backtick bullets as routes:\n%s\n' "$routes"
+
+  assert_contains "$SKILL_FILE" '`scope a feature`' "route picker includes feature route"
+  assert_contains "$SKILL_FILE" '`scope a refactor`' "route picker includes refactor route"
+  assert_contains "$SKILL_FILE" '`triage a bug`' "route picker includes bug route"
+  assert_contains "$SKILL_FILE" '`I'\''m feeling lucky (hand over to the reef)`' "route picker includes feeling-lucky route"
+  assert_contains "$SKILL_FILE" '`deep research`' "route picker includes deep-research route"
+}
+
+test_issue_recommendation_uses_issue_text_only() {
+  assert_contains "$SKILL_FILE" 'reads only the issue title and body before showing the picker' "issue-based runs only read issue text before recommending"
+  assert_contains "$SKILL_FILE" 'marks exactly one route as `(recommended)`' "issue-based runs mark exactly one recommended route"
+}
+
+test_selected_route_persists_as_bearing() {
+  bearings=$(grep -n 'bearing' "$SKILL_FILE")
+  printf 'DIAGNOSTIC: bearing references currently in reef-scope/SKILL.md:\n%s\n' "$bearings"
+
+  assert_contains "$SKILL_FILE" 'bearing: `feature`' "feature bearing is documented"
+  assert_contains "$SKILL_FILE" 'bearing: `refactor`' "refactor bearing is documented"
+  assert_contains "$SKILL_FILE" 'bearing: `bug`' "bug bearing is documented"
+  assert_contains "$SKILL_FILE" 'bearing: `deep-research`' "deep-research bearing is documented"
+  assert_contains "$SKILL_FILE" 'bearing: `feeling-lucky`' "feeling-lucky bearing is documented"
+}
+
+test_deep_research_route_has_dedicated_guide() {
+  if [ -f "$DEEP_RESEARCH_FILE" ]; then
+    pass "deep-research guide file exists"
+  else
+    fail "deep-research guide file exists" "missing file: $DEEP_RESEARCH_FILE"
+  fi
+
+  assert_contains "$SKILL_FILE" '[scope-deep-research.md](scope-deep-research.md)' "reef-scope routes deep research into dedicated guide"
+  assert_contains "$DEEP_RESEARCH_FILE" 'what they want researched' "deep-research guide asks what to research"
+  assert_contains "$DEEP_RESEARCH_FILE" 'why it matters' "deep-research guide asks why it matters"
+  assert_contains "$DEEP_RESEARCH_FILE" 'what end goal they want answered' "deep-research guide asks for the end goal"
+}
+
+test_readme_documents_route_options() {
+  assert_contains "$README_FILE" 'The route picker always offers these five options:' "README introduces route picker options"
+  assert_contains "$README_FILE" '`scope a feature`' "README lists feature route"
+  assert_contains "$README_FILE" '`scope a refactor`' "README lists refactor route"
+  assert_contains "$README_FILE" '`triage a bug`' "README lists bug route"
+  assert_contains "$README_FILE" '`I'\''m feeling lucky (hand over to the reef)`' "README lists feeling-lucky route"
+  assert_contains "$README_FILE" '`deep research`' "README lists deep-research route"
+}
+
+test_route_picker_lists_exact_routes
+test_issue_recommendation_uses_issue_text_only
+test_selected_route_persists_as_bearing
+test_deep_research_route_has_dedicated_guide
+test_readme_documents_route_options
+
+echo ""
+if [ "$FAIL" -gt 0 ]; then
+  printf "%s" "$OUTPUT_BUF"
+  echo "================================"
+  printf "Results: %s passed, ${RED}%s failed${NC}, %s total\n" "$PASS" "$FAIL" "$TOTAL"
+  exit 1
+else
+  echo "================================"
+  printf "Results: %s passed, %s total\n" "$PASS" "$TOTAL"
+fi

--- a/tests/reef-scope.test.sh
+++ b/tests/reef-scope.test.sh
@@ -46,15 +46,39 @@ assert_contains() {
   fi
 }
 
-test_route_picker_lists_exact_routes() {
-  routes=$(grep '^- `' "$SKILL_FILE" | sed 's/^- //')
-  printf 'DIAGNOSTIC: reef-scope currently lists these backtick bullets as routes:\n%s\n' "$routes"
+assert_equals() {
+  expected="$1"
+  actual="$2"
+  label="$3"
 
-  assert_contains "$SKILL_FILE" '`scope a feature`' "route picker includes feature route"
-  assert_contains "$SKILL_FILE" '`scope a refactor`' "route picker includes refactor route"
-  assert_contains "$SKILL_FILE" '`triage a bug`' "route picker includes bug route"
-  assert_contains "$SKILL_FILE" '`I'\''m feeling lucky (hand over to the reef)`' "route picker includes feeling-lucky route"
-  assert_contains "$SKILL_FILE" '`deep research`' "route picker includes deep-research route"
+  if [ "$expected" = "$actual" ]; then
+    pass "$label"
+  else
+    fail "$label" "expected: $expected, actual: $actual"
+  fi
+}
+
+route_picker_block() {
+  awk '
+    /^The route picker always offers exactly these five options:/ { capture=1; next }
+    capture && /^If `ISSUE_ID` was provided/ { exit }
+    capture && /^- `/ { print }
+  ' "$SKILL_FILE"
+}
+
+test_route_picker_lists_exact_routes() {
+  routes="$(route_picker_block)"
+  route_count="$(printf '%s\n' "$routes" | sed '/^$/d' | wc -l | tr -d ' ')"
+  expected_routes='- `scope a feature`
+- `scope a refactor`
+- `triage a bug`
+- `I'\''m feeling lucky (hand over to the reef)`
+- `deep research`'
+
+  printf 'DIAGNOSTIC: reef-scope route picker block currently resolves to:\n%s\n' "$routes"
+
+  assert_equals "5" "$route_count" "route picker exposes exactly five selectable routes"
+  assert_equals "$expected_routes" "$routes" "route picker routes match the required options exactly"
 }
 
 test_issue_recommendation_uses_issue_text_only() {


### PR DESCRIPTION
closes #151 add reef-scope route picker and persist route bearings

## Ambiguous choices

None — implementation followed the plan exactly.

## Test results

239 existing orchestration/tracker/worktree tests passed, plus 23 new reef-scope route-picker tests passed.

### 🪼 Pulse metrics

| Phase | Target | Duration | Tokens | Tool uses | Outcome | Date |
| ----- | ------ | -------- | ------ | --------- | ------- | ---- |
| implement | #151 | — | — | — | Implementation complete for add reef-scope route picker and persist route bearings | 2026-04-23 19:37 |
| inspect | #151 | — | — | — | to-rework: implementation matches the planned reef-scope behavior and the full suite passed, but the new picker test only proves the five required routes are present, not that they are the only selectable routes, so the exactly-these-selectable-routes acceptance criterion is still under-covered. | 2026-04-23 19:44 |
| rework | #151 | — | — | — | Rework complete — addressed review feedback | 2026-04-23 19:50 |
| inspect | #151 | — | — | — | to-merge: all acceptance criteria are met in the current branch state, the full suite passed in the inspect worktree, and the fresh inspect report has been appended to PR #155. | 2026-04-23 19:58 |
<!-- end metrics table -->

<details><summary><h3>🧿 Inspect review — 2026/04/23 19:42 NZST</h3></summary>

Verdict: to-rework

Acceptance criteria review:
- Route picker instructions are present in `reef-scope/SKILL.md` and list the five required routes.
- Issue-based runs are instructed to read only the issue title and body before recommending exactly one route.
- The selected route is persisted as `bearing`, including `feeling-lucky` and `deep-research`.
- The deep-research route points to a dedicated `scope-deep-research.md` guide that captures what to research, why it matters, and the desired end goal.
- `README.md` documents the route options in the `reef-scope` phase details section.

Test suite:
- `./test.sh` passed in the inspect worktree (`239 passed, 239 total` and `23 passed, 23 total`).

Gap:
- `tests/reef-scope.test.sh` checks that each required route string is present, but it does not verify that these are the only selectable routes. That leaves the “exactly these selectable routes” acceptance criterion under-tested.

Cleanup:
- No trivial cleanup changes were needed.

Ambiguous choices review:
- The PR says there were no ambiguous choices. I did not find product-level drift in the implementation itself.
</details>






<details><summary><h3>🦀 Rework — </h3></summary>

Feedback addressed:
- Tightened `tests/reef-scope.test.sh` so it no longer greps every backtick bullet in `reef-scope/SKILL.md`.
- Added a route-picker-block diagnostic print to confirm the exact block under test.
- Enforced that the picker exposes exactly five selectable routes and that the block matches the required options in order.

What changed:
- Added `assert_equals` and a `route_picker_block()` extractor that isolates the route-picker section between the picker heading and the issue-text recommendation paragraph.
- Replaced five presence-only assertions with exact block and count assertions.

Judgment calls:
- Kept the diagnostic print in the focused test because it documents the extracted picker block and helps future rework/inspect passes confirm the assertion scope quickly.

Test results:
- `./test.sh` passed (`239 passed`, `20 passed`, `89 passed`, `22 passed`).

</details>


<details><summary><h3>🦀 Rework — 2026/04/23 19:50 NZST</h3></summary>

Feedback addressed:
- Tightened `tests/reef-scope.test.sh` so it no longer greps every backtick bullet in `reef-scope/SKILL.md`.
- Added a route-picker-block diagnostic print to confirm the exact block under test.
- Enforced that the picker exposes exactly five selectable routes and that the block matches the required options in order.

What changed:
- Added `assert_equals` and a `route_picker_block()` extractor that isolates the route-picker section between the picker heading and the issue-text recommendation paragraph.
- Replaced five presence-only assertions with exact block and count assertions.

Judgment calls:
- Kept the diagnostic print in the focused test because it documents the extracted picker block and helps future rework/inspect passes confirm the assertion scope quickly.

Test results:
- `./test.sh` passed (`239 passed`, `20 passed`, `89 passed`, `22 passed`).

</details>

<details><summary><h3>🧿 Inspect review — 2026/04/23 19:58 NZST</h3></summary>

Verdict: to-merge

Acceptance criteria review:
- `reef-scope/SKILL.md` now shows a route picker on every run with exactly these five selectable routes: `scope a feature`, `scope a refactor`, `triage a bug`, `I'm feeling lucky (hand over to the reef)`, and `deep research`.
- Issue-based runs are instructed to read only the issue title and body before the picker and to mark exactly one route as `(recommended)`.
- The selected route is persisted as `bearing`, including explicit `feeling-lucky` and `deep-research` values.
- The deep-research route points to `reef-scope/scope-deep-research.md`, which explicitly captures what to research, why it matters, and the desired end goal.
- `README.md` documents the five route options under the `reef-scope` phase details section.
- Automated coverage now checks the exact picker block, recommendation instructions, dedicated deep-research path, and persisted bearings.

Test suite:
- `./test.sh` passed in the inspect worktree (`239 passed`, `20 passed`, `89 passed`, `22 passed`).

Cleanup:
- No trivial cleanup changes were needed.

Ambiguous choices review:
- The PR still reports no ambiguous choices, and I did not find drift from the issue acceptance criteria in the current branch state.
</details>

