### PR TITLE
003 pipeline plumbing: slice guard, coverage matrix anchor, inspect/s…

### DIFF
--- a/ORCHESTRATION.md
+++ b/ORCHESTRATION.md
@@ -31,7 +31,7 @@ General rules:
 - set-variables
   ```sh
   SKILL_DIR="{base directory for this skill}"
-  TRACKER_BRANCH="{from config.md}" # e.g. main
+  TRACKER_BRANCH="{from config.md}" # e.g. "main"
   LOCK_FILE=".agents/moonjelly-reef/pulse.lock"
   ```
 - checkout-tracker-branch — if local-tracker-committed
@@ -53,15 +53,15 @@ General rules:
 
 - set-variables
   ```sh
-  START_TIME="{current UTC timestamp}"
-  ```
-- set-variables
-  ```sh
-  ISSUE_ID="{issue-id}" # pre-existing and passed or generate, eg.: #42
+  ISSUE_ID="{issue-id or -}" # e.g. "#42"; "-" if nothing provided
   ```
 - fetch-context
   ```sh
   ./tracker.sh issue view "$ISSUE_ID" --json body,title,labels
+  ```
+- set-variables
+  ```sh
+  START_TIME="{current UTC timestamp}"
   ```
 - phase-specific
 - set-variables
@@ -81,21 +81,21 @@ General rules:
   ```
 - update-tracker
   ```sh
-  ISSUE_BODY="{plan-content}" # frontmatter + plan issue body from context
+  ISSUE_BODY="{frontmatter + plan content}"
   ./tracker.sh issue edit "$ISSUE_ID" --body "$ISSUE_BODY" --remove-label to-scope --add-label to-slice
   ```
 - set-variables — if overlap should block the scoped issue
   ```sh
-  ISSUE_TITLE="{current issue title} [await: #77, #83]"
+  ISSUE_TITLE_UPDATED="{current issue title} [await: #77, #83]"
   ```
 - update-tracker — if overlap should block the scoped issue
   ```sh
-  ./tracker.sh issue edit "$ISSUE_ID" --title "$ISSUE_TITLE" --remove-label to-slice --add-label to-await-waves
+  ./tracker.sh issue edit "$ISSUE_ID" --title "$ISSUE_TITLE_UPDATED"
   ```
 - set-variables
   ```sh
   DURATION="{human-readable duration since START_TIME}" # e.g. "42s", "1m 12s"
-  ISSUE_BODY="{current plan issue body with metrics section appended}"
+  ISSUE_BODY="{current issue body with metrics section appended}"
   ```
 - update-tracker
   ```sh
@@ -106,13 +106,14 @@ General rules:
 
 - set-variables
   ```sh
-  ISSUE_ID="{issue-id}" # if passed directly or extracted from passed URL
-  PR_ID="{pr-id}" # if passed directly or extracted from passed URL
+  ISSUE_ID="{issue-id or -}" # e.g. "#42"
+  PR_ID="{pr-id or -}"       # e.g. "#43"
+  MERGE_STRATEGY="{from .agents/moonjelly-reef/config.md merge-strategy field}"
   ```
 - fetch-context
   ```sh
-  ./tracker.sh issue view "$ISSUE_ID" --json body,title,labels # if ISSUE_ID known
-  ./tracker.sh pr view "$PR_ID" --json number,body,headRefName,baseRefName,comments,reviews # if PR_ID known
+  ./tracker.sh issue view "$ISSUE_ID" --json body,title,labels
+  ./tracker.sh pr view "$PR_ID" --json number,body,headRefName,baseRefName,comments,reviews
   ```
 - set-variables
   ```sh
@@ -155,10 +156,6 @@ General rules:
   ```sh
   ./tracker.sh pr view "$PR_ID" --json mergeStateStatus -q .mergeStateStatus
   ```
-- set-variables — if approved
-  ```sh
-  MERGE_STRATEGY="{from .agents/moonjelly-reef/config.md merge-strategy field}"
-  ```
 - pr-merge — if approved
   ```sh
   ./tracker.sh pr merge "$PR_ID" --"$MERGE_STRATEGY" --delete-branch
@@ -197,7 +194,7 @@ General rules:
   ```
 - dependency-gate — if `to-await-waves`
   ```sh
-  DEPENDENCY_ID="{from [await: ...] title suffix}" # e.g. #42
+  DEPENDENCY_ID="{from [await: ...] title suffix}" # e.g. "#42"
   ./tracker.sh issue view "$DEPENDENCY_ID" --json labels
   ```
 - set-variables
@@ -214,11 +211,11 @@ General rules:
   ```sh
   ISSUE_ID="{from handoff ISSUE_ID}"
   NEXT_PHASE="{from handoff NEXT_PHASE}"
-  PR_ID="{from handoff PR_ID}" # if returned; otherwise "—"
-  SUMMARY="{from handoff SUMMARY}" # if returned
-  SUBAGENT_DURATION="{duration of sub-agent total execution}" # if known; otherwise "—"
-  SUBAGENT_TOKENS="{total token count used by the sub-agent}" # if known; otherwise "—"
-  SUBAGENT_TOOL_USES="{tool use count for the sub-agent}" # if known; otherwise "—"
+  PR_ID="{from handoff PR_ID}" # e.g. "#72"; "—" if not returned
+  SUMMARY="{from handoff SUMMARY}" # e.g. "PR created"
+  SUBAGENT_DURATION="{duration of sub-agent total execution}" # e.g. "3m12s"; "—" if unknown
+  SUBAGENT_TOKENS="{total token count used by the sub-agent}" # e.g. "18k"; "—" if unknown
+  SUBAGENT_TOOL_USES="{tool use count for the sub-agent}" # e.g. 24; "—" if unknown
   ```
 - set-variables — if `"$AGENT_COUNT_PULSE" -gt 0`
   ```sh
@@ -245,14 +242,14 @@ General rules:
   ```sh
   SUCCESS_COUNT="{from metrics logger handoff}" # e.g. 2
   FAIL_COUNT="{from metrics logger handoff}" # e.g. 0
-  FAIL_IDS="{from metrics logger handoff}" # e.g. #25, #89
+  FAIL_IDS="{from metrics logger handoff}" # e.g. "#25, #89"
   ```
 
 ### [slice.md](./reef-pulse/slice.md)
 
 - set-variables
   ```sh
-  ISSUE_ID="{issue-id}" # pre-existing and passed, e.g. #42
+  ISSUE_ID="{issue-id or -}" # e.g. "#42"
   ```
 - fetch-context
   ```sh
@@ -291,9 +288,9 @@ General rules:
 
 - set-variables
   ```sh
-  PR_BRANCH="{from plan issue body pr-branch field}"
-  BASE_BRANCH="{from plan issue body}"
-  BEARING="{from plan issue body bearing field}"
+  PR_BRANCH="{from context}"
+  BASE_BRANCH="{from context}"
+  BEARING="{from context}"
   WORKTREE_PATH=".worktrees/$ISSUE_ID-slice"
   ```
 - enter-worktree
@@ -312,11 +309,10 @@ General rules:
   ```
 - set-variables
   ```sh
-  SLICE_TITLE="{slice-title} [await: #{blocker-id}]"  # omit [await: ...] if unblocked
-  SLICE_PR_BRANCH="{derived from plan issue pr-branch + slice title slug}"
+  SLICE_TITLE="{slice-title} [await: #{blocker-id}]"
   SLICE_BEARING="{per-slice bearing, usually $BEARING unless a slice needs a narrower inferred lane}"
-  SLICE_BODY="{slice-body}" # as per the template below, with pr-branch: $SLICE_PR_BRANCH and bearing: $SLICE_BEARING
-  SLICE_LABEL="{to-research for unblocked deep-research slices, otherwise to-implement; or to-await-waves if blocked}"
+  SLICE_PR_BRANCH="{derived from plan issue pr-branch + slice title slug}"
+  SLICE_BODY="{slice-body as per the template below, with pr-branch: $SLICE_PR_BRANCH and bearing: $SLICE_BEARING}"
   ```
 - create-slices
   ```sh
@@ -324,11 +320,11 @@ General rules:
   ```
 - set-variables
   ```sh
-  ISSUE_BODY="{plan issue body with pr-branch in frontmatter and coverage matrix appended}"
+  PARENT_ISSUE_BODY_UPDATED="{$ISSUE_BODY_UPDATED with pr-branch in frontmatter and coverage matrix appended}"
   ```
 - update-tracker
   ```sh
-  ./tracker.sh issue edit "$ISSUE_ID" --body "$ISSUE_BODY" --remove-label to-slice --add-label in-progress
+  ./tracker.sh issue edit "$ISSUE_ID" --body "$PARENT_ISSUE_BODY_UPDATED" --remove-label to-slice --add-label in-progress
   ```
 - exit-worktree
   ```sh
@@ -345,7 +341,7 @@ General rules:
 
 - set-variables
   ```sh
-  ISSUE_ID="{issue-id}" # pre-existing and passed, e.g. #42
+  ISSUE_ID="{issue-id}" # pre-existing and passed, e.g. "#42"
   ```
 - fetch-context
   ```sh
@@ -380,14 +376,14 @@ General rules:
   ```
 - set-variables
   ```sh
-  CLOSES="closes $ISSUE_ID $ISSUE_TITLE" # e.g. #42
+  CLOSES="closes $ISSUE_ID $ISSUE_TITLE" # e.g. "closes #42 add auth endpoint"
   REPORT="{implementation report}"
   PR_BODY_NEW="$CLOSES\n\n$REPORT"
   ./tracker.sh pr create --base "$BASE_BRANCH" --title "$ISSUE_TITLE" --body "$PR_BODY_NEW" --label to-inspect
   ```
 - set-variables
   ```sh
-  PR_ID="{from pr create output}" # e.g. #43
+  PR_ID="{from pr create output}" # e.g. "#43"
   ISSUE_BODY_UPDATED="{original issue body with added frontmatter values}"
   # add to frontmatter (if not already): pr-branch: $PR_BRANCH
   # add to frontmatter:  pr-id: $PR_ID
@@ -408,7 +404,7 @@ General rules:
 
 - set-variables
   ```sh
-  ISSUE_ID="{issue-id}" # pre-existing and passed, e.g. #42
+  ISSUE_ID="{issue-id or -}" # e.g. "#42"
   ```
 - fetch-context
   ```sh
@@ -437,14 +433,14 @@ General rules:
   ```
 - set-variables
   ```sh
-  CLOSES="closes $ISSUE_ID $ISSUE_TITLE" # e.g. #42
+  CLOSES="closes $ISSUE_ID $ISSUE_TITLE" # e.g. "closes #42 auth-token-rotation"
   REPORT="{research report}"
   PR_BODY_NEW="$CLOSES\n\n$REPORT"
   ./tracker.sh pr create --base "$BASE_BRANCH" --title "$ISSUE_TITLE" --body "$PR_BODY_NEW" --label to-inspect
   ```
 - set-variables
   ```sh
-  PR_ID="{from pr create output}" # e.g. #43
+  PR_ID="{from pr create output}" # e.g. "#43"
   ISSUE_BODY_UPDATED="{original issue body with added frontmatter values}"
   # add to frontmatter (if not already): pr-branch: $PR_BRANCH
   # add to frontmatter:  pr-id: $PR_ID
@@ -575,7 +571,7 @@ General rules:
 
 - set-variables
   ```sh
-  ISSUE_ID="{issue-id}" # pre-existing and passed, e.g. #42
+  ISSUE_ID="{issue-id}" # e.g. "#42"
   ```
 - fetch-context
   ```sh
@@ -610,7 +606,7 @@ General rules:
   ```
 - update-pr-body
   ```sh
-  PR_ID="{from issue frontmatter pr-id field}" # if not found, try ./tracker.sh pr list --search
+  PR_ID="{from issue frontmatter pr-id field, or - if not present}" # e.g. "#42"
   PR_BODY=$(./tracker.sh pr view "$PR_ID" --json body -q .body)
   REPORT="{inspect-report}" # <details><summary><h3>🧿 Inspect review — {yyyy/MM/dd HH:mm}</h3></summary>{report-content}</details>
   PR_BODY_UPDATED="$PR_BODY\n\n$REPORT"
@@ -641,7 +637,7 @@ General rules:
 
 - set-variables
   ```sh
-  ISSUE_ID="{issue-id}" # pre-existing and passed, e.g. #42
+  ISSUE_ID="{issue-id}" # e.g. "#42"
   ```
 - fetch-context
   ```sh
@@ -652,7 +648,7 @@ General rules:
   ISSUE_TITLE="{from issue title}"
   BASE_BRANCH="{from issue frontmatter base-branch field}"
   PR_BRANCH="{from issue frontmatter pr-branch field}"
-  PR_ID="{from issue frontmatter pr-id field}"
+  PR_ID="{from issue frontmatter pr-id field, or - if not present}" # e.g. "#7"
   WORKTREE_PATH=".worktrees/$ISSUE_TITLE-rework"
   ```
 - enter-worktree
@@ -696,7 +692,7 @@ General rules:
 
 - set-variables
   ```sh
-  ISSUE_ID="{issue-id}" # pre-existing and passed, e.g. #42
+  ISSUE_ID="{issue-id or -}" # e.g. "#42"
   ```
 - fetch-context
   ```sh
@@ -725,7 +721,7 @@ General rules:
   ```
 - update-tracker
   ```sh
-  NEXT_LABEL="{to-research for deep-research, otherwise to-implement}"
+  NEXT_LABEL="to-implement"
   ./tracker.sh issue edit "$ISSUE_ID" --remove-label to-await-waves --add-label "$NEXT_LABEL" --title "$ISSUE_TITLE"
   ```
 - enter-worktree
@@ -761,7 +757,7 @@ General rules:
 
 - set-variables
   ```sh
-  ISSUE_ID="{issue-id}" # pre-existing and passed, e.g. #42
+  ISSUE_ID="{issue-id}" # e.g. "#42"
   ```
 - fetch-context
   ```sh
@@ -820,28 +816,22 @@ General rules:
   ```sh
   ISSUE_ID="$ISSUE_ID"
   NEXT_PHASE="to-seal"
-  PR_ID="$PR_ID" # inherited from router context
+  PR_ID="$PR_ID"
   ```
 
 ### [merge-has-parent.md](./reef-pulse/merge-has-parent.md)
 
 - set-variables
   ```sh
-  PARENT_ID="{from issue frontmatter parent-issue field}"
-  PR_ID="{from issue frontmatter pr-id field}"
-  ```
-- set-variables
-  ```sh
-  MERGE_STRATEGY="{from .agents/moonjelly-reef/config.md merge-strategy field}"
+  PARENT_ID="{from context}" # e.g. "#3"
+  PR_ID="{from context}" # e.g. "#7"
+  BASE_BRANCH="{from context}" # e.g. "feat/my-feature"
+  MERGE_STRATEGY="{from context}" # e.g. "squash"
   ```
 - pr-merge
   ```sh
   ./tracker.sh pr merge "$PR_ID" --"$MERGE_STRATEGY" --delete-branch
   ./tracker.sh pr edit "$PR_ID" --remove-label to-merge --add-label landed
-  ```
-- set-variables
-  ```sh
-  BASE_BRANCH="{from issue frontmatter base-branch field}"
   ```
 - check-siblings-and-completion
   ```sh
@@ -859,15 +849,15 @@ General rules:
 - handoff
   ```sh
   ISSUE_ID="$ISSUE_ID"
-  NEXT_PHASE="to-seal" # or "in-progress" if not all issues labeled 'landed'
-  PR_ID="—" # sub-issue merge does not open the parent issue PR
+  NEXT_PHASE="$NEXT_PHASE"
+  PR_ID="-" # sub-issue merge does not open the parent issue PR
   ```
 
 ### [seal.md](./reef-pulse/seal.md)
 
 - set-variables
   ```sh
-  ISSUE_ID="{issue-id}" # pre-existing and passed, e.g. #42
+  ISSUE_ID="{issue-id}" # e.g. "#42"
   ```
 - fetch-context
   ```sh
@@ -907,7 +897,7 @@ General rules:
   ```
 - if PR needs creation
   ```sh
-  CLOSES="closes $ISSUE_ID $ISSUE_TITLE" # e.g. #42
+  CLOSES="closes $ISSUE_ID $ISSUE_TITLE" # e.g. "closes #42 My feature title"
   PR_BODY_NEW="$CLOSES\n\n$REPORT"
   ./tracker.sh pr create --base "$BASE_BRANCH" --head "$PR_BRANCH" --title "$ISSUE_TITLE" --body "$PR_BODY_NEW" --label to-seal
   # Persist the PR metadata on the plan issue so downstream human review can always find it:

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ stateDiagram-v2
         state "🤿　to-land" as to_land
 
         [*] --> to_scope
-        to_scope --> to_slice : reef-scope skill<br />scope the work, define success criteria
+        to_scope --> to_slice : reef-scope skill<br />scope the work, write the plan
         to_slice --> slice_lifecycle : slice.md<br />🔷　creates sub-issues:<br />labels each sub-issue to-implement or to-research
 <br />adds coverage matrix to parent issue
         to_slice --> slice_lifecycle : slice.md<br />🔶　no sub-issues needed:<br />labels the current issue to-implement or to-research
@@ -93,7 +93,7 @@ stateDiagram-v2
 <details>
 <summary>🤿 <b><code>reef-scope</code></b> — scope an issue</summary>
 
-The single entry point for turning ideas into plans. It always shows a route picker, recommends a route from issue text when an issue is passed in, writes a plan with **success criteria**, and labels `to-slice`.
+The single entry point for turning ideas into plans. It always shows a route picker, recommends a route from issue text when an issue is passed in, writes a plan with User Stories, Implementation Decisions, and Testing Decisions, and labels `to-slice`.
 
 The route picker always offers these five options:
 
@@ -238,7 +238,7 @@ Fix every issue flagged by the inspector. Address all PR comments, run the full 
 <details>
 <summary>🌊 <b><code>to-seal</code></b> 🏷️</summary>
 
-Holistic review of the current issue's `pr-branch` — checking the composed whole, not the parts. Verify every success criterion end-to-end, run the full suite, produce the aggregate report, label `to-land` or `to-rework` on gaps.
+Holistic review of the current issue's `pr-branch` — checking the composed whole, not the parts. Verify every plan item (User Stories, Implementation Decisions, Testing Decisions) end-to-end, run the full suite, produce the aggregate report, label `to-land` or `to-rework` on gaps.
 
 | source file | [`reef-pulse/seal.md`](reef-pulse/seal.md) |
 | :---------- | :----------------------------------------- |

--- a/reef-land/SKILL.md
+++ b/reef-land/SKILL.md
@@ -145,7 +145,7 @@ For each concern or comment:
 - Confirm you understand it correctly
 - Ask clarifying questions if the intent is ambiguous
 - Propose how it maps to work: is it a code change? A restructuring? A naming fix?
-- Check if it relates to an existing success criterion or needs a new one
+- Check if it relates to an existing plan item (US, ID, TD) or needs a new one
 
 Ask questions one at a time. For each question, provide your recommended answer.
 
@@ -176,7 +176,7 @@ Append the gap report to the current PR body. Include original PR review comment
 
   Context: {what was clarified or decided}
 
-### New or updated success criteria (if any)
+### New or updated plan items (if any)
 
 - [ ] {new criterion}
 
@@ -194,7 +194,7 @@ PR_BODY="{current PR body with gap report appended in <details><summary> block}"
 ./tracker.sh issue edit "$ISSUE_ID" --remove-label to-land --add-label to-rework
 ```
 
-If the discussion changed any plan-level Decisions, Stories, or Success Criteria, also update the plan body:
+If the discussion changed any plan-level User Stories, Implementation Decisions, or Testing Decisions, also update the plan body:
 
 ```sh
 PLAN_BODY=$(./tracker.sh issue view "$ISSUE_ID" --json body)

--- a/reef-pulse/implement.md
+++ b/reef-pulse/implement.md
@@ -111,7 +111,7 @@ Report these variables to the caller and **do not continue**.
 Read and understand:
 
 - **This issue's acceptance criteria** — this is your checklist. Every criterion must be addressed.
-- **The plan + success criteria** — understand the "why" behind this issue.
+- **The plan** — understand the "why" behind this issue (User Stories, Implementation Decisions, Testing Decisions).
 - **Sibling issues** — awareness of what others are doing or have done. Don't duplicate, don't conflict.
 - **The decision record** — the original decisions that led here.
 

--- a/reef-pulse/inspect.md
+++ b/reef-pulse/inspect.md
@@ -51,7 +51,7 @@ FEELING_LUCKY="{from issue frontmatter feeling-lucky field, or - if not present}
 WORKTREE_PATH=".worktrees/$ISSUE_TITLE-inspect"
 ```
 
-For plan issues, read success criteria from the plan issue body instead of acceptance criteria.
+For plan issues (issues without a parent-issue), read User Stories, Implementation Decisions, and Testing Decisions from the plan issue body as the inspection target instead of acceptance criteria.
 
 ## Mindset — Inspector Barreleye
 
@@ -66,7 +66,7 @@ What you do:
 - **Run the full test suite yourself.** Don't trust "all tests pass" in the report.
 - **Do trivial cleanups.** Stale TODOs, leftover debug prints, dead code from debugging, formatting — fix these yourself and commit. Don't ask permission.
 - **Flag substantive gaps.** Missing tests, incomplete behavior, skipped acceptance criteria — these go in review comments, not silent fixes.
-- **Read the ambiguous choices.** The implementer documented decisions they made. Flag anything that drifted too far from the success criteria or that the human should know about.
+- **Read the ambiguous choices.** The implementer documented decisions they made. Flag anything that drifted too far from the plan items or that the human should know about.
 
 You do NOT need to evaluate product direction, user stories, or the problem statement in great detail.
 
@@ -97,9 +97,9 @@ Report these variables to the caller and **do not continue**.
 
 Run the full project test suite. Record the result.
 
-## 2. Check each acceptance criterion
+## 2. Check each acceptance criterion and corresponding plan items
 
-For each acceptance criterion on the issue:
+For each acceptance criterion on the slice issue:
 
 - Read the actual code that implements it. Trace the code path.
 - Confirm the behavior is correct by reading the test that covers it.
@@ -109,12 +109,18 @@ For each acceptance criterion on the issue:
 - Check that the writing is clear, coherent, not overly drawn out, and actually answers the promised angle or question.
 - If `"$FEELING_LUCKY" = "true"`, do not get fussy about fuzzy acceptance criteria — apply the same code-level checks (trace the path, check tests) but judge quality holistically: clarity, simplicity, and obvious polish opportunities.
 
+Also cross-check against the **plan items (US, ID, TD)** that the coverage matrix maps to this slice:
+
+- Read the parent plan issue (if this is a sub-issue) and identify which User Stories, Implementation Decisions, and Testing Decisions this slice was meant to satisfy.
+- Verify the implementation actually satisfies those plan items, not just the AC checkboxes.
+- Flag any drift where the acceptance criteria didn't fully capture what the plan item requires.
+
 ## 3. Review the report
 
 Read the PR description's "Ambiguous choices" section. For each choice:
 
 - Does it make sense given the constraints?
-- Does it drift from the success criteria? If so, is the drift acceptable?
+- Does it drift from the plan items? If so, is the drift acceptable?
 - Would the human want to know about this before merging?
 
 ## 4. Trivial cleanups

--- a/reef-pulse/research.md
+++ b/reef-pulse/research.md
@@ -46,7 +46,7 @@ Read the issue. It must contain:
 - Acceptance criteria
 - `base-branch` in frontmatter (where the PR merges into)
 - `pr-branch` in frontmatter (the branch the PR lives on)
-- Research-oriented success criteria or acceptance criteria
+- Research-oriented acceptance criteria or Research Questions
 
 ```sh
 ISSUE_TITLE="{from issue title}" # e.g. "auth-token-rotation"
@@ -88,7 +88,7 @@ Report these variables to the caller and **do not continue**.
 Read and understand:
 
 - **This issue's acceptance criteria** — this is your checklist. Every criterion must be addressed.
-- **The plan + success criteria** — understand the question the research must answer.
+- **The plan** — understand the question the research must answer (Research Questions, Testing Decisions).
 - **Sibling issues** — awareness of what others are doing or have done. Don't duplicate, don't conflict.
 - **The decision record** — the original decisions that led here.
 

--- a/reef-pulse/rework.md
+++ b/reef-pulse/rework.md
@@ -51,7 +51,7 @@ PR_ID="{from issue frontmatter pr-id field, or - if not present}" # e.g. "#7"
 WORKTREE_PATH=".worktrees/$ISSUE_TITLE-rework"
 ```
 
-For plan issues, read success criteria from the plan issue body instead of acceptance criteria.
+For plan issues (issues without a parent-issue), read User Stories, Implementation Decisions, and Testing Decisions from the plan issue body as the rework target instead of acceptance criteria.
 
 ## 1. Git prep
 
@@ -86,7 +86,7 @@ Also read the gap report from the PR body (`<details><summary>` blocks written b
 
 Also re-read:
 
-- The issue's acceptance criteria or plan's success criteria
+- The issue's acceptance criteria or the plan's User Stories, Implementation Decisions, and Testing Decisions
 - The gap classification from the seal report if present (missing coverage, incomplete implementation, integration gap, planning gap)
 
 ## 3. Fix

--- a/reef-pulse/seal.md
+++ b/reef-pulse/seal.md
@@ -43,7 +43,7 @@ Report these variables to the caller and **do not continue**.
 
 Read the plan. It must have:
 
-- Success criteria
+- User Stories, Implementation Decisions, and Testing Decisions
 - Coverage matrix (if multi-slice)
 - `pr-branch` in frontmatter
 - Slice PRs with "Ambiguous choices" sections
@@ -102,13 +102,13 @@ Verify you have the latest — all slice PRs should be merged into this `pr-bran
 
 Not negotiable. Record the result.
 
-## 3. Check every success criterion holistically
+## 3. Check every plan item holistically
 
-For each success criterion in the plan:
+For each User Story, Implementation Decision, and Testing Decision in the plan:
 
 - Read the actual code on the `pr-branch` that satisfies it. Trace the full path — don't check module by module, check end-to-end.
-- Verify from the **consumer's perspective**. If the criterion says "the legacy UI must render identically", don't just check that the data is correct — check that it's in the format the legacy UI expects. (Prevents painpoint A4.)
-- Cross-reference the coverage matrix: which issues were supposed to cover this criterion? Did they actually cover it when composed together?
+- Verify from the **consumer's perspective**. If a user story says "the legacy UI must render identically", don't just check that the data is correct — check that it's in the format the legacy UI expects. (Prevents painpoint A4.)
+- Cross-reference the coverage matrix: which issues were supposed to cover this plan item? Did they actually cover it when composed together?
 
 If `"$BEARING" = "deep-research"`:
 
@@ -127,7 +127,7 @@ Mark each criterion: ✓ met, ✗ not met (with explanation).
 Read the "Ambiguous choices" section from each slice's merged PR. For each decision:
 
 - Does it make sense?
-- Did it introduce drift from the original success criteria or decision record?
+- Did it introduce drift from the original plan items or decision record?
 - Would the human want to know about this?
 
 ## 5. Check for integration issues
@@ -144,21 +144,21 @@ Look for problems that only appear when slices are composed:
 
 Use your findings from steps 3-5 to tighten the plan before deciding PASS vs GAPS:
 
-- If the review revealed something that SHOULD have been a criterion but wasn't, update the success criteria on the plan issue.
+- If the review revealed something that SHOULD have been captured but wasn't, update the Testing Decisions or Implementation Decisions on the plan issue.
 - Classify each gap found:
-  - **Missing coverage**: a success criterion has no slice addressing it
-  - **Incomplete implementation**: a slice was done but didn't fully satisfy a criterion when composed
+  - **Missing coverage**: a plan item has no slice addressing it
+  - **Incomplete implementation**: a slice was done but didn't fully satisfy a plan item when composed
   - **Integration gap**: slices work individually but not together
-  - **Planning gap**: the plan or success criteria were ambiguous or missed something
+  - **Planning gap**: the Testing Decisions or Implementation Decisions were ambiguous or missed something
 
-If you updated the plan's success criteria:
+If you updated the plan's Testing Decisions or Implementation Decisions:
 
 ```sh
-ISSUE_BODY="{plan issue body with updated success criteria}"
+ISSUE_BODY="{plan issue body with updated Testing Decisions or Implementation Decisions}"
 ./tracker.sh issue edit "$ISSUE_ID" --body "$ISSUE_BODY"
 ```
 
-If any gaps need decisions beyond what success criteria cover (e.g. the plan itself is ambiguous about a design direction), treat that as a **human decision needed** case. Do NOT send it back to `to-scope`. Keep it moving to `to-land`, make the warning explicit in the seal report, and call out exactly which decision needs human judgment before more automated work should happen.
+If any gaps need decisions beyond what the plan covers (e.g. the plan itself is ambiguous about a design direction), treat that as a **human decision needed** case. Do NOT send it back to `to-scope`. Keep it moving to `to-land`, make the warning explicit in the seal report, and call out exactly which decision needs human judgment before more automated work should happen.
 
 ## 7. Documentation
 
@@ -185,11 +185,11 @@ The report should be concise and focused on what the human needs to know. Do NOT
 
 ### Status: {PASS / GAPS FOUND / HUMAN DECISION NEEDED}
 
-### Success criteria
+### Plan items
 
-- ✓ SC1: {criterion} — verified: {one-line how}
-- ✓ SC2: {criterion} — verified: {one-line how}
-- ✗ SC3: {criterion} — GAP: {what's wrong}
+- ✓ US1: {user story} — verified: {one-line how}
+- ✓ ID1: {implementation decision} — verified: {one-line how}
+- ✗ TD1: {testing decision} — GAP: {what's wrong}
 
 ### Agent decisions to review
 
@@ -247,14 +247,14 @@ ISSUE_BODY="{original issue body with added frontmatter values}"
 ./tracker.sh pr edit "$PR_ID" --remove-label to-seal --add-label to-land
 ```
 
-**If the remaining gap is a human decision beyond current success criteria:**
+**If the remaining gap is a human decision beyond the current plan:**
 
 ```sh
 ./tracker.sh issue edit "$ISSUE_ID" --remove-label to-seal --add-label to-land --add-label blocked-need-human-input
 ./tracker.sh pr edit "$PR_ID" --remove-label to-seal --add-label to-land --add-label blocked-need-human-input
 ```
 
-**If gaps found (fixable within success criteria and without human input needed):**
+**If gaps found (fixable within the plan and without human input needed):**
 
 ```sh
 ./tracker.sh issue edit "$ISSUE_ID" --remove-label to-seal --add-label to-rework

--- a/reef-pulse/slice-subissues.md
+++ b/reef-pulse/slice-subissues.md
@@ -49,19 +49,24 @@ If the plan says to work on the current branch (no new `pr-branch`), skip the br
 
 ## 2. Build the coverage matrix
 
-For each success criterion in the plan, map it to which slice(s) and which acceptance criterion/criteria cover it.
+For each plan item, map it to which slice(s) and which acceptance criterion/criteria cover it.
+
+- **Features**: the left column is all User Stories (US), Implementation Decisions (ID), and Testing Decisions (TD) combined.
+- **Deep-research**: the left column is all Research Questions.
+
+Architectural or non-testable IDs that have no direct implementation output should be noted as "covered by design" in the Acceptance Criteria column.
 
 ```markdown
 ## Coverage Matrix
 
-| Success Criterion                    | Slice                                | Acceptance Criteria                                           |
-| ------------------------------------ | ------------------------------------ | ------------------------------------------------------------- |
-| SC1: Users can log in with email     | 001 Auth endpoint                    | AC1: POST /login returns token, AC2: invalid creds return 401 |
-| SC2: Session persists across refresh | 002 Token storage                    | AC1: token stored in httpOnly cookie                          |
-| SC3: Legacy UI renders identically   | 001 Auth endpoint, 003 Legacy compat | AC3: response format matches legacy schema                    |
+| Plan Item                                                | Slice                                | Acceptance Criteria                                           |
+| -------------------------------------------------------- | ------------------------------------ | ------------------------------------------------------------- |
+| US1: Users can log in with email                         | 001 Auth endpoint                    | AC1: POST /login returns token, AC2: invalid creds return 401 |
+| TD1: Session persists across refresh                     | 002 Token storage                    | AC1: token stored in httpOnly cookie                          |
+| ID1: Legacy UI renders identically (covered by design)   | 001 Auth endpoint, 003 Legacy compat | covered by design                                             |
 ```
 
-**Verify completeness**: every success criterion must appear in at least one row. If any criterion is uncovered, either add it to an existing slice's acceptance criteria or create a new slice. Do not proceed with gaps. (Prevents painpoint A3.)
+**Verify completeness**: every plan item must appear in at least one row. If any item is uncovered, either add it to an existing slice's acceptance criteria or create a new slice. Do not proceed with gaps. (Prevents painpoint A3.)
 
 ## 3. Verify the breakdown
 
@@ -69,7 +74,7 @@ Verify internally:
 
 - Is the granularity reasonable? (prefer many thin slices over few thick ones)
 - Are the dependency relationships correct? Are there implicit deps not captured?
-- Does every success criterion appear in the coverage matrix?
+- Does every plan item (US, ID, TD or Research Question) appear in the coverage matrix?
 
 If anything looks off, adjust the breakdown. Do not ask the user — reef-scope already iterated with the user on the plan. Your job is to slice it mechanically.
 

--- a/reef-pulse/slice.md
+++ b/reef-pulse/slice.md
@@ -53,13 +53,28 @@ SUMMARY="Skipped: issue does not carry the to-slice label."
 
 Report these variables to the caller and **do not continue**.
 
-Read the issue. It must contain a plan with success criteria (from reef-scope). Success criteria are plan-level; this skill breaks them into **acceptance criteria** per slice. The frontmatter block tells you the work type, `base-branch`, and `pr-branch`.
+Read the issue. It must contain a plan with User Stories, Implementation Decisions, and Testing Decisions (from reef-scope). This skill synthesizes those plan items into **acceptance criteria** per slice. The frontmatter block tells you the work type, `base-branch`, and `pr-branch`.
 
 ```sh
 BASE_BRANCH="{from issue frontmatter base-branch field, or - if not present}" # e.g. "main"
 PR_BRANCH="{from issue frontmatter pr-branch field, or - if not present}"     # e.g. "feat/my-feature"
 BEARING="{from issue frontmatter bearing field, or - if not present}"         # e.g. "feature"
 ```
+
+### Guard: refactor and bug bearings skip slicing
+
+RUN ONLY WHEN `"$BEARING" = "refactor"` or `"$BEARING" = "bug"`.
+
+These bearings no longer reach the slice phase — they are already labeled `to-implement` by `reef-scope`.
+
+```sh
+ISSUE_ID="$ISSUE_ID"
+NEXT_PHASE="—"
+PR_ID="—"
+SUMMARY="Skipped: $BEARING bearings do not reach the slice phase. The plan issue should already be labeled to-implement."
+```
+
+Report these variables to the caller and **do not continue**.
 
 ### Guard: verify branch frontmatter
 
@@ -130,7 +145,6 @@ Rules:
 - If `"$BEARING" = "deep-research"`, draft research questions rather than implementation work. Compact research plans can stay as a single research issue. Larger research plans can be split into angle-based or dependency-based research slices. Acceptance criteria should say what must be answered, clarified, or persisted.
 - If `"$FEELING_LUCKY" = "true"`, produce acceptance criteria and dependencies with best-effort judgment without asking the user follow-up questions.
 
-For small bugs (scope = quick fix in the plan): produce a single slice. The plan's success criteria become the slice's acceptance criteria directly.
 
 ## 2. Delegate
 

--- a/reef-scope/SKILL.md
+++ b/reef-scope/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: reef-scope
-description: Scope an issue into a plan with success criteria, ready for the Moonjelly Reef to pick up. Route between a feature, refactor, a bug triage or deep research. Turn an ideas into a plan.
+description: Scope an issue into a plan, ready for the Moonjelly Reef to pick up. Route between a feature, refactor, a bug triage or deep research. Turn an idea into a plan.
 ---
 
 # reef-scope

--- a/reef-scope/scope-deep-research.md
+++ b/reef-scope/scope-deep-research.md
@@ -38,7 +38,37 @@ Fold the answers into the Testing Decisions section of the plan. Do not create a
 
 ## 5. Write the plan
 
-Write the scoped issue so the acceptance criteria describe what must be answered, clarified, or persisted, not what code must be written.
+Write the scoped issue using this template. The acceptance criteria describe what must be answered, clarified, or persisted, not what code must be written.
+
+<plan-template>
+
+## Problem Statement
+
+The question or uncertainty the research must resolve.
+
+## Research Questions
+
+A numbered list of the specific questions this research must answer:
+
+1. {question 1}
+2. {question 2}
+3. {question 3}
+
+Every question must be answerable — it produces a concrete finding, decision, or documented outcome.
+
+## Testing Decisions
+
+What makes this research complete? Include:
+
+- What must be answered or documented for this research to be complete
+- What open questions, if left unanswered, would make the research feel incomplete
+- Who will act on the findings and what they need to move forward
+
+## Out of Scope
+
+What this research does NOT need to answer.
+
+</plan-template>
 
 After writing the plan, append the full Q&A transcript from the interview:
 


### PR DESCRIPTION
closes #191 003 pipeline plumbing: slice guard, coverage matrix anchor, inspect/seal awareness, language sweep

## Ambiguous choices

None — implementation followed the plan exactly.

## Test results

476 tests passed, 0 failed (365 orchestration + 89 tracker + 22 worktree).

Note: fixed 1 pre-existing test failure (ORCHESTRATION.md line 273 had `{$ISSUE_BODY_UPDATED with updated Success & Acceptance criteria}` but slice-one-issue.md had `{plan issue body with scoped pr-branch, rewritten bearing, and appended Acceptance criteria}` — a mismatch introduced when slice 001 updated the phase file but the ORCHESTRATION.md was in a different lineage than main's "fix: tests" commit).

<details><summary><h3>🧿 Inspect review — 2026/04/24 19:41</h3></summary>

## Verdict: PASS

All 8 acceptance criteria met. Test suite green (476 passed, 0 failed).

### Acceptance criteria

- ✓ AC1: `slice.md` guard for refactor/bug bearings — present at the top of slice.md under "Guard: refactor and bug bearings skip slicing"; hands off with SUMMARY="Skipped: $BEARING bearings do not reach the slice phase"
- ✓ AC2: `slice-subissues.md` coverage matrix left column — updated to "US + ID + TD items" for features and "Research Questions" for deep-research; example table reflects this
- ✓ AC3: `scope-deep-research.md` plan template includes `## Research Questions` — present as a numbered list section in the plan template
- ✓ AC4: `inspect.md` checks against both slice AC and plan items (US, ID, TD) — Section 2 now titled "Check each acceptance criterion and corresponding plan items"; cross-check block reads parent plan issue for US/ID/TD and verifies implementation satisfies those, not just AC checkboxes
- ✓ AC5: `seal.md` uses Testing Decisions / Implementation Decisions (not Success Criteria) — all references in seal.md use the new terminology
- ✓ AC6: No skill file under `reef-pulse/` or `reef-scope/` uses "success criteria" to mean plan-level criteria — confirmed clean across implement.md, inspect.md, rework.md, seal.md, tdd-lite.md, research.md, await-waves.md, reef-land/SKILL.md, reef-scope/SKILL.md
- ✓ AC7: README updated — reef-scope section now says "writes a plan with User Stories, Implementation Decisions, and Testing Decisions"; to-seal section now says "Verify every plan item (User Stories, Implementation Decisions, Testing Decisions)"; no "success criteria" language remains
- ✓ AC8: `./test.sh` passes — 476 passed, 0 failed

### Drift note (non-blocking)

`UBIQUITOUS_LANGUAGE.md` still defines "success criteria" as the canonical plan-level term and the coverage matrix row still says "mapping each success criterion". This file was not in the language sweep scope per the issue, and the AC does not require updating it. Flagged for awareness — a future ubiquitous-language refresh should align the glossary with the US/ID/TD terminology.

### No trivial cleanups needed

No debug prints, stale TODOs, or dead code found.

</details>