### PR TITLE
001 reef-land step 3: explicit ordered explore-first protocol

### DIFF
--- a/reef-land/SKILL.md
+++ b/reef-land/SKILL.md
@@ -140,16 +140,22 @@ Collect all feedback from:
 
 Then interview the human to refine the change requests into concrete, actionable gaps. The goal is alignment — you need to understand exactly what the human wants changed so the reef can act on it without further human input.
 
-For each concern or comment:
+For each concern or comment, follow this protocol in order before surfacing any question to the human:
+
+1. Read all files and lines referenced in the comment.
+2. Read related test files and codebase conventions relevant to the referenced area.
+3. Form a hypothesis about the intent — decide whether the intent is clear or genuinely ambiguous.
+4. Only surface a question to the human if the intent remains ambiguous after steps 1–3.
+5. When asking, lead with your recommended answer that demonstrates the investigation.
+
+Then for each comment:
 
 - Confirm you understand it correctly
-- Ask clarifying questions if the intent is ambiguous
+- Ask clarifying questions if the intent is ambiguous (after completing the protocol above)
 - Propose how it maps to work: is it a code change? A restructuring? A naming fix?
 - Check if it relates to an existing success criterion or needs a new one
 
 Ask questions one at a time. For each question, provide your recommended answer.
-
-If a question can be answered by exploring the codebase, explore the codebase instead of asking.
 
 ### Trivial vs substantial changes
 


### PR DESCRIPTION
closes #163 001 reef-land step 3: explicit ordered explore-first protocol

## Ambiguous choices

None — implementation followed the plan exactly.

## Test results

314 tests passed, 52 failed (pre-existing), 366 total. No regressions introduced.

<details><summary><h3>🧿 Inspect review — 2026/04/24 16:30</h3></summary>

## Acceptance criteria

**AC1** — Step 3 contains an explicit numbered per-comment protocol with all 5 actions: PASS. Lines 143–149 introduce a clearly numbered 5-step protocol covering read → read conventions → form hypothesis → ask only if ambiguous → lead with recommended answer.

**AC2** — Passive fallback line removed: PASS. `"If a question can be answered by exploring the codebase, explore the codebase instead of asking."` is gone entirely.

**AC3** — Protocol appears before Trivial vs substantial changes: PASS. The numbered protocol block (lines 143–149) precedes the Trivial vs substantial section.

**AC4** — Character of step 3 preserved: PASS. Interview flow, trivial/substantial split, gap report format, and label update logic are unchanged.

## Test suite

314 passed, 52 failed (pre-existing — confirmed identical count on base branch before this PR). No regressions introduced.

## Cleanups

None needed.

## Verdict

All acceptance criteria met. No regressions. Clean implementation.

</details>