### PR TITLE
teach to-slice how to break down research and lucky work

### DIFF
--- a/ORCHESTRATION.md
+++ b/ORCHESTRATION.md
@@ -251,13 +251,21 @@ General rules:
   NEXT_PHASE="blocked-missing-scope"
   PR_ID="—"
   ```
+- phase-specific
+  - contains: `deep-research` + `feeling-lucky` + `feature (feeling-lucky)`
+  - contains: `Compact research plans can stay as a single research issue`
+  - contains: `angle-based or dependency-based research slices`
+  - contains: `without asking the user follow-up questions`
 
 ### [slice-one-issue.md](./reef-pulse/slice-one-issue.md)
 
+- phase-specific
+  - contains: `inferred combined value before saving the issue body`
+  - contains: `If the slice bearing is deep-research, the acceptance criteria must stay research-focused`
 - set-variables
 
   ```sh
-  ISSUE_BODY="{plan issue body with scoped pr-branch preserved and acceptance criteria appended}"
+  ISSUE_BODY="{plan issue body with scoped pr-branch and rewritten bearing preserved, plus acceptance criteria appended}"
   ```
 
 - update-tracker
@@ -277,6 +285,8 @@ General rules:
   ```sh
   PR_BRANCH="{from plan issue body pr-branch field}"
   BASE_BRANCH="{from plan issue body}"
+  PLAN_BEARING="{from plan issue body bearing field}"
+  EFFECTIVE_BEARING="{deep-research or inferred lane such as feature (feeling-lucky)}"
   WORKTREE_PATH=".worktrees/$ISSUE_ID-slice"
   ```
 - enter-worktree
@@ -287,14 +297,17 @@ General rules:
   ```sh
   git push -u origin "$PR_BRANCH"
   ```
-- phase-specific
 - set-variables
   ```sh
   SLICE_TITLE="{slice-title} [await: #{blocker-id}]"  # omit [await: ...] if unblocked
   SLICE_PR_BRANCH="{derived from plan issue pr-branch + slice title slug}"
-  SLICE_BODY="{slice-body}" # as per the template below, with pr-branch: $SLICE_PR_BRANCH
+  SLICE_BEARING="{per-slice bearing, usually $EFFECTIVE_BEARING unless a slice needs a narrower inferred lane}"
+  SLICE_BODY="{slice-body}" # as per the template below, with pr-branch: $SLICE_PR_BRANCH and bearing: $SLICE_BEARING
   SLICE_LABEL="to-implement" # or to-await-waves if blocked
   ```
+- phase-specific
+  - contains: `For deep-research, make the slices research-native`
+  - contains: `bearing: $SLICE_BEARING`
 - create-slices
   ```sh
   ./tracker.sh issue create --title "$SLICE_TITLE" --body "$SLICE_BODY" --label "$SLICE_LABEL"

--- a/reef-pulse/slice-one-issue.md
+++ b/reef-pulse/slice-one-issue.md
@@ -17,14 +17,16 @@ The router has already fetched context and drafted exactly 1 slice. No sub-issue
 Take the fast path — skip sub-issues, coverage matrix, and seal. The plan becomes the slice:
 
 1. **Keep the scoped `pr-branch`.** Preserve the `pr-branch` already written by reef-scope in the plan frontmatter.
-2. **No sub-issues.** The plan IS the slice.
-3. **Write acceptance criteria on the plan issue.** Append an `## Acceptance criteria` section to the plan issue body with the criteria you drafted for the single slice.
-4. **No coverage matrix.** Success criteria and acceptance criteria are 1:1 — the mapping adds no information.
+2. **Keep the scoped `pr-branch` and rewritten `bearing` preserved.** If the plan started as `feeling-lucky`, rewrite the frontmatter `bearing` to the inferred combined value before saving the issue body. If the plan is `deep-research`, preserve `bearing: "deep-research"`.
+3. **No sub-issues.** The plan IS the slice.
+4. **Write acceptance criteria on the plan issue.** Append an `## Acceptance criteria` section to the plan issue body with the criteria you drafted for the single slice.
+5. **Shape the acceptance criteria to the lane.** If the slice bearing is deep-research, the acceptance criteria must stay research-focused and describe what must be answered, clarified, or persisted rather than implementation tasks.
+6. **No coverage matrix.** Success criteria and acceptance criteria are 1:1 — the mapping adds no information.
 
 Assemble the updated plan issue body:
 
 ```sh
-ISSUE_BODY="{plan issue body with scoped pr-branch preserved and acceptance criteria appended}"
+ISSUE_BODY="{plan issue body with scoped pr-branch and rewritten bearing preserved, plus acceptance criteria appended}"
 ```
 
 ## 2. Label to-implement

--- a/reef-pulse/slice-subissues.md
+++ b/reef-pulse/slice-subissues.md
@@ -15,6 +15,8 @@ The router has already fetched context and drafted 2+ slices. Set post-fetch var
 ```sh
 PR_BRANCH="{from plan issue body pr-branch field}"
 BASE_BRANCH="{from plan issue body}"
+PLAN_BEARING="{from plan issue body bearing field}"
+EFFECTIVE_BEARING="{deep-research or inferred lane such as feature (feeling-lucky)}"
 WORKTREE_PATH=".worktrees/$ISSUE_ID-slice"
 ```
 
@@ -77,12 +79,14 @@ Assemble each slice body:
 ```sh
 SLICE_TITLE="{slice-title} [await: #{blocker-id}]"  # omit [await: ...] if unblocked
 SLICE_PR_BRANCH="{derived from plan issue pr-branch + slice title slug}"
-SLICE_BODY="{slice-body}" # as per the template below, with pr-branch: $SLICE_PR_BRANCH
+SLICE_BEARING="{per-slice bearing, usually $EFFECTIVE_BEARING unless a slice needs a narrower inferred lane}"
+SLICE_BODY="{slice-body}" # as per the template below, with pr-branch: $SLICE_PR_BRANCH and bearing: $SLICE_BEARING
 SLICE_LABEL="to-implement" # or to-await-waves if blocked
 ```
 
 For blocked slices, append `[await: #{id}, #{id}]` to the title. Unblocked slices get a plain title.
 Give each sub-issue its own `pr-branch`. Derive `SLICE_PR_BRANCH` from the plan issue's `pr-branch` plus a stable slug from the slice title.
+For deep-research, make the slices research-native: use research questions or investigation angles as the slice descriptions, and write acceptance criteria around what must be answered, clarified, or persisted. For feeling-lucky, use the inferred combined bearing and best-effort acceptance criteria without bouncing the work back to scope.
 
 Slice body template:
 
@@ -92,6 +96,7 @@ Slice body template:
 parent-issue: "#$ISSUE_ID"
 base-branch: $PR_BRANCH
 pr-branch: $SLICE_PR_BRANCH
+bearing: $SLICE_BEARING
 
 ---
 

--- a/reef-pulse/slice.md
+++ b/reef-pulse/slice.md
@@ -52,6 +52,12 @@ Report these three variables to the caller and **do not continue**.
 
 Break the plan into slices. Each slice is a thin vertical cut through ALL integration layers end-to-end — not a horizontal slice of one layer.
 
+Also read `bearing` from the frontmatter:
+
+- `deep-research` plans as research-native work
+- `feeling-lucky` plans as deliberately under-scoped work that must be interpreted here
+- `feature`, `refactor`, and `bug` keep their normal slice behavior
+
 Rules:
 
 - Each slice delivers a narrow but COMPLETE path through every layer (schema, API, UI, tests).
@@ -61,6 +67,8 @@ Rules:
 - DO include durable decisions: route paths, schema shapes, data model names.
 - Surface **implicit prerequisites**. If multiple slices depend on a shared dependency (a new table, a utility module, an API client), that dependency is its own slice and the others are blocked by it. (Prevents painpoint D2.)
 - For refactors: slices must respect the tiny-commit discipline. Each slice leaves the codebase compiling and tests green.
+- If the plan bearing is `deep-research`, draft research questions rather than implementation work. Compact research plans can stay as a single research issue. Larger research plans can be split into angle-based or dependency-based research slices. Acceptance criteria should say what must be answered, clarified, or persisted.
+- If the plan bearing is `feeling-lucky`, this is the first phase allowed to deeply interpret the ticket using both the issue and the codebase. Infer the likeliest lane, rewrite `bearing` into a combined value such as `feature (feeling-lucky)`, and produce acceptance criteria and dependencies with best-effort judgment without asking the user follow-up questions.
 
 For small bugs (scope = quick fix in the plan): produce a single slice. The plan's success criteria become the slice's acceptance criteria directly.
 

--- a/tests/reef-slice.test.sh
+++ b/tests/reef-slice.test.sh
@@ -1,0 +1,94 @@
+#!/bin/sh
+# Behavioral tests for reef-pulse slicing instructions.
+set -u
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$TESTS_DIR/.." && pwd)"
+SLICE_FILE="$REPO_ROOT/reef-pulse/slice.md"
+SINGLE_FILE="$REPO_ROOT/reef-pulse/slice-one-issue.md"
+SUBISSUES_FILE="$REPO_ROOT/reef-pulse/slice-subissues.md"
+ORCHESTRATION_FILE="$REPO_ROOT/ORCHESTRATION.md"
+PASS=0
+FAIL=0
+TOTAL=0
+OUTPUT_BUF=""
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+pass() {
+  PASS=$((PASS + 1))
+  TOTAL=$((TOTAL + 1))
+  OUTPUT_BUF="${OUTPUT_BUF}$(printf "${GREEN}PASS${NC}: %s" "$1")
+"
+}
+
+fail() {
+  FAIL=$((FAIL + 1))
+  TOTAL=$((TOTAL + 1))
+  OUTPUT_BUF="${OUTPUT_BUF}$(printf "${RED}FAIL${NC}: %s" "$1")
+"
+  if [ $# -gt 1 ]; then
+    OUTPUT_BUF="${OUTPUT_BUF}$(printf "  %s" "$2")
+"
+  fi
+}
+
+assert_contains() {
+  file="$1"
+  pattern="$2"
+  label="$3"
+
+  if grep -qF "$pattern" "$file"; then
+    pass "$label"
+  else
+    fail "$label" "expected pattern: $pattern"
+  fi
+}
+
+test_slice_router_handles_research_and_lucky_bearings() {
+  diagnostics="$(grep -nE 'deep-research|feeling-lucky|research-native|best-effort|follow-up|angle-based|dependency-based' "$SLICE_FILE" || true)"
+  printf 'DIAGNOSTIC: slice.md bearing guidance currently contains:\n%s\n' "$diagnostics"
+
+  assert_contains "$SLICE_FILE" '`deep-research` plans as research-native work' "slice router treats deep-research as research-native work"
+  assert_contains "$SLICE_FILE" 'Compact research plans can stay as a single research issue' "slice router keeps compact research as one issue"
+  assert_contains "$SLICE_FILE" 'angle-based or dependency-based research slices' "slice router can split larger research work into research slices"
+  assert_contains "$SLICE_FILE" 'deeply interpret the ticket using both the issue and the codebase' "slice router lets feeling-lucky inspect issue plus codebase"
+  assert_contains "$SLICE_FILE" 'rewrite `bearing` into a combined value such as `feature (feeling-lucky)`' "slice router preserves lucky provenance in rewritten bearing"
+  assert_contains "$SLICE_FILE" 'without asking the user follow-up questions' "slice router handles lucky work without bouncing back to scope"
+}
+
+test_single_issue_path_preserves_bearing_and_acceptance_shape() {
+  assert_contains "$SINGLE_FILE" 'scoped `pr-branch` and rewritten `bearing` preserved' "single-issue flow preserves rewritten bearing in frontmatter"
+  assert_contains "$SINGLE_FILE" 'If the slice bearing is deep-research, the acceptance criteria must stay research-focused' "single-issue flow keeps research acceptance criteria research-native"
+}
+
+test_subissues_path_carries_effective_bearing_into_slice_bodies() {
+  assert_contains "$SUBISSUES_FILE" 'PLAN_BEARING="{from plan issue body bearing field}"' "subissues flow reads bearing from the plan"
+  assert_contains "$SUBISSUES_FILE" 'EFFECTIVE_BEARING="{deep-research or inferred lane such as feature (feeling-lucky)}"' "subissues flow computes effective bearing for lucky work"
+  assert_contains "$SUBISSUES_FILE" 'bearing: $SLICE_BEARING' "subissue template persists slice bearing in frontmatter"
+  assert_contains "$SUBISSUES_FILE" 'For deep-research, make the slices research-native' "subissues flow keeps research slice descriptions research-native"
+}
+
+test_orchestration_tracks_slice_bearing_rules() {
+  assert_contains "$ORCHESTRATION_FILE" 'contains: `deep-research` + `feeling-lucky` + `feature (feeling-lucky)`' "orchestration spec records slice bearing cases"
+  assert_contains "$ORCHESTRATION_FILE" 'contains: `inferred combined value before saving the issue body`' "orchestration spec records single-issue bearing preservation"
+  assert_contains "$ORCHESTRATION_FILE" 'bearing: $SLICE_BEARING' "orchestration spec records subissue bearing frontmatter"
+}
+
+test_slice_router_handles_research_and_lucky_bearings
+test_single_issue_path_preserves_bearing_and_acceptance_shape
+test_subissues_path_carries_effective_bearing_into_slice_bodies
+test_orchestration_tracks_slice_bearing_rules
+
+echo ""
+if [ "$FAIL" -gt 0 ]; then
+  printf "%s" "$OUTPUT_BUF"
+  echo "================================"
+  printf "Results: %s passed, ${RED}%s failed${NC}, %s total\n" "$PASS" "$FAIL" "$TOTAL"
+  exit 1
+else
+  echo "================================"
+  printf "Results: %s passed, %s total\n" "$PASS" "$TOTAL"
+fi


### PR DESCRIPTION
closes #152

## Ambiguous choices

None — implementation followed the plan exactly.

## Test results

381 tests passed, 0 failed.

### 🪼 Pulse metrics

| Phase | Target | Duration | Tokens | Tool uses | Outcome | Date |
| ----- | ------ | -------- | ------ | --------- | ------- | ---- |
| implement | #152 | — | — | — | Implementation complete for teach to-slice how to break down research and lucky work | 2026-04-23 20:18 |
| inspect | #152 | — | — | — | approved: research and feeling-lucky slicing guidance matches the acceptance criteria, tests passed, and the inspect report is appended to the PR. | 2026-04-23 20:21 |
<!-- end metrics table -->

<details><summary><h3>🧿 Inspect review — 2026/04/23 20:21</h3></summary>

Verdict: approved.

Acceptance criteria check:
- `to-slice` now treats `deep-research` as research-native work in `reef-pulse/slice.md`, including compact single-issue handling and angle/dependency-based splitting for larger research plans.
- `feeling-lucky` work is now interpreted in `to-slice`, with the inferred combined bearing preserved and best-effort acceptance criteria explicitly allowed without bouncing back to scope.
- The single-issue and subissue paths both preserve the rewritten or effective bearing in `reef-pulse/slice-one-issue.md` and `reef-pulse/slice-subissues.md`.
- Tests cover the router guidance, single-issue behavior, subissue behavior, and orchestration references in `tests/reef-slice.test.sh`.

Verification:
- Full suite run locally in the inspect worktree at `a106c37` passed: 396 checks total, 0 failed (`250 + 20 + 15 + 89 + 22`).
- No cleanup commit was needed.
- PR body still says `381 tests passed`; the current inspect run observed 396 passing checks.

</details>

