### PR TITLE
003 inspect.md §6: add reader-context note before inspect report template

### DIFF
--- a/reef-pulse/inspect.md
+++ b/reef-pulse/inspect.md
@@ -156,6 +156,8 @@ Report these variables to the caller and **do not continue**.
 
 Read the current PR body, then append the inspect report as a collapsible block:
 
+The rework agent is a different agent session — no context from this conversation carries over. Be explicit and self-contained.
+
 ```sh
 PR_ID="{from issue frontmatter pr-id field, or - if not present}" # e.g. "#42"
 PR_BODY=$(./tracker.sh pr view "$PR_ID" --json body -q .body)


### PR DESCRIPTION
closes #167 003 inspect.md §6: add reader-context note before inspect report template

## Ambiguous choices

None — implementation followed the plan exactly.

## Test results

314 tests passed, 52 failed, 366 total. The 52 failures are pre-existing across multiple files and unrelated to this change. No new failures were introduced.

<details><summary><h3>🧿 Inspect review — 2026/04/24 16:20</h3></summary>

**Verdict: all acceptance criteria met. No gaps.**

**Test suite:** 314 passed, 52 failed — same as base branch. No new failures introduced by this PR.

**Acceptance criteria:**

1. ✅ Note appears immediately before the `REPORT=` shell block in §6 (`reef-pulse/inspect.md` line 159)
2. ✅ Note names "the rework agent" as the reader
3. ✅ Note states "no context from this conversation carries over"
4. ✅ Wording mirrors `reef-land/SKILL.md` step 3 style (em-dash structure, identical "no context from this conversation", "Be explicit and self-contained.")
5. ✅ No other changes to the file — diff is exactly 2 lines added

**Ambiguous choices:** None. No drift from plan.

</details>