### PR TITLE
teach inspect, rework, and seal how to review research and lucky work

### DIFF
--- a/ORCHESTRATION.md
+++ b/ORCHESTRATION.md
@@ -461,6 +461,8 @@ General rules:
   WORKTREE_STATUS=$(./worktree-enter.sh --fork-from "$PR_BRANCH" --pull-latest "$BASE_BRANCH" --path "$WORKTREE_PATH")
   ```
 - phase-specific
+  - contains: `For deep-research, inspect the committed research artifact mechanically rather than treating it like code.`
+  - contains: `If acceptance criteria are fuzzy because the issue was intentionally feeling-lucky, do not get fussy about their absence.`
 - commit-code — if cleanup-needed
   ```sh
   ./commit.sh --branch "$PR_BRANCH" -m "inspect: cleanup"
@@ -517,6 +519,8 @@ General rules:
   WORKTREE_STATUS=$(./worktree-enter.sh --fork-from "$PR_BRANCH" --pull-latest "$BASE_BRANCH" --path "$WORKTREE_PATH")
   ```
 - phase-specific
+  - contains: `For deep-research, rework means revising the committed research docs to close the flagged gaps.`
+  - contains: `For feeling-lucky, rework may refine the inferred lane or bearing if QA surfaced a better interpretation.`
 - commit-code
   ```sh
   ./commit.sh --branch "$PR_BRANCH" -m "rework: address review feedback"
@@ -714,6 +718,8 @@ General rules:
   WORKTREE_STATUS=$(./worktree-enter.sh --fork-from "$PR_BRANCH" --pull-latest "$BASE_BRANCH" --path "$WORKTREE_PATH")
   ```
 - phase-specific
+  - contains: `For deep-research, review the written research holistically against the end goal, not just the slice acceptance criteria.`
+  - contains: `For feeling-lucky, keep the normal mechanical quality bar but apply slightly softer strictness during holistic review.`
 - commit-code — if documentation-added
   ```sh
   ./commit.sh --branch "$PR_BRANCH" -m "seal: add documentation"

--- a/reef-pulse/inspect.md
+++ b/reef-pulse/inspect.md
@@ -80,6 +80,10 @@ For each acceptance criterion on the issue:
 - Confirm the behavior is correct by reading the test that covers it.
 - If there's no test for an acceptance criterion, that's a gap — flag it.
 - If the test exists but uses mocks where integration tests are expected, flag it. (Prevents painpoint C3.)
+- For deep-research, inspect the committed research artifact mechanically rather than treating it like code.
+- Check that the writing is clear, coherent, not overly drawn out, and actually answers the promised angle or question.
+- If acceptance criteria are fuzzy because the issue was intentionally feeling-lucky, do not get fussy about their absence.
+- Still review lucky work for clarity, simplicity, polish opportunities, and obvious quality problems.
 
 ### 3. Review the report
 

--- a/reef-pulse/rework.md
+++ b/reef-pulse/rework.md
@@ -70,6 +70,9 @@ Address every comment and gap. For each piece of feedback:
 
 - Fix it if you can
 - If you disagree with the feedback, fix it anyway and add a PR comment explaining your reasoning. Let the inspector decide on the next round. Don't argue — fix.
+- For deep-research, rework means revising the committed research docs to close the flagged gaps.
+- Typical research fixes include answering missed questions, tightening the writing, clarifying conclusions, or adding missing source links.
+- For feeling-lucky, rework may refine the inferred lane or bearing if QA surfaced a better interpretation.
 
 Do NOT skip any feedback item. If a comment is unclear, make your best interpretation and note what you assumed.
 

--- a/reef-pulse/seal.md
+++ b/reef-pulse/seal.md
@@ -83,6 +83,10 @@ For each success criterion in the plan:
 - Read the actual code on the `pr-branch` that satisfies it. Trace the full path — don't check module by module, check end-to-end.
 - Verify from the **consumer's perspective**. If the criterion says "the legacy UI must render identically", don't just check that the data is correct — check that it's in the format the legacy UI expects. (Prevents painpoint A4.)
 - Cross-reference the coverage matrix: which issues were supposed to cover this criterion? Did they actually cover it when composed together?
+- For deep-research, review the written research holistically against the end goal, not just the slice acceptance criteria.
+- Check whether the full research answer is coherent, complete enough for the promised question, and sensible as a whole.
+- For feeling-lucky, keep the normal mechanical quality bar but apply slightly softer strictness during holistic review.
+- Ask whether the outcome makes good sense for the exploratory ticket the human tossed into the reef.
 
 Mark each criterion: ✓ met, ✗ not met (with explanation).
 

--- a/tests/reef-review-bearings.test.sh
+++ b/tests/reef-review-bearings.test.sh
@@ -1,0 +1,100 @@
+#!/bin/sh
+# Behavioral tests for research and feeling-lucky review guidance.
+set -u
+
+TESTS_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$TESTS_DIR/.." && pwd)"
+INSPECT_FILE="$REPO_ROOT/reef-pulse/inspect.md"
+REWORK_FILE="$REPO_ROOT/reef-pulse/rework.md"
+SEAL_FILE="$REPO_ROOT/reef-pulse/seal.md"
+ORCHESTRATION_FILE="$REPO_ROOT/ORCHESTRATION.md"
+PASS=0
+FAIL=0
+TOTAL=0
+OUTPUT_BUF=""
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+pass() {
+  PASS=$((PASS + 1))
+  TOTAL=$((TOTAL + 1))
+  OUTPUT_BUF="${OUTPUT_BUF}$(printf "${GREEN}PASS${NC}: %s" "$1")
+"
+}
+
+fail() {
+  FAIL=$((FAIL + 1))
+  TOTAL=$((TOTAL + 1))
+  OUTPUT_BUF="${OUTPUT_BUF}$(printf "${RED}FAIL${NC}: %s" "$1")
+"
+  if [ $# -gt 1 ]; then
+    OUTPUT_BUF="${OUTPUT_BUF}$(printf "  %s" "$2")
+"
+  fi
+}
+
+assert_contains() {
+  file="$1"
+  pattern="$2"
+  label="$3"
+
+  if grep -qF "$pattern" "$file"; then
+    pass "$label"
+  else
+    fail "$label" "expected pattern: $pattern"
+  fi
+}
+
+test_inspect_handles_research_and_lucky_work() {
+  diagnostics="$(grep -nE 'research|deep-research|feeling-lucky|lucky|mechanical' "$INSPECT_FILE" || true)"
+  printf 'DIAGNOSTIC: inspect guidance currently contains:\n%s\n' "$diagnostics"
+
+  assert_contains "$INSPECT_FILE" 'For deep-research, inspect the committed research artifact mechanically rather than treating it like code.' "inspect treats research as committed research"
+  assert_contains "$INSPECT_FILE" 'Check that the writing is clear, coherent, not overly drawn out, and actually answers the promised angle or question.' "inspect checks research writing quality and relevance"
+  assert_contains "$INSPECT_FILE" 'If acceptance criteria are fuzzy because the issue was intentionally feeling-lucky, do not get fussy about their absence.' "inspect stays mechanically pragmatic for lucky work"
+  assert_contains "$INSPECT_FILE" 'Still review lucky work for clarity, simplicity, polish opportunities, and obvious quality problems.' "inspect preserves the normal mechanical bar for lucky work"
+}
+
+test_rework_handles_research_gaps_and_lucky_reframing() {
+  diagnostics="$(grep -nE 'research|deep-research|feeling-lucky|lucky|bearing|lane' "$REWORK_FILE" || true)"
+  printf 'DIAGNOSTIC: rework guidance currently contains:\n%s\n' "$diagnostics"
+
+  assert_contains "$REWORK_FILE" 'For deep-research, rework means revising the committed research docs to close the flagged gaps.' "rework treats research fixes as research-doc revisions"
+  assert_contains "$REWORK_FILE" 'Typical research fixes include answering missed questions, tightening the writing, clarifying conclusions, or adding missing source links.' "rework lists research-specific revision work"
+  assert_contains "$REWORK_FILE" 'For feeling-lucky, rework may refine the inferred lane or bearing if QA surfaced a better interpretation.' "rework allows lucky work to refine its inferred lane"
+}
+
+test_seal_handles_research_and_lucky_holistically() {
+  diagnostics="$(grep -nE 'research|deep-research|feeling-lucky|lucky|strict|holistic|end goal' "$SEAL_FILE" || true)"
+  printf 'DIAGNOSTIC: seal guidance currently contains:\n%s\n' "$diagnostics"
+
+  assert_contains "$SEAL_FILE" 'For deep-research, review the written research holistically against the end goal, not just the slice acceptance criteria.' "seal reviews research against the end goal"
+  assert_contains "$SEAL_FILE" 'Check whether the full research answer is coherent, complete enough for the promised question, and sensible as a whole.' "seal checks the research answer as a complete whole"
+  assert_contains "$SEAL_FILE" 'For feeling-lucky, keep the normal mechanical quality bar but apply slightly softer strictness during holistic review.' "seal softens holistic strictness for lucky-origin work"
+  assert_contains "$SEAL_FILE" 'Ask whether the outcome makes good sense for the exploratory ticket the human tossed into the reef.' "seal evaluates lucky work against the exploratory ticket"
+}
+
+test_orchestration_records_review_bearing_rules() {
+  assert_contains "$ORCHESTRATION_FILE" 'contains: `For deep-research, inspect the committed research artifact mechanically rather than treating it like code.`' "orchestration captures inspect research guidance"
+  assert_contains "$ORCHESTRATION_FILE" 'contains: `For feeling-lucky, rework may refine the inferred lane or bearing if QA surfaced a better interpretation.`' "orchestration captures rework lucky guidance"
+  assert_contains "$ORCHESTRATION_FILE" 'contains: `For deep-research, review the written research holistically against the end goal, not just the slice acceptance criteria.`' "orchestration captures seal research guidance"
+  assert_contains "$ORCHESTRATION_FILE" 'contains: `For feeling-lucky, keep the normal mechanical quality bar but apply slightly softer strictness during holistic review.`' "orchestration captures seal lucky guidance"
+}
+
+test_inspect_handles_research_and_lucky_work
+test_rework_handles_research_gaps_and_lucky_reframing
+test_seal_handles_research_and_lucky_holistically
+test_orchestration_records_review_bearing_rules
+
+echo ""
+if [ "$FAIL" -gt 0 ]; then
+  printf "%s" "$OUTPUT_BUF"
+  echo "================================"
+  printf "Results: %s passed, ${RED}%s failed${NC}, %s total\n" "$PASS" "$FAIL" "$TOTAL"
+  exit 1
+else
+  echo "================================"
+  printf "Results: %s passed, %s total\n" "$PASS" "$TOTAL"
+fi


### PR DESCRIPTION
closes #154 teach inspect, rework, and seal how to review research and lucky work

## Ambiguous choices

None — implementation followed the plan exactly.

## Test results

Full suite passed: 464 tests passed, 0 failed, 0 skipped.

<details><summary><h3>🧿 Inspect review — 2026/04/24 00:52</h3></summary>

## Verdict: PASS

All 5 acceptance criteria met. Full test suite green (283+17+15+20+18+89+22 = 464 tests passed, 0 failed).

### AC1 — to-inspect reviews research work mechanically as committed research ✓
`reef-pulse/inspect.md` step 2 now includes four new lines:
- "For deep-research, inspect the committed research artifact mechanically rather than treating it like code."
- "Check that the writing is clear, coherent, not overly drawn out, and actually answers the promised angle or question."
- "If acceptance criteria are fuzzy because the issue was intentionally feeling-lucky, do not get fussy about their absence."
- "Still review lucky work for clarity, simplicity, polish opportunities, and obvious quality problems."

All four lines are exactly what the AC describes. The guidance is placed inside step 2 ("Check each acceptance criterion"), the right mechanical checkpoint. Lucky work preserves the normal bar while relaxing strictness on criterion fuzziness.

### AC2 — to-rework treats research gaps as doc revisions and allows lucky work to refine its inferred lane ✓
`reef-pulse/rework.md` step 3 now includes:
- "For deep-research, rework means revising the committed research docs to close the flagged gaps."
- "Typical research fixes include answering missed questions, tightening the writing, clarifying conclusions, or adding missing source links."
- "For feeling-lucky, rework may refine the inferred lane or bearing if QA surfaced a better interpretation."

Matches AC precisely. Research rework is framed as document revision; lucky rework allows bearing refinement.

### AC3 — to-seal does holistic review with softer strictness for lucky-origin work ✓
`reef-pulse/seal.md` step 3 now includes:
- "For deep-research, review the written research holistically against the end goal, not just the slice acceptance criteria."
- "Check whether the full research answer is coherent, complete enough for the promised question, and sensible as a whole."
- "For feeling-lucky, keep the normal mechanical quality bar but apply slightly softer strictness during holistic review."
- "Ask whether the outcome makes good sense for the exploratory ticket the human tossed into the reef."

Normal mechanical quality bar preserved for lucky work; softer strictness applies only to holistic review. Correct scoping.

### AC4 — to-await-waves, to-merge, and to-land remain behaviorally unchanged ✓
`git diff origin/reef-scope-bearings..HEAD` shows zero changes to `reef-pulse/await-waves.md`, `reef-pulse/merge.md`, or `reef-land/`. Verified clean.

### AC5 — Tests cover adjusted inspect, rework, and seal behavior ✓
`tests/reef-review-bearings.test.sh` (new file, 100 lines) provides 15 tests covering:
- 4 tests for inspect research/lucky guidance
- 3 tests for rework research/lucky guidance
- 4 tests for seal research/lucky guidance
- 4 tests for ORCHESTRATION.md containing the key lines (machine-readable record)

All 15 pass. The ORCHESTRATION.md entries ensure automated consistency checks remain anchored.

### No cleanup needed
No debug prints, stale TODOs, dead code, or formatting issues found.

</details>