### PR TITLE
add a first-class to-research lifecycle and wire it through the docs

### DIFF
--- a/ORCHESTRATION.md
+++ b/ORCHESTRATION.md
@@ -262,6 +262,7 @@ General rules:
 - phase-specific
   - contains: `inferred combined value before saving the issue body`
   - contains: `If the slice bearing is deep-research, the acceptance criteria must stay research-focused`
+  - contains: `For deep-research, label the issue to-research instead of to-implement.`
 - set-variables
 
   ```sh
@@ -270,12 +271,13 @@ General rules:
 
 - update-tracker
   ```sh
-  ./tracker.sh issue edit "$ISSUE_ID" --body "$ISSUE_BODY" --remove-label to-slice --add-label to-implement
+  NEXT_PHASE="{to-research for deep-research, otherwise to-implement}"
+  ./tracker.sh issue edit "$ISSUE_ID" --body "$ISSUE_BODY" --remove-label to-slice --add-label "$NEXT_PHASE"
   ```
 - handoff
   ```sh
   ISSUE_ID="$ISSUE_ID"
-  NEXT_PHASE="to-implement"
+  NEXT_PHASE="to-research"
   PR_ID="—"
   ```
 
@@ -303,7 +305,7 @@ General rules:
   SLICE_PR_BRANCH="{derived from plan issue pr-branch + slice title slug}"
   SLICE_BEARING="{per-slice bearing, usually $EFFECTIVE_BEARING unless a slice needs a narrower inferred lane}"
   SLICE_BODY="{slice-body}" # as per the template below, with pr-branch: $SLICE_PR_BRANCH and bearing: $SLICE_BEARING
-  SLICE_LABEL="to-implement" # or to-await-waves if blocked
+  SLICE_LABEL="{to-research for unblocked deep-research slices, otherwise to-implement; or to-await-waves if blocked}"
   ```
 - phase-specific
   - contains: `For deep-research, make the slices research-native`
@@ -371,6 +373,60 @@ General rules:
   # add to frontmatter (if not already): pr-branch: $PR_BRANCH
   # add to frontmatter:  pr-id: $PR_ID
   ./tracker.sh issue edit "$ISSUE_ID" --body "$ISSUE_BODY_UPDATED" --remove-label to-implement --add-label to-inspect
+  ```
+- exit-worktree
+  ```sh
+  ./worktree-exit.sh --path "$WORKTREE_PATH"
+  ```
+- handoff
+  ```sh
+  ISSUE_ID="$ISSUE_ID"
+  NEXT_PHASE="to-inspect"
+  PR_ID="$PR_ID"
+  ```
+
+### [research.md](./reef-pulse/research.md)
+
+- set-variables
+  ```sh
+  ISSUE_ID="{issue-id}" # pre-existing and passed, e.g.: #42
+  ```
+- fetch-context
+  ```sh
+  ./tracker.sh issue view "$ISSUE_ID" --json body,title,labels
+  ```
+- set-variables
+  ```sh
+  ISSUE_TITLE="{from issue title}"
+  BASE_BRANCH="{from issue frontmatter base-branch field}"
+  PR_BRANCH="{from issue frontmatter pr-branch field}"
+  WORKTREE_PATH=".worktrees/$ISSUE_TITLE-research"
+  ```
+- enter-worktree
+  ```sh
+  WORKTREE_STATUS=$(./worktree-enter.sh --fork-from "$BASE_BRANCH" --pull-latest "$BASE_BRANCH" --path "$WORKTREE_PATH")
+  ```
+- phase-specific
+  - contains: `produce a durable research artifact instead of code`
+  - contains: `lightweight source links near externally sourced findings`
+- commit-code
+  ```sh
+  ./commit.sh --branch "$PR_BRANCH" -m "$ISSUE_TITLE: research"
+  ```
+- set-variables
+  ```sh
+  CLOSES="closes $ISSUE_ID $ISSUE_TITLE" # e.g.: #42
+  REPORT="{research report}"
+  PR_BODY_NEW="$CLOSES\n\n$REPORT"
+  ./tracker.sh pr create --base "$BASE_BRANCH" --title "$ISSUE_TITLE" --body "$PR_BODY_NEW" --label to-inspect
+  ```
+- set-variables
+  ```sh
+  PR_ID="{from pr create output}" # e.g.: #43
+  ISSUE_BODY_UPDATED="{original issue body with added frontmatter values}"
+  # add to frontmatter (if not already): pr-branch: $PR_BRANCH
+  # add to frontmatter:  pr-id: $PR_ID
+  ./tracker.sh issue edit "$ISSUE_ID" --body "$ISSUE_BODY_UPDATED" --remove-label to-research --add-label to-inspect
   ```
 - exit-worktree
   ```sh
@@ -502,6 +558,7 @@ General rules:
   ```sh
   ISSUE_TITLE="{from issue title, stripping [await: ...] suffix}"
   BASE_BRANCH="{from issue frontmatter base-branch field}"
+  BEARING="{from issue frontmatter bearing field}"
   WORKTREE_PATH=".worktrees/$ISSUE_TITLE-await-waves"
   ```
 - set-variables
@@ -514,7 +571,8 @@ General rules:
   ```
 - update-tracker
   ```sh
-  ./tracker.sh issue edit "$ISSUE_ID" --remove-label to-await-waves --add-label to-implement --title "$ISSUE_TITLE"
+  NEXT_LABEL="{to-research for deep-research, otherwise to-implement}"
+  ./tracker.sh issue edit "$ISSUE_ID" --remove-label to-await-waves --add-label "$NEXT_LABEL" --title "$ISSUE_TITLE"
   ```
 - enter-worktree
   ```sh
@@ -536,7 +594,7 @@ General rules:
 - handoff
   ```sh
   ISSUE_ID="$ISSUE_ID"
-  NEXT_PHASE="to-implement" # or "to-await-waves" if still blocked
+  NEXT_PHASE="to-research" # or "to-implement" or "to-await-waves" depending on bearing and blockers
   PR_ID="—"
   ```
 

--- a/README.md
+++ b/README.md
@@ -44,9 +44,9 @@ stateDiagram-v2
 
         [*] --> to_scope
         to_scope --> to_slice : reef-scope skill<br />scope the work, define success criteria
-        to_slice --> slice_lifecycle : slice.md<br />🔷　creates sub-issues:<br />labels each sub-issue to-implement
+        to_slice --> slice_lifecycle : slice.md<br />🔷　creates sub-issues:<br />labels each sub-issue to-implement or to-research
 <br />adds coverage matrix to parent issue
-        to_slice --> slice_lifecycle : slice.md<br />🔶　no sub-issues needed:<br />labels the current issue to-implement
+        to_slice --> slice_lifecycle : slice.md<br />🔶　no sub-issues needed:<br />labels the current issue to-implement or to-research
         slice_lifecycle --> to_seal
         slice_lifecycle --> to_land
         to_seal --> to_land : seal.md<br />holistic review on current issue pr-branch
@@ -59,15 +59,19 @@ stateDiagram-v2
 
         state "🌊　to-await-waves" as to_await
         state "🌊　to-implement" as to_implement
+        state "🌊　to-research" as to_research
         state "🌊　to-inspect" as to_inspect
         state "🌊　to-rework" as to_rework
         state "🌊　to-merge" as to_merge
         state "merge.md<br />🔷　has parent issue:<br />merge PR, when all sub-issues are landed → to-seal" as merge_multi
         state "merge.md<br />🔶　no parent issue:<br />PR stays open → to-seal" as merge_single
-        [*] --> to_implement : no deps
+        [*] --> to_implement : no deps, implementation lane
+        [*] --> to_research : no deps, research lane
         [*] --> to_await : has deps
-        to_await --> to_implement : await-waves.md<br />check if deps are landed, re-review plan
+        to_await --> to_implement : await-waves.md<br />deps landed, implementation lane still fits
+        to_await --> to_research : await-waves.md<br />deps landed, research lane still fits
         to_implement --> to_inspect : implement.md<br />TDD per slice, full suite green
+        to_research --> to_inspect : research.md<br />research artifact committed, source links nearby
         to_inspect --> to_merge : inspect.md<br />acceptance criteria met, PR clean
         to_inspect --> to_rework : inspect.md<br />gaps flagged
         to_rework --> to_inspect : rework.md<br />read feedback, fix, re-verify
@@ -76,13 +80,13 @@ stateDiagram-v2
     }
 
     class to_scope,to_land human
-    class to_slice,to_seal,plan_rework,to_await,to_implement,to_inspect,to_rework,to_merge agent
+    class to_slice,to_seal,plan_rework,to_await,to_implement,to_research,to_inspect,to_rework,to_merge agent
     class merge_multi,merge_single arrow
 ```
 
 > While sub-issues are being worked, the parent issue sits in `in-progress`. It is promoted to `to-seal` by `merge.md` once all sub-issues are landed.
 >
-> Each issue has one `DELIVERY CYCLE`. It may contain one or many `IMPLEMENTATION CYCLE`s: one on the issue itself when no sub-issues are needed, or one per sub-issue when the work is split.
+> Each issue has one `DELIVERY CYCLE`. It may contain one or many execution cycles: one on the issue itself when no sub-issues are needed, or one per sub-issue when the work is split. Most slices use the implementation cycle; research slices branch through `to-research` but rejoin the same inspect, rework, merge, and seal flow.
 
 ## Skills
 
@@ -147,10 +151,10 @@ These are the 🌊 automated phases dispatched by the `reef-pulse` skill. Each p
 <details>
 <summary>🌊 <b><code>to-slice</code></b> 🏷️</summary>
 
-Automatically breaks the plan into vertical slices, or determines that the current issue can be implemented directly without sub-issues.
+Automatically breaks the plan into vertical slices, or determines that the current issue can be executed directly without sub-issues.
 
-- 🔷　creates sub-issues: labels each sub-issue `to-implement`, adds coverage matrix to the parent issue
-- 🔶　no sub-issues needed: labels the current issue `to-implement`
+- 🔷　creates sub-issues: labels each sub-issue `to-implement`, `to-research`, or `to-await-waves`, adds coverage matrix to the parent issue
+- 🔶　no sub-issues needed: labels the current issue `to-implement` or `to-research`
 
 | source file | [`reef-pulse/slice.md`](reef-pulse/slice.md) |
 | :---------- | :------------------------------------------- |
@@ -162,7 +166,7 @@ Automatically breaks the plan into vertical slices, or determines that the curre
 <details>
 <summary>🌊 <b><code>to-await-waves</code></b> 🏷️</summary>
 
-Check if a blocked issue's dependencies are all landed. If yes, re-review the plan against current code and label `to-implement`. If not, exit — next pulse will check again.
+Check if a blocked issue's dependencies are all landed. If yes, re-review the plan against current code and restore the right execution label: `to-research` for deep-research work, `to-implement` otherwise. If not, exit — next pulse will check again.
 
 | source file | [`reef-pulse/await-waves.md`](reef-pulse/await-waves.md) |
 | :---------- | :------------------------------------------------------- |
@@ -182,6 +186,18 @@ Implement an issue using TDD in a git worktree. Create worktree → read context
 </details>
 
 <p align="right">🐙<br /><sub>An octopus in a little workshop arranges shells, pebbles, and ribbons of kelp with patient hands. By dusk, a once-empty corner of the reef has become something useful and alive.</sub></p>
+
+<details>
+<summary>🌊 <b><code>to-research</code></b> 🏷️</summary>
+
+Execute a research issue in a git worktree. Investigate the promised question, persist committed Markdown research artifacts, keep lightweight source links close to externally sourced findings, write the report, and label `to-inspect`.
+
+| source file | [`reef-pulse/research.md`](reef-pulse/research.md) |
+| :---------- | :------------------------------------------------- |
+
+</details>
+
+<p align="right">🐬<br /><sub>A dolphin loops ahead of the reef and returns with a ribbon of shells, each one pointing back toward what it found in the open water. The trail is playful, but nothing in it is vague.</sub></p>
 
 <details>
 <summary>🌊 <b><code>to-inspect</code></b> 🏷️</summary>

--- a/reef-pulse/SKILL.md
+++ b/reef-pulse/SKILL.md
@@ -90,7 +90,7 @@ Read the config to determine the tracker type, then scan for all tagged issues.
 ```sh
 # Scan all reef-tagged issues in a single query
 ./tracker.sh issue list --json number,title,labels --limit 100 \
-  --search 'label:to-scope OR label:to-slice OR label:to-await-waves OR label:to-implement OR label:to-inspect OR label:to-rework OR label:to-merge OR label:to-seal OR label:to-land'
+  --search 'label:to-scope OR label:to-slice OR label:to-await-waves OR label:to-implement OR label:to-research OR label:to-inspect OR label:to-rework OR label:to-merge OR label:to-seal OR label:to-land'
 ```
 
 ### 3. Dispatch automated (🌊) work — Flow wave
@@ -109,6 +109,7 @@ For each item, spawn a sub-agent with: `"Read and follow $SKILL_DIR/{file}. Targ
 | -------------- | ------------------------- |
 | `to-slice`     | `$SKILL_DIR/slice.md`     |
 | `to-implement` | `$SKILL_DIR/implement.md` |
+| `to-research`  | `$SKILL_DIR/research.md`  |
 | `to-inspect`   | `$SKILL_DIR/inspect.md`   |
 | `to-rework`    | `$SKILL_DIR/rework.md`    |
 | `to-merge`     | `$SKILL_DIR/merge.md`     |
@@ -140,6 +141,7 @@ Immediately after dispatching, print each dispatched agent with its phase emoji.
 | ---------------- | ----------- |
 | `to-slice`       | `𐃆🐋`       |
 | `to-implement`   | `  🐙`      |
+| `to-research`    | `  🐬`      |
 | `to-inspect`     | `  🧿`      |
 | `to-rework`      | `  🦀`      |
 | `to-merge`       | `  🐢`      |

--- a/reef-pulse/await-waves.md
+++ b/reef-pulse/await-waves.md
@@ -29,6 +29,7 @@ Set the post-fetch variables (after reading the issue title and body):
 ```sh
 ISSUE_TITLE="{from issue title, stripping [await: ...] suffix}"
 BASE_BRANCH="{from issue frontmatter base-branch field}"
+BEARING="{from issue frontmatter bearing field}"
 WORKTREE_PATH=".worktrees/$ISSUE_TITLE-await-waves"
 ```
 
@@ -52,11 +53,12 @@ DEPENDENCY_ID="{from [await: ...] title suffix}" # e.g. "#55"
 
 ## 2. Promote
 
-Strip the `[await: ...]` suffix from the title and flip the label:
+Strip the `[await: ...]` suffix from the title and flip the label. If the bearing is `deep-research`, promote into label `to-research`; otherwise promote into label `to-implement`:
 
 ```sh
 ISSUE_TITLE="{stripped title without [await: ...] suffix}"
-./tracker.sh issue edit "$ISSUE_ID" --remove-label to-await-waves --add-label to-implement --title "$ISSUE_TITLE"
+NEXT_LABEL="{to-research for deep-research, otherwise to-implement}"
+./tracker.sh issue edit "$ISSUE_ID" --remove-label to-await-waves --add-label "$NEXT_LABEL" --title "$ISSUE_TITLE"
 ```
 
 Promotion is final. The worktree step below is best-effort course correction.
@@ -105,9 +107,9 @@ ISSUE_BODY_UPDATED="{issue body, with updated acceptance criteria if changed}"
 
 ```sh
 ISSUE_ID="$ISSUE_ID"
-NEXT_PHASE="to-implement" # or "to-await-waves" if still blocked
+NEXT_PHASE="to-research" # or "to-implement" or "to-await-waves" depending on bearing and blockers
 PR_ID="—"
-SUMMARY="{ISSUE_TITLE} is unblocked and ready for implementation" # or "still blocked by #N, #M"
+SUMMARY="{ISSUE_TITLE} is unblocked and ready for research or implementation" # or "still blocked by #N, #M"
 ```
 
 Report these three variables to the caller.

--- a/reef-pulse/research.md
+++ b/reef-pulse/research.md
@@ -1,0 +1,157 @@
+# research
+
+Before starting, read `.agents/moonjelly-reef/config.md` — it tells you the issue tracker type (GitHub, local, Jira, etc.) and any installed optional skills. If the file doesn't exist, read and follow [setup.md](setup.md) first and return here after.
+
+> **Shell blocks are literal commands** — `./worktree-enter.sh`, `./worktree-exit.sh`, `./commit.sh`, and `./tracker.sh` are real scripts next to this file. Execute them as written; do not substitute with raw git commands.
+>
+> **Tracker note**: Commands below use `./tracker.sh` syntax for both issue and PR operations. For local-tracker projects, run `./tracker.sh` directly. For GitHub, replace `./tracker.sh` with `gh`. For MCP trackers (ClickUp, Jira, Linear), use equivalent MCP tool calls.
+
+> **AFK skill**: this skill runs without human interaction. When in doubt: check the plan, make your best judgment, move on. Never block waiting for human input.
+
+## Input
+
+This skill requires a specific issue: e.g. `#55` or `research/001-auth-token-rotation`.
+
+Read the issue. It must contain:
+
+- Acceptance criteria
+- `base-branch` in frontmatter (where the PR merges into)
+- `pr-branch` in frontmatter (the branch the PR lives on)
+- Research-oriented success criteria or acceptance criteria
+
+Set the pre-fetch variables:
+
+```sh
+ISSUE_ID="{issue-id}" # pre-existing and passed, e.g.: #42
+```
+
+## 0. Fetch context
+
+```sh
+./tracker.sh issue view "$ISSUE_ID" --json body,title,labels
+```
+
+Set the post-fetch variables (after reading the issue body):
+
+```sh
+ISSUE_TITLE="{from issue title}"
+BASE_BRANCH="{from issue frontmatter base-branch field}"
+PR_BRANCH="{from issue frontmatter pr-branch field}"
+WORKTREE_PATH=".worktrees/$ISSUE_TITLE-research"
+```
+
+## 1. Git prep
+
+This is non-negotiable. Every step must pass before you write research artifacts.
+
+Enter a worktree forked from $BASE_BRANCH so you start from a clean integration point:
+
+```sh
+WORKTREE_STATUS=$(./worktree-enter.sh --fork-from "$BASE_BRANCH" --pull-latest "$BASE_BRANCH" --path "$WORKTREE_PATH")
+```
+
+Read the output. On `ready` or `synced`: continue. On `conflicts`: attempt to resolve the conflicts in the worktree. If resolved, commit the merge and push to `origin/$BASE_BRANCH` using explicit refspec (no force), then continue. If unresolvable:
+
+```sh
+./tracker.sh issue edit "$ISSUE_ID" --add-label blocked-with-conflicts
+```
+
+Stop — do not proceed.
+
+Verify:
+
+- [ ] The project builds / compiles cleanly before you touch anything
+- [ ] The full test suite passes before you touch anything (this is your baseline)
+
+If the baseline is already broken, **stop and report this**. Do not try to fix pre-existing failures. Label the issue `to-rework` with a note explaining what's broken.
+
+## 2. Read context
+
+Before writing any artifacts, read and understand:
+
+- **This issue's acceptance criteria** — this is your checklist. Every criterion must be addressed.
+- **The plan + success criteria** — understand the question the research must answer.
+- **Sibling issues** — awareness of what others are doing or have done. Don't duplicate, don't conflict.
+- **The decision record** — the original decisions that led here.
+
+## 3. Execute the research
+
+Investigate the issue and persist the findings in committed Markdown files in the repository. The goal is to produce a durable research artifact instead of code.
+
+Research outputs must:
+
+- live in committed Markdown files
+- keep lightweight source links near externally sourced findings
+- clearly answer the promised question, angle, or uncertainty from the issue
+
+If external research is unnecessary, say so in the artifact and skip source links for that section. If the issue reveals follow-up questions, capture them in the artifact instead of leaving them implicit.
+
+Commit your work when the research artifacts are complete.
+
+## 4. Write the report
+
+When research is complete, compose the PR description using this template:
+
+```markdown
+## Ambiguous choices
+
+Decisions made during research that weren't covered by the acceptance criteria or where judgment was needed:
+
+- **{topic}**: chose {X} because {reason}. This differs from the plan in that {difference, if any}.
+
+(If no ambiguous choices were made, write "None — research followed the plan exactly.")
+
+## Research outputs
+
+- `{path/to/artifact.md}` — {what it answers}
+
+## Test results
+
+{Output of the full test suite run. If too long, summarize: "X tests passed, 0 failed, 0 skipped."}
+```
+
+## 5. Open the PR
+
+```sh
+./commit.sh --branch "$PR_BRANCH" -m "$ISSUE_TITLE: research"
+```
+
+The PR body must start with the "closes" reference, followed by the research report:
+
+```sh
+CLOSES="closes $ISSUE_ID $ISSUE_TITLE" # e.g.: #42
+REPORT="{research report}"
+PR_BODY_NEW="$CLOSES\n\n$REPORT"
+./tracker.sh pr create --base "$BASE_BRANCH" --title "$ISSUE_TITLE" --body "$PR_BODY_NEW" --label to-inspect
+```
+
+The PR targets `$BASE_BRANCH` — the branch it merges into.
+
+## 6. Update the issue and label
+
+Persist the PR metadata for the newly created PR on the issue body so downstream phases (inspect, rework, merge) can find it.
+
+```sh
+PR_ID="{from pr create output}" # e.g.: #43
+ISSUE_BODY_UPDATED="{original issue body with added frontmatter values}"
+# add to frontmatter (if not already): pr-branch: $PR_BRANCH
+# add to frontmatter:  pr-id: $PR_ID
+./tracker.sh issue edit "$ISSUE_ID" --body "$ISSUE_BODY_UPDATED" --remove-label to-research --add-label to-inspect
+```
+
+## 7. Clean up
+
+```sh
+./worktree-exit.sh --path "$WORKTREE_PATH"
+```
+
+## Handoff
+
+```sh
+ISSUE_ID="$ISSUE_ID"
+NEXT_PHASE="to-inspect"
+PR_ID="$PR_ID"
+SUMMARY="Research complete for $ISSUE_TITLE"
+```
+
+Report these three variables to the caller.

--- a/reef-pulse/slice-one-issue.md
+++ b/reef-pulse/slice-one-issue.md
@@ -21,7 +21,8 @@ Take the fast path — skip sub-issues, coverage matrix, and seal. The plan beco
 3. **No sub-issues.** The plan IS the slice.
 4. **Write acceptance criteria on the plan issue.** Append an `## Acceptance criteria` section to the plan issue body with the criteria you drafted for the single slice.
 5. **Shape the acceptance criteria to the lane.** If the slice bearing is deep-research, the acceptance criteria must stay research-focused and describe what must be answered, clarified, or persisted rather than implementation tasks.
-6. **No coverage matrix.** Success criteria and acceptance criteria are 1:1 — the mapping adds no information.
+6. **Route research slices into the research phase.** For deep-research, label the issue to-research instead of to-implement.
+7. **No coverage matrix.** Success criteria and acceptance criteria are 1:1 — the mapping adds no information.
 
 Assemble the updated plan issue body:
 
@@ -29,19 +30,20 @@ Assemble the updated plan issue body:
 ISSUE_BODY="{plan issue body with scoped pr-branch and rewritten bearing preserved, plus acceptance criteria appended}"
 ```
 
-## 2. Label to-implement
+## 2. Label the next phase
 
 ```sh
-./tracker.sh issue edit "$ISSUE_ID" --body "$ISSUE_BODY" --remove-label to-slice --add-label to-implement
+NEXT_PHASE="{to-research for deep-research, otherwise to-implement}"
+./tracker.sh issue edit "$ISSUE_ID" --body "$ISSUE_BODY" --remove-label to-slice --add-label "$NEXT_PHASE"
 ```
 
 ## Handoff
 
 ```sh
 ISSUE_ID="$ISSUE_ID"
-NEXT_PHASE="to-implement"
+NEXT_PHASE="to-research"
 PR_ID="—"
-SUMMARY="No sub-issues needed — plan issue moves to to-implement"
+SUMMARY="No sub-issues needed — plan issue moves directly into research or implementation"
 ```
 
 Report these three variables to the caller.

--- a/reef-pulse/slice-subissues.md
+++ b/reef-pulse/slice-subissues.md
@@ -81,7 +81,7 @@ SLICE_TITLE="{slice-title} [await: #{blocker-id}]"  # omit [await: ...] if unblo
 SLICE_PR_BRANCH="{derived from plan issue pr-branch + slice title slug}"
 SLICE_BEARING="{per-slice bearing, usually $EFFECTIVE_BEARING unless a slice needs a narrower inferred lane}"
 SLICE_BODY="{slice-body}" # as per the template below, with pr-branch: $SLICE_PR_BRANCH and bearing: $SLICE_BEARING
-SLICE_LABEL="to-implement" # or to-await-waves if blocked
+SLICE_LABEL="{to-research for unblocked deep-research slices, otherwise to-implement; or to-await-waves if blocked}"
 ```
 
 For blocked slices, append `[await: #{id}, #{id}]` to the title. Unblocked slices get a plain title.
@@ -121,7 +121,7 @@ Create the slice:
 ./tracker.sh issue create --title "$SLICE_TITLE" --body "$SLICE_BODY" --label "$SLICE_LABEL"
 ```
 
-Label each slice: `to-implement` if no blockers, `to-await-waves` if blocked.
+Label each slice: `to-research` if no blockers and the slice bearing is `deep-research`, `to-implement` if no blockers and the slice is implementation work, `to-await-waves` if blocked.
 
 ## 5. Update the plan
 

--- a/tests/reef-research.test.sh
+++ b/tests/reef-research.test.sh
@@ -1,0 +1,108 @@
+#!/bin/sh
+# Behavioral tests for the dedicated to-research lifecycle.
+set -u
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$TESTS_DIR/.." && pwd)"
+PULSE_FILE="$REPO_ROOT/reef-pulse/SKILL.md"
+AWAIT_FILE="$REPO_ROOT/reef-pulse/await-waves.md"
+RESEARCH_FILE="$REPO_ROOT/reef-pulse/research.md"
+SINGLE_FILE="$REPO_ROOT/reef-pulse/slice-one-issue.md"
+SUBISSUES_FILE="$REPO_ROOT/reef-pulse/slice-subissues.md"
+README_FILE="$REPO_ROOT/README.md"
+ORCHESTRATION_FILE="$REPO_ROOT/ORCHESTRATION.md"
+PASS=0
+FAIL=0
+TOTAL=0
+OUTPUT_BUF=""
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+pass() {
+  PASS=$((PASS + 1))
+  TOTAL=$((TOTAL + 1))
+  OUTPUT_BUF="${OUTPUT_BUF}$(printf "${GREEN}PASS${NC}: %s" "$1")
+"
+}
+
+fail() {
+  FAIL=$((FAIL + 1))
+  TOTAL=$((TOTAL + 1))
+  OUTPUT_BUF="${OUTPUT_BUF}$(printf "${RED}FAIL${NC}: %s" "$1")
+"
+  if [ $# -gt 1 ]; then
+    OUTPUT_BUF="${OUTPUT_BUF}$(printf "  %s" "$2")
+"
+  fi
+}
+
+assert_contains() {
+  file="$1"
+  pattern="$2"
+  label="$3"
+
+  if grep -qF "$pattern" "$file"; then
+    pass "$label"
+  else
+    fail "$label" "expected pattern: $pattern"
+  fi
+}
+
+test_pulse_dispatches_to_research_as_first_class_phase() {
+  diagnostics="$(grep -nE 'to-await-waves|to-implement|to-research|to-inspect|🪸|🐬' "$PULSE_FILE" || true)"
+  printf 'DIAGNOSTIC: reef-pulse phase routing currently contains:\n%s\n' "$diagnostics"
+
+  assert_contains "$PULSE_FILE" 'label:to-research' "pulse scan includes to-research items"
+  assert_contains "$PULSE_FILE" '| `to-research`  | `$SKILL_DIR/research.md`  |' "pulse dispatch table routes to-research into research.md"
+  assert_contains "$PULSE_FILE" '| `to-research`    | `  🐬`      |' "pulse emoji table assigns the dolphin to to-research"
+}
+
+test_await_waves_promotes_research_work_into_to_research() {
+  assert_contains "$AWAIT_FILE" 'label `to-research`' "await-waves docs describe promotion into to-research for research work"
+  assert_contains "$AWAIT_FILE" 'NEXT_PHASE="to-research" # or "to-implement" or "to-await-waves" depending on bearing and blockers' "await-waves handoff documents research-aware routing"
+}
+
+test_slice_flows_stop_forcing_research_into_to_implement() {
+  assert_contains "$SINGLE_FILE" 'For deep-research, label the issue to-research instead of to-implement.' "single-issue slicing routes research issues into to-research"
+  assert_contains "$SINGLE_FILE" 'NEXT_PHASE="to-research"' "single-issue handoff returns to-research for research work"
+  assert_contains "$SUBISSUES_FILE" 'SLICE_LABEL="{to-research for unblocked deep-research slices, otherwise to-implement; or to-await-waves if blocked}"' "subissue slicing labels unblocked research slices to-research"
+}
+
+test_research_phase_exists_and_documents_markdown_outputs() {
+  if [ -f "$RESEARCH_FILE" ]; then
+    pass "research phase file exists"
+  else
+    fail "research phase file exists" "missing file: $RESEARCH_FILE"
+  fi
+
+  assert_contains "$RESEARCH_FILE" 'produce a durable research artifact instead of code' "research phase focuses on durable research artifacts"
+  assert_contains "$RESEARCH_FILE" 'lightweight source links near externally sourced findings' "research phase requires nearby source links"
+  assert_contains "$RESEARCH_FILE" './commit.sh --branch "$PR_BRANCH" -m "$ISSUE_TITLE: research"' "research phase commits research artifacts onto the PR branch"
+}
+
+test_readme_and_orchestration_document_to_research() {
+  assert_contains "$README_FILE" 'state "🌊　to-research" as to_research' "README state machine includes to-research"
+  assert_contains "$README_FILE" '<summary>🌊 <b><code>to-research</code></b> 🏷️</summary>' "README adds a dedicated to-research phase section"
+  assert_contains "$README_FILE" '🐬' "README uses dolphin flavor text for the research phase"
+  assert_contains "$ORCHESTRATION_FILE" '### [research.md](./reef-pulse/research.md)' "orchestration spec includes the research phase file"
+  assert_contains "$ORCHESTRATION_FILE" './tracker.sh issue edit "$ISSUE_ID" --body "$ISSUE_BODY_UPDATED" --remove-label to-research --add-label to-inspect' "orchestration spec records research issue promotion to inspect"
+}
+
+test_pulse_dispatches_to_research_as_first_class_phase
+test_await_waves_promotes_research_work_into_to_research
+test_slice_flows_stop_forcing_research_into_to_implement
+test_research_phase_exists_and_documents_markdown_outputs
+test_readme_and_orchestration_document_to_research
+
+echo ""
+if [ "$FAIL" -gt 0 ]; then
+  printf "%s" "$OUTPUT_BUF"
+  echo "================================"
+  printf "Results: %s passed, ${RED}%s failed${NC}, %s total\n" "$PASS" "$FAIL" "$TOTAL"
+  exit 1
+else
+  echo "================================"
+  printf "Results: %s passed, %s total\n" "$PASS" "$TOTAL"
+fi

--- a/tests/reef-slice.test.sh
+++ b/tests/reef-slice.test.sh
@@ -62,18 +62,21 @@ test_slice_router_handles_research_and_lucky_bearings() {
 test_single_issue_path_preserves_bearing_and_acceptance_shape() {
   assert_contains "$SINGLE_FILE" 'scoped `pr-branch` and rewritten `bearing` preserved' "single-issue flow preserves rewritten bearing in frontmatter"
   assert_contains "$SINGLE_FILE" 'If the slice bearing is deep-research, the acceptance criteria must stay research-focused' "single-issue flow keeps research acceptance criteria research-native"
+  assert_contains "$SINGLE_FILE" 'For deep-research, label the issue to-research instead of to-implement.' "single-issue flow routes research work into to-research"
 }
 
 test_subissues_path_carries_effective_bearing_into_slice_bodies() {
   assert_contains "$SUBISSUES_FILE" 'PLAN_BEARING="{from plan issue body bearing field}"' "subissues flow reads bearing from the plan"
   assert_contains "$SUBISSUES_FILE" 'EFFECTIVE_BEARING="{deep-research or inferred lane such as feature (feeling-lucky)}"' "subissues flow computes effective bearing for lucky work"
   assert_contains "$SUBISSUES_FILE" 'bearing: $SLICE_BEARING' "subissue template persists slice bearing in frontmatter"
+  assert_contains "$SUBISSUES_FILE" 'SLICE_LABEL="{to-research for unblocked deep-research slices, otherwise to-implement; or to-await-waves if blocked}"' "subissues flow routes research slices into to-research when unblocked"
   assert_contains "$SUBISSUES_FILE" 'For deep-research, make the slices research-native' "subissues flow keeps research slice descriptions research-native"
 }
 
 test_orchestration_tracks_slice_bearing_rules() {
   assert_contains "$ORCHESTRATION_FILE" 'contains: `deep-research` + `feeling-lucky` + `feature (feeling-lucky)`' "orchestration spec records slice bearing cases"
   assert_contains "$ORCHESTRATION_FILE" 'contains: `inferred combined value before saving the issue body`' "orchestration spec records single-issue bearing preservation"
+  assert_contains "$ORCHESTRATION_FILE" 'contains: `For deep-research, label the issue to-research instead of to-implement.`' "orchestration spec records research single-issue routing"
   assert_contains "$ORCHESTRATION_FILE" 'bearing: $SLICE_BEARING' "orchestration spec records subissue bearing frontmatter"
 }
 


### PR DESCRIPTION
closes #153 add a first-class to-research lifecycle and wire it through the docs

## Ambiguous choices

None — implementation followed the plan exactly.

## Test results

- `tests/orchestration.test.sh`: 277 passed, 0 failed
- `tests/reef-research.test.sh`: 17 passed, 0 failed
- `tests/reef-scope.test.sh`: 20 passed, 0 failed
- `tests/reef-slice.test.sh`: 18 passed, 0 failed
- `tests/tracker.test.sh`: 89 passed, 0 failed
- `tests/worktree.test.sh`: 22 passed, 0 failed

### 🪼 Pulse metrics

| Phase | Target | Duration | Tokens | Tool uses | Outcome | Date |
| ----- | ------ | -------- | ------ | --------- | ------- | ---- |
| implement | #153 | — | — | — | Implementation complete for add a first-class to-research lifecycle and wire it through the docs | 2026-04-24 00:40 |
| inspect | #153 | — | — | — | approved: dedicated to-research lifecycle is wired through routing, docs, orchestration, and tests with full suite green | 2026-04-24 00:45 |
<!-- end metrics table -->

<details><summary><h3>🧿 Inspect review — 2026/04/24 04:13</h3></summary>

Verdict: approved for merge.

Acceptance criteria check:
- Dedicated `to-research` phase added and documented across lifecycle files.
- Research outputs are specified as committed Markdown artifacts with nearby lightweight source links.
- `reef-pulse` dispatches `to-research` as a first-class automated phase and routing docs agree.
- Deep-research and feeling-lucky slicing guidance remains intact while research work routes into `to-research`.
- README includes the dolphin-themed `to-research` phase section and updated Mermaid flow.
- `ORCHESTRATION.md` updates keep the persistence and handoff contract aligned for `to-research`.
- Guardrail tests cover the new phase and routing/persistence rules.

Verification:
- `./test.sh` in the inspect worktree passed: 277 orchestration, 17 reef-research, 20 reef-scope, 18 reef-slice, 89 tracker, 22 worktree.

Ambiguous choices review:
- PR says "None — implementation followed the plan exactly." I found no drift that needs escalation.
</details>
