### PR TITLE
AI-authored PRs: enable proper self-review by having the REEF open PRs

### DIFF
--- a/research/001-git-identity-vs-github-pr-opener.md
+++ b/research/001-git-identity-vs-github-pr-opener.md
@@ -1,0 +1,133 @@
+---
+issue: "#200"
+parent-issue: "#48"
+date: "2026-04-26"
+---
+
+# 001 Git identity vs GitHub PR opener
+
+## Summary
+
+Git commit author identity and GitHub PR opener identity are **fully independent and separately controllable**. The PR opener is determined solely by the GitHub API token used to call `POST /repos/{owner}/{repo}/pulls` (or `gh pr create`). No git-side manipulation changes who GitHub considers the PR opener. As a result, the self-review restriction ("Pull request authors can't approve their own pull request") applies to the **GitHub account that opened the PR**, not to any commit author listed in the branch history.
+
+This means that if the reef opens a PR using the diver's personal access token, the diver is the PR opener and cannot use "Request changes" or "Approve" on that PR — regardless of what name or email appears in the git commits.
+
+## Question 1 — Does `git commit --author` affect who GitHub considers the PR opener for review-eligibility purposes?
+
+**Answer: No.**
+
+The git author field (`git commit --author "Name <email>"` or `git config user.name / user.email`) is stored in the commit object and is purely cosmetic metadata from GitHub's identity system perspective. It controls:
+
+- Who gets the green contribution square on the commits page
+- Who appears in `git log --author`
+- The "authored by" display on the commit detail page
+
+It does **not** control:
+
+- Which GitHub account is considered the PR opener
+- Which account is subject to the self-review restriction
+- Who GitHub's review eligibility checks run against
+
+Evidence:
+- GitHub CLI maintainer confirmed: "gh can only act as the user whose auth token it has… all actions will be taken on its behalf." (source: [cli/cli#6616](https://github.com/cli/cli/issues/6616), closed as not planned)
+- The `gh pr create` command has no `--author` flag; a request to add one was rejected on security grounds — "it would be problematic if one user could create pull requests attributed to another user."
+- The `POST /repos/{owner}/{repo}/pulls` REST API has no author-override parameter. The PR `user` field in the API response always reflects the token owner.
+
+## Question 2 — Are git author identity and GitHub API token identity independently controllable?
+
+**Answer: Yes — they are fully independent, and only the token identity matters for PR authorship.**
+
+| Identity layer | What controls it | Affects PR review restriction? |
+| --- | --- | --- |
+| Git commit author name/email | `git config user.name/email` or `--author` flag | No |
+| Git commit committer name/email | Signing config, merge operator | No |
+| GitHub PR opener | API token used to call `gh pr create` or REST POST | Yes — this is the identity GitHub enforces |
+
+You can set any arbitrary name and email in `git config` or via `--author` while being authenticated as a completely different GitHub account. The PR will open under the token account's identity no matter what the commit metadata says.
+
+## Survey of lightweight tricks
+
+### 1. `git commit --author "Name <email>"`
+
+**Assessment: Dead end for PR opener identity.**
+
+Changes the git commit's author metadata only. GitHub links commits to accounts via email matching (when the email matches a verified GitHub account email), but this affects commit attribution display only — not the PR opener. The review restriction is checked against the PR opener account, not commit authors.
+
+### 2. `git config user.name / user.email`
+
+**Assessment: Dead end for PR opener identity.**
+
+Same as above. Setting `user.email` to a different user's verified GitHub email would attribute the commits to that user in the git graph, but the PR opener remains the token holder.
+
+Note: if email privacy is enabled on the target account, GitHub may even block the push if the commit author email doesn't match the authenticated user's noreply address.
+
+### 3. `on-behalf-of:` commit trailer
+
+**Assessment: Dead end for PR opener identity.**
+
+The `on-behalf-of: @org <name@organization.com>` trailer adds a badge to commits showing they were contributed on behalf of an organization. It does not affect which GitHub account is considered the PR opener, and no evidence exists that it affects review eligibility checks.
+
+Sources: [GitHub Docs — Creating a commit on behalf of an organization](https://docs.github.com/en/pull-requests/committing-changes-to-your-project/creating-and-editing-commits/creating-a-commit-on-behalf-of-an-organization)
+
+### 4. `Co-authored-by:` commit trailer
+
+**Assessment: Dead end for PR opener identity.**
+
+Adds co-authorship attribution to commits, which is reflected in the GitHub UI and contribution graphs. It does not change who opened the PR. Being listed as a co-author of commits does not make you a co-author of the PR for review-restriction purposes.
+
+The GitHub community has discussed whether co-commit-authorship should affect PR review eligibility, but no such feature exists. (Source: community discussion #6292, #14866)
+
+### 5. Squash attribution (`squash and merge` changing commit author)
+
+**Assessment: Dead end for PR opener identity — affects merge commit only.**
+
+Since September 2022, GitHub displays the git commit author before performing a squash merge. When squash merging, the PR branch author becomes the author of the resulting squash commit. But this is about the *resulting merge commit* — it has no effect on the PR's opener identity while the PR is open, and therefore does not affect who can review it.
+
+Source: [GitHub Changelog, Sept 2022](https://github.blog/changelog/2022-09-15-git-commit-author-shown-when-squash-merging-a-pull-request/)
+
+### 6. Push-on-behalf-of (GitHub Enterprise only)
+
+**Assessment: Not applicable — enterprise-only, not a lightweight trick.**
+
+GitHub Enterprise Server supports admin impersonation via `sudo` API tokens. This is not available on GitHub.com and requires Site Admin access. Not relevant to this problem.
+
+### 7. GitHub Actions `GITHUB_TOKEN` as PR opener
+
+**Assessment: Viable alternative identity — creates PRs as `github-actions[bot]`.**
+
+If a GitHub Actions workflow opens a PR using the built-in `GITHUB_TOKEN`, the PR opener is `github-actions[bot]`, not the human user. This means the human user can review, approve, and request changes on such PRs.
+
+Limitations:
+- Requires a GitHub Actions workflow to trigger PR creation (not a pure reef-skill approach)
+- PRs opened by `github-actions[bot]` do not themselves trigger `pull_request` workflows (requires a PAT to bypass)
+- Constitutes a significant setup burden on the user (creating and wiring Actions workflows)
+
+### 8. GitHub App installation token as PR opener
+
+**Assessment: Viable but requires user setup — out of scope per parent issue #48.**
+
+A GitHub App installation token opens PRs as `{app-name}[bot]`, making the human user the reviewer. However, this requires registering a GitHub App and configuring it on the repository, which the parent issue explicitly ruled out.
+
+### 9. Changing the PR opener after creation
+
+**Assessment: Not possible — GitHub has no API to reassign PR authorship.**
+
+The GitHub community has requested a "change PR author" feature since at least April 2022 ([community/discussions#15067](https://github.com/orgs/community/discussions/15067)). It remains unimplemented. There is no REST or GraphQL API to reassign a PR's opener after creation.
+
+### 10. Draft PR then convert to ready
+
+**Assessment: Does not change PR author identity.**
+
+Converting a draft PR to ready-for-review does not change which account is considered the PR opener.
+
+## Self-review restriction: confirmed behavior
+
+- GitHub's restriction reads: "Pull request authors can't request changes on their own pull request" and "Pull request authors cannot approve their own pull requests."
+- This has been a stable, intentional design since at least 2021. As of April 2026, no GitHub-native feature exists to allow PR authors to review their own PRs.
+- The restriction is enforced at the GitHub application layer based on the `user.login` stored when the PR was created — not based on git history.
+- Community discussions (#6292, #46345, #14866) requesting this feature remain open and unanswered by GitHub staff.
+
+## Follow-up questions surfaced
+
+1. Can sibling issue #201's research (GitHub REST/GraphQL API PR attribution) uncover any undocumented parameter that overrides the `user` field? This research found none, but #201 should confirm via direct API call testing if possible.
+2. What is the minimum viable alternative? The synthesis issue (#203) should evaluate whether the GitHub Actions `GITHUB_TOKEN` workflow approach (trick 7) is lightweight enough given the scope constraints — it is the only option that avoids a dedicated bot account while still enabling self-review.

--- a/research/002-github-api-pr-attribution.md
+++ b/research/002-github-api-pr-attribution.md
@@ -1,0 +1,77 @@
+# 002 GitHub API PR Attribution
+
+**Issue**: #201  
+**Parent**: #48 — AI-authored PRs: enable proper self-review  
+**Question**: Can the GitHub REST or GraphQL API open a pull request attributed to a different author than the authenticated token owner — and if so, would that make the PR reviewable by the token owner?
+
+## Finding: Both APIs are dead ends for author override
+
+Neither the REST API nor the GraphQL API exposes any mechanism to attribute a PR to a user other than the authenticated token owner.
+
+### REST API — `POST /repos/{owner}/{repo}/pulls`
+
+The endpoint accepts these body parameters:
+
+| Parameter | Type | Required |
+| --- | --- | --- |
+| `title` | string | yes (or `issue`) |
+| `head` | string | yes |
+| `head_repo` | string | no |
+| `base` | string | yes |
+| `body` | string | no |
+| `maintainer_can_modify` | boolean | no |
+| `draft` | boolean | no |
+| `issue` | integer | no |
+
+No `author`, `user`, or any attribution field exists. The PR `user` field in the response is always set to the account whose token made the request.
+
+Source: https://docs.github.com/en/rest/pulls/pulls#create-a-pull-request
+
+### GraphQL API — `createPullRequest` mutation
+
+The `CreatePullRequestInput` object accepts:
+
+| Field | Type | Required |
+| --- | --- | --- |
+| `repositoryId` | ID | yes |
+| `baseRefName` | String | yes |
+| `headRefName` | String | yes |
+| `title` | String | yes |
+| `body` | String | no |
+| `headRepositoryId` | ID | no |
+| `maintainerCanModify` | Boolean | no |
+| `draft` | Boolean | no |
+| `clientMutationId` | String | no |
+
+No author field exists. GitHub's own docs for the related `createCommitOnBranch` mutation make the policy explicit: "this mutation does not support specifying the author or committer of the commit and will not add support for this in the future. A commit created by a successful execution of this mutation will be authored by the owner of the credential which authenticates the API request." The same policy applies to `createPullRequest`.
+
+Source: https://docs.github.com/en/graphql/reference/input-objects#createpullrequestinput
+
+## Finding: The self-review restriction is enforced by PR opener identity, not commit authorship
+
+GitHub determines review eligibility from the account that opened the PR (the API token owner), not from the git commit author field. This is confirmed by:
+
+- GitHub Docs: "Pull request authors cannot approve their own pull requests."
+- Community discussions confirm: the restriction applies to "the person who created the PR", not the person who authored the commits.
+- The `peter-evans/create-pull-request` action docs state explicitly: "the user account [whose PAT opened the PR] will be unable to perform actions such as request changes or approve the pull request."
+
+Source: https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/approving-a-pull-request-with-required-reviews  
+Source: https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md  
+Source: https://github.com/orgs/community/discussions/6292
+
+## Answer to the acceptance criteria
+
+**Can `POST /repos/{owner}/{repo}/pulls` create a PR whose "author" differs from the authenticated token?**  
+No. There is no `author` parameter. The PR opener is always the token owner.
+
+**Does the GraphQL `createPullRequest` mutation support author override?**  
+No. The `CreatePullRequestInput` has no author field. GitHub's stated policy is that the authenticated credential owner is always the attributed actor, and the API will not add author override support.
+
+**If both paths are dead ends: why does the API always pin PR authorship to the token owner?**  
+GitHub's authentication model ties every write action to the authenticated identity — the account associated with the token. There is no impersonation mechanism available to PATs or fine-grained tokens. Because PR authorship is a write action (creating the PR resource), it is always attributed to the token owner. This is by design and is not circumventable via the API without a separate identity (e.g., a GitHub App acting on behalf of a user, or a second PAT from a different account).
+
+## Implications for the reef
+
+Changing the git commit `--author` (covered in sibling issue #200) is orthogonal to this question: even if commits carry a different author name, the PR opener — and therefore the account blocked from self-review — is always the account whose token called `gh pr create`. No API trick can decouple these two identities using a single token.
+
+The only lightweight path that keeps a single token and still allows the token owner to review the PR is one where someone or something else opens the PR. Options to explore in synthesis (#203): a GitHub App token acting on behalf of a user, or pushing via a second PAT from a dedicated machine account.

--- a/research/003-synthesis-and-recommendation.md
+++ b/research/003-synthesis-and-recommendation.md
@@ -1,0 +1,102 @@
+---
+issue: "#203"
+parent-issue: "#48"
+date: "2026-04-26"
+---
+
+# 003 Synthesis and recommendation
+
+## Summary
+
+All lightweight options for enabling the human user to review reef-opened PRs have been exhausted. The root cause is a GitHub platform constraint: **the PR opener is always the account whose token calls `gh pr create`, and the PR opener cannot review their own PR.** No git-side manipulation, no API parameter, and no commit metadata change can alter this.
+
+The only zero-setup path that avoids opening a bot account is a **workaround**: prefix the PR title or body with a visual signal so the human reviewer knows to use the GitHub web UI's "Start a review" → "Comment" path instead of "Request changes." This does not require any code changes in the reef.
+
+If the diver wants true "Request changes" capability, a **dedicated machine account** (a second GitHub user) is the lightest option that actually works — requiring only a second PAT stored as a secret, nothing else.
+
+## Open question from Testing Decisions: answered
+
+> Are git author identity and API token identity independently controllable on GitHub?
+
+**Yes — they are fully independent. Only the token identity matters for PR authorship and review eligibility.**
+
+Git commit author (set via `git config` or `git commit --author`) is purely cosmetic metadata. GitHub links commits to accounts via email matching for contribution display only. The PR `user` field — which determines who is blocked from self-review — is always and exclusively set to the account whose token called `POST /repos/{owner}/{repo}/pulls`.
+
+See: [001-git-identity-vs-github-pr-opener.md](./001-git-identity-vs-github-pr-opener.md) §Question 2, [002-github-api-pr-attribution.md](./002-github-api-pr-attribution.md) §Finding: self-review restriction.
+
+## All options surveyed
+
+| Option | Dead end? | Why |
+| --- | --- | --- |
+| `git commit --author` / `git config user.email` | Dead end | Controls commit metadata only; PR opener is the token holder regardless |
+| `on-behalf-of:` commit trailer | Dead end | Organization badge only; no effect on PR opener identity |
+| `Co-authored-by:` commit trailer | Dead end | Commit-level attribution only; no effect on review eligibility |
+| Squash attribution | Dead end | Affects the post-merge commit only; PR is already open and restricted |
+| Changing PR author after creation | Dead end | GitHub has no API to reassign PR authorship (community request open since 2022, unimplemented) |
+| Draft → ready-for-review conversion | Dead end | Does not change PR opener identity |
+| REST API `POST /repos/{owner}/{repo}/pulls` with author override | Dead end | No `author` parameter exists; `user` is always the token holder |
+| GraphQL `createPullRequest` with author override | Dead end | `CreatePullRequestInput` has no author field; GitHub's stated policy is that the authenticated credential owner is always the attributed actor and this will not change |
+| Push-on-behalf-of | Dead end | GitHub Enterprise Server only; not available on GitHub.com |
+| GitHub Actions `GITHUB_TOKEN` | Viable but heavyweight | PR opens as `github-actions[bot]` → diver can review; but requires Actions workflow setup, constitutes user-facing setup burden, and Actions-opened PRs don't trigger further `pull_request` workflows without a PAT |
+| GitHub App installation token | Viable but out of scope | App-opened PRs are reviewable by the diver; requires registering and configuring a GitHub App — explicitly out of scope per #48 |
+| Second PAT from a dedicated machine account | Viable and lightweight | Second account + one secret; PR opens under the bot identity, diver reviews freely |
+
+## Viable path: dedicated machine account
+
+### What it is
+
+A second GitHub account (e.g. `mesqueeb-reef-bot`) authenticates with a PAT stored as a repository secret or in the skill's config. When the reef opens a PR, it calls `gh pr create` with `GH_TOKEN=<bot-pat>` — one environment variable override. The human user (`mesqueeb`) is then a non-author and can use "Request changes", "Approve", or "Comment" freely.
+
+### Minimal change to the reef's PR-opening step
+
+In `commit-push.sh` or wherever the reef calls `gh pr create`, prefix the command with `GH_TOKEN="$REEF_BOT_PAT"`:
+
+```sh
+GH_TOKEN="$REEF_BOT_PAT" gh pr create \
+  --base "$BASE_BRANCH" \
+  --title "$ISSUE_TITLE" \
+  --body "$PR_BODY"
+```
+
+`REEF_BOT_PAT` is the only new user-facing configuration required. It can be stored in a `.env` file at the repo root (already gitignored) or as an environment variable in the shell profile.
+
+If `REEF_BOT_PAT` is unset, the reef falls back to the current behavior (diver's own token, no self-review). The skill degrades gracefully.
+
+### Setup burden on the user
+
+1. Create a second GitHub account (one-time, free).
+2. Generate a classic PAT with `repo` scope from that account.
+3. Set `REEF_BOT_PAT=<token>` in the environment or a `.env` file.
+
+That is the complete setup. No GitHub App registration, no Actions workflow, no branch protection changes.
+
+### Why this is the minimum
+
+- It is the only option that does not require GitHub App registration or organization membership.
+- The `GH_TOKEN` env-var override is a single-line change to the PR-opening command.
+- Every other viable option (Actions, GitHub App) requires more setup steps.
+
+## Workaround: no setup required
+
+If the diver does not want to create a second account, a zero-setup workaround exists:
+
+- GitHub does allow the PR author to **comment** on their own PR, including adding inline comments.
+- The reef can open PRs as it does today.
+- The diver uses "Add your review" → "Comment" (not "Request changes") to provide feedback. Reef agents reading the PR body + comments can act on that feedback exactly as they would on "Request changes" today.
+
+This requires a reef-side change: the inspect and rework phases must treat PR comments from the PR author as equivalent to a "Request changes" review. This is a code change in the reef, not a GitHub limitation.
+
+## Recommendation for the diver
+
+Two paths, in order of preference:
+
+1. **Implement the dedicated machine account path.** Lightest true fix. Single-line change to PR-opening command + one secret. Unlocks the full GitHub review workflow for the diver.
+
+2. **Accept the comment-as-feedback workaround.** Zero setup. Requires a reef-side code change so that inspect/rework phases read PR author comments as change requests. Slightly weaker UX (no "Request changes" badge) but fully functional.
+
+If neither path is acceptable, the status quo (reef opens PRs, diver cannot block them via "Request changes") is the only remaining option.
+
+## Follow-up questions
+
+- If path 1 is chosen: does the reef need to handle the case where the bot account is not a repository collaborator? (Answer: the PAT needs at least `repo` scope and the account needs push access, or the PR must be opened from a fork — worth confirming during implementation.)
+- If path 2 is chosen: what exact signal in a PR comment should the reef treat as "request changes"? A keyword (e.g. `CHANGES REQUESTED:`) or any comment from the PR author?


### PR DESCRIPTION
closes #48 AI-authored PRs: enable proper self-review by having the REEF open PRs

<details>
<summary><h3>🦭 Seal of approval — 2026/04/26 17:30</h3></summary>

## Final Report

### Status: PASS

### Plan items

- ✓ RQ1: Does git commit author affect GitHub review eligibility? — 001 §Question 1 answers definitively (No), with three independent evidence sources: gh CLI maintainer rejection of `--author`, absence of author parameter in REST API, and GitHub policy docs.
- ✓ RQ3: All lightweight git/GitHub tricks surveyed — 10 options covered in 001 (git commit --author, git config, on-behalf-of trailer, Co-authored-by trailer, squash attribution, push-on-behalf-of, GitHub Actions GITHUB_TOKEN, GitHub App token, reassign PR after creation, draft→ready). Each marked dead-end / viable / not-applicable.
- ✓ RQ2: GitHub REST and GraphQL API PR attribution — 002 confirms both APIs are dead ends; no author-override field exists; GitHub stated policy confirmed.
- ✓ Testing Decision: are git author identity and API token identity independently controllable? — 003 §Open question answered explicitly: yes, fully independent; only the token identity affects PR authorship and review eligibility.
- ✓ RQ4: Practical minimum single change to reef PR-opening step — 003 §Viable path documents the dedicated machine account path end-to-end: single `GH_TOKEN="$REEF_BOT_PAT"` env-var prefix, plus a zero-setup comment-as-feedback workaround alternative.

### Judgment calls

- **Out-of-scope options included in survey tables (001, 003)**: GitHub Actions GITHUB_TOKEN and GitHub App token are marked "viable but out-of-scope" / "viable but heavyweight". Decision is sound — these give the diver the full picture without implying implementation. No plan drift.
- **Comment-as-feedback workaround added by 003 implementer**: not in the original plan; surfaced naturally from the dead-end analysis. Well-grounded addition that serves the diver. Acceptable.

### Integration notes

All three slices compose cleanly. 001 and 002 are orthogonal research tracks that both confirm the same root cause (token identity is authoritative). 003 synthesises them without contradiction. The open Testing Decisions question is answered consistently across all three documents. Cross-references between slices are correct.

### Test results

Full suite: 494 passed, 0 failed, 0 skipped.

</details>

### 🪼 Pulse metrics

| Phase | Target | Duration | Tokens | Tool uses | Outcome | Date |
| ----- | ------ | -------- | ------ | --------- | ------- | ---- |
| scope | #48 | 4m | — | — | plan created | 2026/04/26 08:47 |
| slice | #48 | — | — | — | 3 sub-issues created | 2026/04/26 |
| slice | #48 | 2m18s | 27079 | 19 | Slices created: 3 research sub-issues #200, #201, #203 | 2026/04/26 14:48 |
| seal | #48 | 2m27s | 34488 | 27 | Seal PASS — all 5 plan items verified across 3 research documents, 494 tests passed | 2026/04/26 15:19 |
| **Total** | | **~8m45s** | **61567** | **46** | | |