### PR TITLE
002 research.md §4: add reader-context note before PR body template

### DIFF
--- a/reef-pulse/research.md
+++ b/reef-pulse/research.md
@@ -110,6 +110,8 @@ Commit your work when the research artifacts are complete.
 
 When research is complete, compose the PR description using this template:
 
+The inspector is a different agent session — no context from this conversation carries over. Be explicit and self-contained.
+
 ```markdown
 ## Ambiguous choices
 


### PR DESCRIPTION
closes #165 002 research.md §4: add reader-context note before PR body template

## Ambiguous choices

None — implementation followed the plan exactly.

## Test results

314 passed, 52 failed, 366 total. The 52 failures are pre-existing and unrelated to this change (same count before and after the edit). The change adds a single sentence before the PR body template in §4 of `reef-pulse/research.md` and does not affect any tested patterns in ORCHESTRATION.md.

<details><summary><h3>🧿 Inspect review — 2026/04/24 16:30</h3></summary>

**Verdict: PASS — all acceptance criteria met, suite result unchanged.**

## Acceptance criteria check

1. Note appears immediately before the PR body template block in §4 — PASS. Note is on the line immediately above the ` ```markdown ` fence.
2. Note names the inspector as the reader — PASS. "The inspector is a different agent session".
3. Note states the reader has no context from the writing session — PASS. "no context from this conversation carries over. Be explicit and self-contained."
4. Wording matches the canonical wording from issue #164 — PASS. Exact match.
5. No other changes to the file — PASS. Diff shows only two lines added.

## Test suite

314 passed, 52 failed — identical to base branch. No new failures introduced.

## Trivial cleanups

None needed.

</details>