### PR TITLE
Replace {yyyy/MM/dd HH:mm} format placeholders with shell TIMESTAMP variable

### DIFF
--- a/WRITING_STYLE_GUIDE.md
+++ b/WRITING_STYLE_GUIDE.md
@@ -373,9 +373,15 @@ The tag name describes what the content is for. A code fence says "here is some 
 
 Reports are collapsible blocks appended to a PR body after a phase completes (inspect, rework, seal, gap reports). Use `<report-template>` with `<details>/<summary>` inside so the agent knows the full output structure including the wrapper:
 
+Before the template, set the timestamp in a `sh` code block:
+
+    ```sh
+    TIMESTAMP=$(date +"%Y/%m/%d %H:%M")
+    ```
+
     <report-template>
     <details>
-    <summary><h3>{emoji} {Phase name} — {yyyy/MM/dd HH:mm}</h3></summary>
+    <summary><h3>{emoji} {Phase name} — $TIMESTAMP</h3></summary>
 
     ### Section
 

--- a/reef-land/SKILL.md
+++ b/reef-land/SKILL.md
@@ -193,9 +193,13 @@ The gap report goes on the PR body in a `<details><summary>` block. Rework has n
 
 Append the gap report to the current PR body. Include original PR review comments (quoted, with file:line) and the refined context from your discussion.
 
+```sh
+TIMESTAMP=$(date +"%Y/%m/%d %H:%M")
+```
+
 <report-template>
 <details>
-<summary><h3>🤿 Diver's notes — {yyyy/MM/dd HH:mm}</h3></summary>
+<summary><h3>🤿 Diver's notes — $TIMESTAMP</h3></summary>
 
 ### Gaps
 

--- a/reef-pulse/implement.md
+++ b/reef-pulse/implement.md
@@ -135,9 +135,13 @@ If any tests fail after implementation: run each failing test against `$BASE_BRA
 
 Compose the implementation report using this template. This output will be read by another agent session — no context from this conversation carries over. Be explicit and self-contained.
 
+```sh
+TIMESTAMP=$(date +"%Y/%m/%d %H:%M")
+```
+
 <report-template>
 <details>
-<summary><h3>🐙 Workshop report — {yyyy/MM/dd HH:mm}</h3></summary>
+<summary><h3>🐙 Workshop report — $TIMESTAMP</h3></summary>
 
 ### Judgment calls
 

--- a/reef-pulse/inspect.md
+++ b/reef-pulse/inspect.md
@@ -186,9 +186,13 @@ RUN ONLY IF you made cleanup commits in this step:
 
 Write the report which will be read by another agent session — no context from this conversation carries over. Be explicit and self-contained.
 
+```sh
+TIMESTAMP=$(date +"%Y/%m/%d %H:%M")
+```
+
 <report-template>
 <details>
-<summary><h3>🧿 Barreleye inspection — {yyyy/MM/dd HH:mm}</h3></summary>
+<summary><h3>🧿 Barreleye inspection — $TIMESTAMP</h3></summary>
 
 ### Judgment calls
 

--- a/reef-pulse/research.md
+++ b/reef-pulse/research.md
@@ -114,9 +114,13 @@ When research is complete, compose the PR description using this template:
 
 This output will be read by another agent session — no context from this conversation carries over. Be explicit and self-contained.
 
+```sh
+TIMESTAMP=$(date +"%Y/%m/%d %H:%M")
+```
+
 <report-template>
 <details>
-<summary><h3>🐬 Dolphin's findings — {yyyy/MM/dd HH:mm}</h3></summary>
+<summary><h3>🐬 Dolphin's findings — $TIMESTAMP</h3></summary>
 
 ### Judgment calls
 

--- a/reef-pulse/rework.md
+++ b/reef-pulse/rework.md
@@ -149,9 +149,13 @@ Not a subset. The full project test suite must be green.
 
 Write the report which will be read by another agent session — no context from this conversation carries over. Be explicit and self-contained.
 
+```sh
+TIMESTAMP=$(date +"%Y/%m/%d %H:%M")
+```
+
 <report-template>
 <details>
-<summary><h3>🦀 Crab's rework — {yyyy/MM/dd HH:mm}</h3></summary>
+<summary><h3>🦀 Crab's rework — $TIMESTAMP</h3></summary>
 
 ### Judgment calls
 

--- a/reef-pulse/seal.md
+++ b/reef-pulse/seal.md
@@ -200,9 +200,13 @@ The report should be concise and focused on what the diver needs to know. Do NOT
 
 This output will be read by another agent session — no context from this conversation carries over. Be explicit and self-contained.
 
+```sh
+TIMESTAMP=$(date +"%Y/%m/%d %H:%M")
+```
+
 <report-template>
 <details>
-<summary><h3>🦭 Seal of approval — {yyyy/MM/dd HH:mm}</h3></summary>
+<summary><h3>🦭 Seal of approval — $TIMESTAMP</h3></summary>
 
 ## Final Report
 

--- a/reef-scope/SKILL.md
+++ b/reef-scope/SKILL.md
@@ -176,7 +176,7 @@ else
 fi
 
 DURATION="{human-readable duration since $START_TIME}" # e.g. "42s", "1m 12s"
-TIMESTAMP="{yyyy/MM/dd HH:mm}" # e.g. "2012/12/21 12:00"
+TIMESTAMP=$(date +"%Y/%m/%d %H:%M")
 INTERVIEW_TRANSCRIPT="{full interview Q&A transcript}" # e.g. Q: What are you trying to Build? A: ...
 ISSUE_BODY_UPDATED="---
 base-branch: $BASE_BRANCH


### PR DESCRIPTION
closes #95 Replace {yyyy/MM/dd HH:mm} format placeholders with shell TIMESTAMP variable

<details><summary><h3>🐙 Workshop report — 2026/04/26 15:30</h3></summary>

### Judgment calls

None — implementation followed the plan exactly.

### Test results

494 tests passed, 0 failed (across orchestration, tracker, worktree, commit-push, fetch, pull, push suites).

</details>

<details>
<summary><h3>🧿 Barreleye inspection — 2026/04/26 14:51</h3></summary>

### Judgment calls

None.

### Checklist

- ✓ **Commit 1 (reef-scope/SKILL.md)**: `TIMESTAMP` assignment changed from `"{yyyy/MM/dd HH:mm}"` to `$(date +"%Y/%m/%d %H:%M")` — verified via `git show 36a5c29`, confirmed the literal shell command replaces the interpreted placeholder
- ✓ **Commit 2 (reef-pulse: implement, inspect, research, rework, seal)**: All 5 files have `TIMESTAMP=$(date +"%Y/%m/%d %H:%M")` in a `sh` block placed immediately before `<report-template>`, and `$TIMESTAMP` inside the `<summary>` — verified line by line
- ✓ **Commit 3 (reef-land/SKILL.md)**: Same two-change pattern applied, TIMESTAMP line in `sh` block immediately before `<report-template>` — verified via `git show 7fe5eb6`
- ✓ **Commit 4 (WRITING_STYLE_GUIDE.md)**: Documentation updated to show pre-template `sh` block with `TIMESTAMP=$(date +"%Y/%m/%d %H:%M")` and `$TIMESTAMP` in summary — verified via `git show 361ab46`
- ✓ **No residual `{yyyy/MM/dd HH:mm}` placeholders**: Full grep across all `.md` and `.sh` files returns zero matches
- ✓ **Other placeholders untouched**: Non-timestamp placeholders like `{topic}`, `{reason}`, etc. remain unchanged
- ✓ **ORCHESTRATION.md unchanged**: No patterns from ORCHESTRATION.md were touched

### Test results

494 tests passed, 0 failed (orchestration, tracker, worktree, commit-push, fetch, pull, push suites).

</details>

<details>
<summary><h3>🦭 Seal of approval — 2026/04/26 16:15</h3></summary>

## Final Report

### Status: PASS

### Plan items

- ✓ **Commit 1 (reef-scope/SKILL.md)**: `TIMESTAMP` assignment changed from `"{yyyy/MM/dd HH:mm}"` to `$(date +"%Y/%m/%d %H:%M")` — verified: grep confirms literal shell command at line 179, used correctly in output at lines 194 and 199
- ✓ **Commit 2 (reef-pulse: implement, inspect, rework, research, seal)**: All 5 files have `TIMESTAMP=$(date +"%Y/%m/%d %H:%M")` in a `sh` block immediately before `<report-template>`, and `$TIMESTAMP` in `<summary>` — verified file-by-file
- ✓ **Commit 3 (reef-land/SKILL.md)**: Same two-change pattern applied — TIMESTAMP line at 197, `<report-template>` at 200, `$TIMESTAMP` in summary at 202
- ✓ **Commit 4 (WRITING_STYLE_GUIDE.md)**: Documentation updated — pre-template `sh` block with `TIMESTAMP=$(date +"%Y/%m/%d %H:%M")` and `$TIMESTAMP` in example summary shown at lines 379/384
- ✓ **No residual `{yyyy/MM/dd HH:mm}` placeholders**: Full grep across all .md and .sh files returns zero matches
- ✓ **Problem statement solved**: LLMs no longer interpret a format string — they execute a literal shell command and expand the variable

### Judgment calls

None warranted. The implementation is a direct, clean execution of the plan with no drift.

### Integration notes

No integration issues found. All 8 changed files follow an identical pattern. No shared resources or naming conflicts.

### Test results

Full suite: 494 passed, 0 failed, 0 skipped (orchestration 361, commit-push 101, worktree 18, tracker 6, fetch 3, pull 3, push 2).

</details>

### 🪼 Pulse metrics

| Phase | Target | Duration | Tokens | Tool uses | Outcome | Date |
| ----- | ------ | -------- | ------ | --------- | ------- | ---- |
| scope | #95 | 8m | — | — | plan created | 2026/04/26 14:00 |
| implement | #95 | 10m44s | 66132 | 71 | Implementation complete for Replace {yyyy/MM/dd HH:mm} format placeholders with shell TIMESTAMP variable | 2026/04/26 14:48 |
| inspect | #95 | 2m27s | 27939 | 31 | Approved: all 4 commits implement the plan exactly — 494 tests passed, 0 failed. | 2026/04/26 14:54 |
| merge | #95 | 1m36s | 19230 | 17 | No parent issue — forwarding to seal for holistic review | 2026/04/26 14:59 |
| seal | #95 | 2m50s | 26163 | 26 | Seal PASS — all 4 commits implement the plan exactly, 494 tests passed 0 failed | 2026/04/26 15:06 |
| **Total** | | | **139463** | **145** | | |