### PR TITLE
004 rework.md §7: add reader-context note before rework report template

### DIFF
--- a/reef-pulse/rework.md
+++ b/reef-pulse/rework.md
@@ -119,6 +119,8 @@ Document judgment calls made during this phase on the PR. Only document decision
 
 Read the current PR body, then append the rework report as a collapsible block. The rework report should include judgment calls, what feedback was addressed, what was changed, and test results.
 
+The inspector is a different agent session — no context from this conversation carries over. Be explicit and self-contained.
+
 ```sh
 PR_BODY=$(./tracker.sh pr view "$PR_ID" --json body -q .body)
 REPORT="{rework-report}" # <details><summary><h3>🦀 Rework — {yyyy/MM/dd HH:mm}</h3></summary>{report-content}</details>


### PR DESCRIPTION
closes #168 004 rework.md §7: add reader-context note before rework report template

## Ambiguous choices

None — implementation followed the plan exactly.

## Test results

314 passed, 52 failed, 366 total. The 52 failures are pre-existing on the `phase-handoff-context-notes` branch (baseline confirmed before any changes). No regressions introduced: rework.md tests show identical pass/fail pattern to baseline.

<details><summary><h3>🧿 Inspect review — 2026/04/24 16:30</h3></summary>

## Verdict: PASS — all acceptance criteria met

### Criterion 1: Note appears immediately before the REPORT= block in §7
PASS. The note was inserted at line 122, immediately before the shell block containing `PR_BODY=` and `REPORT=`. Standard markdown blank line between paragraph and fenced code block is correct placement.

### Criterion 2: Note names the inspect agent (or inspector) as the reader
PASS. "The inspector is a different agent session" — inspector named explicitly.

### Criterion 3: Note states explicitly that the reader has no context from the writing session
PASS. "no context from this conversation carries over" — explicit and direct.

### Criterion 4: Wording mirrors the style in reef-land/SKILL.md step 3
PASS. reef-land/SKILL.md uses: "Rework has no context from this conversation — be explicit and self-contained." The new note uses the same em-dash structure, same key phrase "no context from this conversation", and same closing "Be explicit and self-contained." Style is consistent.

### Criterion 5: No other changes to the file
PASS. Diff shows exactly 2 lines added (the note and a trailing blank line). No other modifications.

### Test suite
314 passed, 52 failed — identical to baseline on `phase-handoff-context-notes`. No regressions.

### Trivial cleanups
None required.

### Ambiguous choices review
PR documents "None — implementation followed the plan exactly." Confirmed by reading the diff. No drift from plan.

</details>