### PR TITLE
reef-land scoping session: agent asks too many questions instead of reading code first

### DIFF
--- a/reef-land/SKILL.md
+++ b/reef-land/SKILL.md
@@ -140,22 +140,18 @@ Collect all feedback from:
 
 Then interview the human to refine the change requests into concrete, actionable gaps. The goal is alignment — you need to understand exactly what the human wants changed so the reef can act on it without further human input.
 
-For each concern or comment, follow this protocol in order before surfacing any question to the human:
+For each concern or comment:
 
 1. Read all files and lines referenced in the comment.
 2. Read related test files and codebase conventions relevant to the referenced area.
 3. Form a hypothesis about the intent — decide whether the intent is clear or genuinely ambiguous.
 4. Only surface a question to the human if the intent remains ambiguous after steps 1–3.
 5. When asking, lead with your recommended answer that demonstrates the investigation.
+6. Confirm your understanding of what change is needed.
+7. Propose how it maps to work: code change? Restructuring? Naming fix?
+8. Check whether it relates to an existing success criterion or needs a new one.
 
-Then for each comment:
-
-- Confirm you understand it correctly
-- Ask clarifying questions if the intent is ambiguous (after completing the protocol above)
-- Propose how it maps to work: is it a code change? A restructuring? A naming fix?
-- Check if it relates to an existing success criterion or needs a new one
-
-Ask questions one at a time. For each question, provide your recommended answer.
+Ask questions one at a time.
 
 ### Trivial vs substantial changes
 

--- a/reef-land/SKILL.md
+++ b/reef-land/SKILL.md
@@ -140,16 +140,22 @@ Collect all feedback from:
 
 Then interview the human to refine the change requests into concrete, actionable gaps. The goal is alignment — you need to understand exactly what the human wants changed so the reef can act on it without further human input.
 
-For each concern or comment:
+For each concern or comment, follow this protocol in order before surfacing any question to the human:
+
+1. Read all files and lines referenced in the comment.
+2. Read related test files and codebase conventions relevant to the referenced area.
+3. Form a hypothesis about the intent — decide whether the intent is clear or genuinely ambiguous.
+4. Only surface a question to the human if the intent remains ambiguous after steps 1–3.
+5. When asking, lead with your recommended answer that demonstrates the investigation.
+
+Then for each comment:
 
 - Confirm you understand it correctly
-- Ask clarifying questions if the intent is ambiguous
+- Ask clarifying questions if the intent is ambiguous (after completing the protocol above)
 - Propose how it maps to work: is it a code change? A restructuring? A naming fix?
 - Check if it relates to an existing success criterion or needs a new one
 
 Ask questions one at a time. For each question, provide your recommended answer.
-
-If a question can be answered by exploring the codebase, explore the codebase instead of asking.
 
 ### Trivial vs substantial changes
 

--- a/reef-scope/scope-feature.md
+++ b/reef-scope/scope-feature.md
@@ -10,7 +10,7 @@ ISSUE_ID="{from context}" # e.g. "#42"
 
 RUN ONLY IF the issue does not have decisions captured yet.
 
-Before asking anything, explore the codebase and answer every question you can from the code. Only bring questions to the diver that genuinely cannot be resolved by reading the repo.
+Before and during the interview, explore the codebase and read related code. If a question can be answered by exploring the codebase, explore the codebase instead.
 
 Then interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
 

--- a/reef-scope/scope-feature.md
+++ b/reef-scope/scope-feature.md
@@ -10,11 +10,11 @@ ISSUE_ID="{from context}" # e.g. "#42"
 
 RUN ONLY IF the issue does not have decisions captured yet.
 
-Interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
+Before asking anything, explore the codebase and answer every question you can from the code. Only bring questions to the diver that genuinely cannot be resolved by reading the repo.
+
+Then interview me relentlessly about every aspect of this plan until we reach a shared understanding. Walk down each branch of the design tree, resolving dependencies between decisions one-by-one. For each question, provide your recommended answer.
 
 Ask the questions one at a time.
-
-If a question can be answered by exploring the codebase, explore the codebase instead.
 
 ## 2. Explore the repo
 


### PR DESCRIPTION
closes #51 reef-land scoping session: agent asks too many questions instead of reading code first

<details><summary><h3>🦭 Seal report — 2026/04/24 16:22</h3></summary>

## Final Report

### Status: PASS

### Success criteria

- ✓ SC1: reef-land step 3 contains an explicit ordered per-comment protocol (read files, read conventions, form hypothesis, only ask if ambiguous, provide recommended answer when asking) — verified: SKILL.md lines 143–149 contain a numbered 5-step protocol covering all five required actions, placed before the "Trivial vs substantial changes" section
- ✓ SC2: The passive "If a question can be answered by exploring the codebase, explore the codebase instead" in reef-land step 3 is removed or subordinated — verified: line is absent from the diff; removed entirely and replaced by the explicit ordered protocol
- ✓ SC3: scope-feature.md interview section starts with "explore answerable questions first" before the relentless-interview directive — verified: scope-feature.md line 13 is the new leading instruction ("Before asking anything, explore the codebase…"), line 15 is the relentless-interview directive
- ✓ SC4: reef-scope retains the relentless interview character (not softened, just explore-first) — verified: "interview me relentlessly about every aspect" is present verbatim and unchanged

### Integration notes

The two slices used slightly different vocabulary — reef-land uses "Read" (concrete numbered steps) while scope-feature.md uses "explore the codebase" (higher-level guidance). This is appropriate: reef-land's protocol is an operational loop applied comment-by-comment, while scope-feature.md sets intent for an interactive interview session. The principle is consistent and the difference in phrasing is justified by context.

### Test results

Full suite: 314 passed, 52 failed, 366 total. The 52 failures are pre-existing on main (identical count confirmed) — none introduced by this PR.

</details>

### 🪼 Pulse metrics

| Phase | Target | Duration | Tokens | Tool uses | Outcome | Date |
| ----- | ------ | -------- | ------ | --------- | ------- | ---- |
| scope | #51    | 3m 45s   | —      | —         | plan created | 2026-04-24 00:04 |
| slice | #51    | —        | —      | —         | 2 slices     | 2026-04-24       |
| slice | #51 | 2m17s | 29915 | 21 | Slices created with acceptance criteria, dependency graph, and coverage matrix | 2026-04-24 16:05 |
| seal | #51 | 2m31s | 34874 | 28 | Seal PASS — all 4 success criteria met; explore-first protocol in reef-land step 3 and scope-feature.md | 2026-04-24 16:24 |
| **Total** | | **8m33s** | **64789** | **49** | | |
<!-- end metrics table -->