### PR TITLE
005 seal.md §8: add reader-context note before seal report template

### DIFF
--- a/reef-pulse/seal.md
+++ b/reef-pulse/seal.md
@@ -180,6 +180,8 @@ The report goes on a **PR from the `pr-branch` to the `base-branch`** (usually `
 
 The report should be concise and focused on what the human needs to know. Do NOT dump the entire plan — the human can read the plan. Focus on:
 
+The reef-land reviewer is a different agent session — no context from this conversation carries over. Be explicit and self-contained.
+
 ```markdown
 ## Final Report
 


### PR DESCRIPTION
closes #169 005 seal.md §8: add reader-context note before seal report template

## Ambiguous choices

None — implementation followed the plan exactly.

## Test results

314 passed, 52 failed, 366 total. The 52 failures are pre-existing baseline failures unrelated to this change (same count before and after the edit). No regressions introduced.

<details><summary><h3>🧿 Inspect review — 2026/04/24</h3></summary>

### Verdict: PASS

All 5 acceptance criteria verified. No gaps found. Test suite: 314 passed, 52 failed (52 failures are pre-existing baseline; no regressions introduced by this change).

**AC1 — Note appears immediately before `## Final Report` block in §8:** Confirmed. The note lands at line 183 of `seal.md`, immediately before the fenced markdown block containing `## Final Report`.

**AC2 — Note names reef-land reviewer as the reader:** Confirmed. Text explicitly reads "The reef-land reviewer is a different agent session".

**AC3 — Note states reader has no context from the writing session:** Confirmed. "no context from this conversation carries over" is present.

**AC4 — Wording mirrors reef-land/SKILL.md step 3 style:** Confirmed. reef-land SKILL.md §3 reads "Rework has no context from this conversation — be explicit and self-contained." The new note uses the same "no context from this conversation carries over — be explicit and self-contained" construction, matching tone and structure.

**AC5 — No other changes to the file:** Confirmed. Git diff shows exactly 2 lines added in `reef-pulse/seal.md` only (the note + a blank line separator before the code block).

No ambiguous choices to flag. No cleanup needed.

</details>