### PR TITLE
002 interview enhancements: testing step, interview log, bug rigor, direct labeling

### DIFF
--- a/reef-scope/scope-deep-research.md
+++ b/reef-scope/scope-deep-research.md
@@ -26,6 +26,26 @@ Figure out the core question, what uncertainty needs to be reduced, and what wou
 
 Plan for a durable Markdown deliverable in the repo. If external research will be needed, plan to keep lightweight `Sources:` links near the related findings.
 
-## 4. Write the plan
+## 4. Nail down completion criteria
+
+Ask the user (one at a time, skip any already answered):
+
+- What must be answered or documented for this research to be complete?
+- What open questions, if left unanswered, would make this research feel incomplete?
+- Who will act on the findings, and what do they need from this research to move forward?
+
+Fold the answers into the Testing Decisions section of the plan. Do not create a separate section.
+
+## 5. Write the plan
 
 Write the scoped issue so the success criteria describe what must be answered, clarified, or persisted, not what code must be written.
+
+After writing the plan, append the full Q&A transcript from the interview:
+
+```
+<details><summary>Interview log</summary>
+
+{full Q&A transcript}
+
+</details>
+```

--- a/reef-scope/scope-feature.md
+++ b/reef-scope/scope-feature.md
@@ -28,7 +28,17 @@ A deep module (as opposed to a shallow module) is one which encapsulates a lot o
 
 Check with the user that these modules match their expectations. Check with the user which modules they want tests written for.
 
-## 4. Write the plan
+## 4. Nail down testing expectations
+
+Ask the user these questions (one at a time, skip any already answered):
+
+- What kind of testing do you expect for this feature?
+- Should each user story have an automated test?
+- Is there anything you'd need to see to feel confident this is ready to merge?
+
+Fold the answers into the Testing Decisions section of the plan. Do not create a separate section.
+
+## 5. Write the plan
 
 Write the plan using this template:
 
@@ -85,3 +95,13 @@ Testable conditions that must ALL be true for this work to be considered done. E
 A description of the things that are out of scope for this feature.
 
 </plan-template>
+
+After writing the plan, append the full Q&A transcript from the interview:
+
+```
+<details><summary>Interview log</summary>
+
+{full Q&A transcript}
+
+</details>
+```

--- a/reef-scope/scope-refactor.md
+++ b/reef-scope/scope-refactor.md
@@ -22,9 +22,16 @@ Interview the user about the implementation. Be extremely detailed and thorough.
 
 Hammer out the exact scope of the implementation. Work out what you plan to change and what you plan NOT to change.
 
-## 6. Assess test coverage
+## 6. Assess test coverage and nail down testing expectations
 
-Look in the codebase to check for test coverage of this area. If there is insufficient test coverage, ask the user what their plans for testing are.
+Look in the codebase to check for test coverage of this area.
+
+Then ask the user these questions (one at a time, skip any already answered):
+
+- What kind of testing do you expect for this refactor?
+- Is there anything you'd need to see to feel confident this is ready to merge?
+
+Fold the answers into the Testing Decisions section of the plan. Do not create a separate section.
 
 ## 7. Design the commit plan
 
@@ -88,3 +95,15 @@ Testable conditions that must ALL be true for this work to be considered done. E
 A description of the things that are out of scope for this refactor.
 
 </plan-template>
+
+After writing the plan, append the full Q&A transcript from the interview:
+
+```
+<details><summary>Interview log</summary>
+
+{full Q&A transcript}
+
+</details>
+```
+
+When persisting the plan in SKILL.md step 6, use `to-implement` instead of `to-slice`. A refactor is a single branch, single PR — slicing adds overhead with no benefit.

--- a/reef-scope/triage-issue.md
+++ b/reef-scope/triage-issue.md
@@ -52,7 +52,26 @@ Create a concrete, ordered list of RED-GREEN cycles. Each cycle is one vertical 
 - Include a final refactor step if needed
 - **Durability**: Only suggest fixes that would survive radical codebase changes. Describe behaviors and contracts, not internal structure. Tests assert on observable outcomes (API responses, UI state, user-visible effects), not internal state. A good suggestion reads like a spec; a bad one reads like a diff.
 
-## 5. Write the plan
+## 5. What does done look like?
+
+Present these four options to the user. Recommend one based on your investigation findings:
+
+1. **Theoretical fix** — fix identified and documented in the plan; no code or tests required
+2. **Compile-verified** — fix applied and confirmed to compile/run without errors
+3. **TDD** — failing test written first, then fix applied; all tests pass
+4. **Dive in together** — interactive debugging session; not suitable for AFK Reef flow
+
+**How to recommend**: if you found a clear root cause with a known fix, recommend option 2 or 3. If the root cause is unclear or the fix requires exploration, recommend option 4. If the issue is well-understood but low-risk, option 1 may suffice.
+
+If the user picks option 4, do not label the issue `to-implement`. Close out by explaining that this issue needs a live session and won't enter the Reef queue.
+
+For options 1–3, the chosen option drives the `## Acceptance Criteria` checklist in the plan:
+
+- **Option 1**: `- [ ] Fix applied to the identified code path`
+- **Option 2**: `- [ ] Fix compiles and runs without errors`
+- **Option 3**: `- [ ] Failing test written first` and `- [ ] All tests pass after fix`
+
+## 6. Write the plan
 
 Write the plan using this template:
 
@@ -88,11 +107,12 @@ A numbered list of RED-GREEN cycles:
 
 **REFACTOR**: [Any cleanup needed after all tests pass]
 
-## Success Criteria
+## Acceptance Criteria
 
-- [ ] {criterion 1}
-- [ ] {criterion 2}
+- [ ] {criterion driven by the chosen rigor option from step 5}
 - [ ] All new tests pass
 - [ ] Existing tests still pass
 
 </plan-template>
+
+When persisting the plan in SKILL.md step 6 (for options 1–3), use `to-implement` instead of `to-slice`. A bug fix is a single branch, single PR — slicing adds overhead with no benefit.


### PR DESCRIPTION
closes #190

## Summary

Four coordinated changes to the scope/triage skill files:

1. **Late-interview testing step**: added a mandatory question at the end of the interview phase in `scope-feature.md`, `scope-refactor.md`, and `scope-deep-research.md` asking about testing expectations, integration criteria, and what "done" looks like. Answers fold into the existing Testing Decisions section.

2. **Interview log block**: after writing the plan in `scope-feature.md`, `scope-refactor.md`, and `scope-deep-research.md`, appends a `<details><summary>Interview log</summary>…</details>` block containing the full Q&A transcript.

3. **Bug rigor question in `triage-issue.md`**: at the end of triage, presents a "what does done look like?" step with four options (theoretical fix / compile-verified / TDD / dive in together), recommends one based on findings. Option 4 exits the Reef flow. Chosen option drives the `## Acceptance Criteria` checklist.

4. **Direct labeling for refactor and bug**: `scope-refactor.md` labels the plan issue `to-implement` (not `to-slice`). `triage-issue.md` labels the plan issue `to-implement` (not `to-slice`).