### PR TITLE
002 scope-feature.md interview: explore-first as lead instruction

### DIFF
--- a/reef-scope/scope-feature.md
+++ b/reef-scope/scope-feature.md
@@ -10,11 +10,11 @@ ISSUE_ID="{from context}" # e.g. "#42"
 
 RUN ONLY IF the issue does not have decisions captured yet.
 
-Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+Before asking anything, explore the codebase and answer every question you can from the code. Only bring questions to the diver that genuinely cannot be resolved by reading the repo.
+
+Then interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
 
 Ask the questions one at a time.
-
-If a question can be answered by exploring the codebase, explore the codebase instead.
 
 ## 2. Explore the repo
 


### PR DESCRIPTION
closes #166 002 scope-feature.md interview: explore-first as lead instruction

## Ambiguous choices

None — implementation followed the plan exactly.

## Test results

314 passed, 52 failed, 366 total.

The 52 failures are pre-existing baseline failures unrelated to scope-feature.md (they cover orchestration contract checks for reef-pulse and reef-land phase files). No new failures were introduced.

<details><summary><h3>🧿 Inspect review — 2026/04/24 16:30</h3></summary>

## Verdict: to-merge

All 4 acceptance criteria pass. No gaps found.

### Acceptance criteria

**AC1** — Interview section opens with explicit explore-first instruction: PASS. The section now leads with "Before asking anything, explore the codebase and answer every question you can from the code. Only bring questions to the diver that genuinely cannot be resolved by reading the repo."

**AC2** — Relentless-interview directive still present and not softened: PASS. Identical wording retained: "Then interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer."

**AC3** — Conditional fallback removed or rewritten as leading directive: PASS. The old "If a question can be answered by exploring the codebase, explore the codebase instead." fallback is gone. It is rewritten as the leading directive at the top of the section.

**AC4** — Overall interview flow preserved (explore first, then interview relentlessly): PASS. Flow is exactly: (1) explore codebase and resolve what you can, (2) interview relentlessly on genuinely unknown intent.

### Test suite

314 passed, 52 failed — identical to base branch. The 52 failures are pre-existing and unrelated to this change. No new failures introduced.

### Trivial cleanups

None needed. File is clean.

### Ambiguous choices

None surfaced by the implementer. Implementation is a straightforward reordering + reframing as described.

</details>