### PR TITLE
004 slice layer: read done-looks-like, remove AC rename step, rework coverage matrix

### DIFF
--- a/reef-pulse/slice-one-issue.md
+++ b/reef-pulse/slice-one-issue.md
@@ -20,14 +20,14 @@ No sub-issues are needed — the plan becomes the slice. Skip sub-issues, covera
 Starting from `$ISSUE_BODY_UPDATED`:
 
 1. **No sub-issues.** The plan IS the slice.
-2. **Rename `## Success criteria` to `## Success & Acceptance criteria`.** Append the acceptance criteria you drafted for the single slice to that section. Shape them to the lane: for deep-research, criteria must describe what must be answered, clarified, or persisted rather than implementation tasks.
+2. **Append acceptance criteria.** Append the acceptance criteria you drafted for the single slice to the `## What does done look like` section. Shape them to the lane: for deep-research, criteria must describe what must be answered, clarified, or persisted rather than implementation tasks.
 3. **Route research slices into the research phase.** For deep-research, label the issue to-research instead of to-implement.
-4. **No coverage matrix.** Success criteria and acceptance criteria are 1:1 — the mapping adds no information.
+4. **No coverage matrix.** The items in `## What does done look like` and acceptance criteria are 1:1 — the mapping adds no information.
 
 Assemble the updated plan issue body:
 
 ```sh
-ISSUE_BODY="{$ISSUE_BODY_UPDATED with updated Success & Acceptance criteria}"
+ISSUE_BODY="{plan issue body with scoped pr-branch, rewritten bearing, and updated Success & Acceptance criteria}"
 ```
 
 ## 2. Label the next phase

--- a/reef-pulse/slice-subissues.md
+++ b/reef-pulse/slice-subissues.md
@@ -6,9 +6,9 @@ Multi-slice flow — delegated from [slice.md](slice.md).
 
 ```sh
 ISSUE_ID="{from context}"           # e.g. "#42"
-PR_BRANCH="{from context}"          # e.g. "feat/my-feature"
-BASE_BRANCH="{from context}"        # e.g. "main"
-BEARING="{from context}"            # e.g. "feature" — already resolved, never "feeling-lucky"
+PR_BRANCH="{from plan issue body pr-branch field}"
+BASE_BRANCH="{from plan issue body}"
+BEARING="{from plan issue body bearing field}"
 FEELING_LUCKY="{from context}"      # e.g. "true"
 ISSUE_BODY_UPDATED="{from context}" # plan body with frontmatter already cleaned up
 WORKTREE_PATH=".worktrees/$ISSUE_ID-slice"
@@ -49,19 +49,19 @@ If the plan says to work on the current branch (no new `pr-branch`), skip the br
 
 ## 2. Build the coverage matrix
 
-For each success criterion in the plan, map it to which slice(s) and which acceptance criterion/criteria cover it.
+For each item in `## What does done look like`, map it to which slice(s) and which acceptance criterion/criteria cover it. The agent infers the correct enumerable source from the prose in `## What does done look like` (user stories for features, commits for refactors, research questions for deep-research).
 
 ```markdown
 ## Coverage Matrix
 
-| Success Criterion                    | Slice                                | Acceptance Criteria                                           |
+| Done-looks-like item                 | Slice                                | Acceptance Criteria                                           |
 | ------------------------------------ | ------------------------------------ | ------------------------------------------------------------- |
-| SC1: Users can log in with email     | 001 Auth endpoint                    | AC1: POST /login returns token, AC2: invalid creds return 401 |
-| SC2: Session persists across refresh | 002 Token storage                    | AC1: token stored in httpOnly cookie                          |
-| SC3: Legacy UI renders identically   | 001 Auth endpoint, 003 Legacy compat | AC3: response format matches legacy schema                    |
+| Users can log in with email          | 001 Auth endpoint                    | AC1: POST /login returns token, AC2: invalid creds return 401 |
+| Session persists across refresh      | 002 Token storage                    | AC1: token stored in httpOnly cookie                          |
+| Legacy UI renders identically        | 001 Auth endpoint, 003 Legacy compat | AC3: response format matches legacy schema                    |
 ```
 
-**Verify completeness**: every success criterion must appear in at least one row. If any criterion is uncovered, either add it to an existing slice's acceptance criteria or create a new slice. Do not proceed with gaps. (Prevents painpoint A3.)
+**Verify completeness**: every item from `## What does done look like` must appear in at least one row. If any item is uncovered, either add it to an existing slice's acceptance criteria or create a new slice. Do not proceed with gaps. (Prevents painpoint A3.)
 
 ## 3. Verify the breakdown
 
@@ -69,7 +69,7 @@ Verify internally:
 
 - Is the granularity reasonable? (prefer many thin slices over few thick ones)
 - Are the dependency relationships correct? Are there implicit deps not captured?
-- Does every success criterion appear in the coverage matrix?
+- Does every item from `## What does done look like` appear in the coverage matrix?
 
 If anything looks off, adjust the breakdown. Do not ask the user — reef-scope already iterated with the user on the plan. Your job is to slice it mechanically.
 
@@ -87,20 +87,15 @@ if [ "{slice has no blockers}" = "true" ]; then
   SLICE_TITLE="{slice-title}" # e.g. "002 Token storage"
 else
   UNBLOCKED=false
-  SLICE_TITLE="{slice-title} [await: #{blocker-id}]" # e.g. "002 Token storage [await: #43]"
+  SLICE_TITLE="{slice-title} [await: #{blocker-id}]"  # omit [await: ...] if unblocked
 fi
 ```
 
 ```sh
-SLICE_BEARING="{per-slice bearing, usually $BEARING unless a slice needs a narrower inferred lane}" # e.g. "implement"
-if [ "$UNBLOCKED" = "true" ] && [ "$SLICE_BEARING" = "deep-research" ]; then
-  SLICE_LABEL="to-research"
-elif [ "$UNBLOCKED" = "true" ]; then
-  SLICE_LABEL="to-implement"
-else
-  SLICE_LABEL="to-await-waves"
-fi
-SLICE_PR_BRANCH="{derived from plan issue pr-branch + slice title slug}" # e.g. "feat/my-feature-002-token-storage"
+SLICE_PR_BRANCH="{derived from plan issue pr-branch + slice title slug}"
+SLICE_BEARING="{per-slice bearing, usually $BEARING unless a slice needs a narrower inferred lane}"
+SLICE_BODY="{slice-body}" # as per the template below, with pr-branch: $SLICE_PR_BRANCH and bearing: $SLICE_BEARING
+SLICE_LABEL="{to-research for unblocked deep-research slices, otherwise to-implement; or to-await-waves if blocked}"
 ```
 
 If `"$FEELING_LUCKY" = "true"`, use best-effort acceptance criteria without bouncing the work back to scope. For deep-research slices, make them research-native: use research questions or investigation angles as the slice descriptions, and write acceptance criteria around what must be answered, clarified, or persisted.
@@ -125,16 +120,11 @@ bearing: $SLICE_BEARING
 - [ ] {criterion 1}
 - [ ] {criterion 2}
 - [ ] {criterion 3}
-
-## Success criteria covered
-
-- Success criterion {n}: {criterion text}
 ```
 
 Create the slice:
 
 ```sh
-SLICE_BODY="{slice-body as per the template below, with pr-branch: $SLICE_PR_BRANCH and bearing: $SLICE_BEARING}"
 ./tracker.sh issue create --title "$SLICE_TITLE" --body "$SLICE_BODY" --label "$SLICE_LABEL"
 ```
 
@@ -143,8 +133,8 @@ SLICE_BODY="{slice-body as per the template below, with pr-branch: $SLICE_PR_BRA
 Starting from `$ISSUE_BODY_UPDATED`, append the coverage matrix and a listing of all created sub-issues with their labels. Change label from `to-slice` to `in-progress`.
 
 ```sh
-PARENT_ISSUE_BODY_UPDATED="{$ISSUE_BODY_UPDATED with pr-branch in frontmatter and coverage matrix appended}"
-./tracker.sh issue edit "$ISSUE_ID" --body "$PARENT_ISSUE_BODY_UPDATED" --remove-label to-slice --add-label in-progress
+ISSUE_BODY="{plan issue body with pr-branch in frontmatter and coverage matrix appended}"
+./tracker.sh issue edit "$ISSUE_ID" --body "$ISSUE_BODY" --remove-label to-slice --add-label in-progress
 ```
 
 ## 6. Document judgment calls

--- a/reef-pulse/slice.md
+++ b/reef-pulse/slice.md
@@ -19,7 +19,7 @@ This skill accepts:
 Set the input as a shell variable:
 
 ```sh
-ISSUE_ID="{issue-id or -}" # e.g. "#42"
+ISSUE_ID="{issue-id}" # pre-existing and passed, e.g. #42
 ```
 
 ## Rules
@@ -53,7 +53,7 @@ SUMMARY="Skipped: issue does not carry the to-slice label."
 
 Report these variables to the caller and **do not continue**.
 
-Read the issue. It must contain a plan with success criteria (from reef-scope). Success criteria are plan-level; this skill breaks them into **acceptance criteria** per slice. The frontmatter block tells you the work type, `base-branch`, and `pr-branch`.
+Read the issue. It must contain a plan with `## What does done look like` (from reef-scope). The frontmatter block tells you the work type, `base-branch`, and `pr-branch`.
 
 ```sh
 BASE_BRANCH="{from issue frontmatter base-branch field, or - if not present}" # e.g. "main"
@@ -130,7 +130,7 @@ Rules:
 - If `"$BEARING" = "deep-research"`, draft research questions rather than implementation work. Compact research plans can stay as a single research issue. Larger research plans can be split into angle-based or dependency-based research slices. Acceptance criteria should say what must be answered, clarified, or persisted.
 - If `"$FEELING_LUCKY" = "true"`, produce acceptance criteria and dependencies with best-effort judgment without asking the user follow-up questions.
 
-For small bugs (scope = quick fix in the plan): produce a single slice. The plan's success criteria become the slice's acceptance criteria directly.
+For small bugs (scope = quick fix in the plan): produce a single slice. The items in `## What does done look like` become the slice's acceptance criteria directly.
 
 ## 2. Delegate
 


### PR DESCRIPTION
closes #182 004 slice layer: read done-looks-like, remove AC rename step, rework coverage matrix

## Ambiguous choices

None — implementation followed the plan exactly.

## Test results

325 passed, 41 failed, 366 total. The 41 failures are pre-existing baseline failures in unrelated files (SKILL.md files, pulse-loop.md, implement.md, research.md, inspect.md, rework.md, await-waves.md, merge.md, merge-has-parent.md, merge-no-parent.md, seal.md). All 11 slice-specific test failures were resolved by this implementation.