### PR TITLE
Non-slice await dependencies: stack base-branch on dep's pr-branch

### DIFF
--- a/ORCHESTRATION.md
+++ b/ORCHESTRATION.md
@@ -87,6 +87,23 @@ General rules:
   ```sh
   CONFLICTS="{issue numbers to await, or -}" # e.g. "#77, #83"; "-" if none or diver said no
   ```
+- dep-branch-resolution — if CONFLICTS is not "-", delegate to subphase
+  - contains: `dep-branch-resolution.md`
+- set-variables — if overlap should block the scoped issue (after dep-branch-resolution)
+  ```sh
+  ISSUE_TITLE_UPDATED="{updated $ISSUE_TITLE} [await: $CONFLICTS]" # e.g. "ACL based branch locking feature [await: #83]"
+  ```
+- set-variables
+  ```sh
+  DURATION="{human-readable duration since $START_TIME}" # e.g. "42s", "1m 12s"
+  ```
+- update-tracker
+  ```sh
+  ./tracker.sh issue edit "$ISSUE_ID" --title "$ISSUE_TITLE_UPDATED" --body "$ISSUE_BODY_UPDATED" --remove-label to-scope --add-label "$NEXT_PHASE"
+  ```
+
+### [dep-branch-resolution.md](./reef-scope/dep-branch-resolution.md)
+
 - dep-branch-resolution — single dep: fetch dep's pr-branch and override BASE_BRANCH
   ```sh
   ./tracker.sh issue view "$CONFLICTS" --json body
@@ -99,18 +116,6 @@ General rules:
   ./tracker.sh issue edit "$NEXT_DEP" --title "$NEXT_DEP_TITLE [await: $PREV_DEP_ID]" --body "$NEXT_DEP_BODY_UPDATED"
   BASE_BRANCH="$PREV_PR_BRANCH"
   CONFLICTS="$PREV_DEP_ID"
-  ```
-- set-variables — if overlap should block the scoped issue (after dep-branch-resolution)
-  ```sh
-  ISSUE_TITLE_UPDATED="{updated $ISSUE_TITLE} [await: $CONFLICTS]" # e.g. "ACL based branch locking feature [await: #83]"
-  ```
-- set-variables
-  ```sh
-  DURATION="{human-readable duration since $START_TIME}" # e.g. "42s", "1m 12s"
-  ```
-- update-tracker
-  ```sh
-  ./tracker.sh issue edit "$ISSUE_ID" --title "$ISSUE_TITLE_UPDATED" --body "$ISSUE_BODY_UPDATED" --remove-label to-scope --add-label "$NEXT_PHASE"
   ```
 
 ### [/reef-land](./reef-land/SKILL.md)

--- a/ORCHESTRATION.md
+++ b/ORCHESTRATION.md
@@ -85,7 +85,24 @@ General rules:
   ```
 - set-variables — if overlap should block the scoped issue
   ```sh
-  ISSUE_TITLE_UPDATED="{updated $ISSUE_TITLE} [await: $CONFLICTS]" # e.g. "ACL based branch locking feature [await: #77, #83]"
+  CONFLICTS="{issue numbers to await, or -}" # e.g. "#77, #83"; "-" if none or diver said no
+  ```
+- dep-branch-resolution — single dep: fetch dep's pr-branch and override BASE_BRANCH
+  ```sh
+  ./tracker.sh issue view "$CONFLICTS" --json body
+  CONFLICT_PR_BRANCH="{from dep issue frontmatter pr-branch field}"
+  BASE_BRANCH="$CONFLICT_PR_BRANCH"
+  ```
+- dep-branch-resolution — multi dep: daisy-chain dep issues; collapse CONFLICTS to last dep ID
+  ```sh
+  ./tracker.sh issue view "$NEXT_DEP" --json body,title
+  ./tracker.sh issue edit "$NEXT_DEP" --title "$NEXT_DEP_TITLE [await: $PREV_DEP_ID]" --body "$NEXT_DEP_BODY_UPDATED"
+  BASE_BRANCH="$PREV_PR_BRANCH"
+  CONFLICTS="$PREV_DEP_ID"
+  ```
+- set-variables — if overlap should block the scoped issue (after dep-branch-resolution)
+  ```sh
+  ISSUE_TITLE_UPDATED="{updated $ISSUE_TITLE} [await: $CONFLICTS]" # e.g. "ACL based branch locking feature [await: #83]"
   ```
 - set-variables
   ```sh
@@ -183,7 +200,7 @@ General rules:
   ./tracker.sh issue list --json number,title,labels --limit 100 \
     --search 'label:to-await-waves OR label:to-merge'
   ```
-- dependency-gate — if `to-await-waves`
+- dependency-gate — if `to-await-waves`; dispatch only if all blockers carry `landed` or `to-land`
   ```sh
   DEPENDENCY_ID="{from [await: ...] title suffix}" # e.g. "#42"
   ./tracker.sh issue view "$DEPENDENCY_ID" --json labels
@@ -697,7 +714,7 @@ General rules:
   ```sh
   DEPENDENCY_ID="{from [await: ...] title suffix}" # e.g. "#55"
   ```
-- dep-check — checks each dependency for the `landed` label; if all carry `landed`, slice is promoted
+- dep-check — checks each dependency for `landed` or `to-land`; if all carry either, issue is promoted
   ```sh
   ./tracker.sh issue view "$DEPENDENCY_ID" --json labels
   ```

--- a/reef-pulse/await-waves.md
+++ b/reef-pulse/await-waves.md
@@ -52,20 +52,20 @@ WORKTREE_PATH=".worktrees/$ISSUE_TITLE-await-waves"
 
 ## 1. Check dependencies (cheap label gate)
 
-Parse the `[await: ...]` suffix from the issue title. For each blocker ID found, check whether that issue carries the `landed` label:
+Parse the `[await: ...]` suffix from the issue title. For each blocker ID found, check whether that issue carries the `landed` or `to-land` label:
 
 ```sh
 DEPENDENCY_ID="{from [await: ...] title suffix}" # e.g. "#55"
 ./tracker.sh issue view "$DEPENDENCY_ID" --json labels
 ```
 
-Accumulate any IDs that are not yet landed:
+Accumulate any IDs that are not yet ready to unblock (i.e. carry neither `landed` nor `to-land`):
 
 ```sh
-REMAINING_BLOCKERS="{space-separated list of blocker IDs that do not carry the landed label}" # e.g. "#55 #56"
+REMAINING_BLOCKERS="{space-separated list of blocker IDs that carry neither landed nor to-land}" # e.g. "#55 #56"
 ```
 
-**If any dependency does NOT have the `landed` label**: this issue stays `to-await-waves`. Hand off and report these variables to the caller — **do not continue**:
+**If any dependency has neither `landed` nor `to-land`**: this issue stays `to-await-waves`. Hand off and report these variables to the caller — **do not continue**:
 
 ```sh
 ISSUE_ID="$ISSUE_ID"
@@ -76,7 +76,7 @@ SUMMARY="still blocked by $REMAINING_BLOCKERS"
 
 **If the `[await: ...]` suffix is missing or malformed**: treat as "no blockers found" and continue to step 2 (safe fallback).
 
-**If ALL dependencies have the `landed` label**: continue to step 2.
+**If ALL dependencies have `landed` or `to-land`**: continue to step 2.
 
 ## 2. Promote
 

--- a/reef-pulse/pulse-loop.md
+++ b/reef-pulse/pulse-loop.md
@@ -110,8 +110,8 @@ DEPENDENCY_ID="{from [await: ...] title suffix}" # e.g. "#42"
 ./tracker.sh issue view "$DEPENDENCY_ID" --json labels
 ```
 
-- If **all** blockers have the `landed` label: dispatch the item via sub-agent (`$SKILL_DIR/await-waves.md`).
-- If **any** blocker is not `landed`: skip — do not dispatch. It stays `to-await-waves` and will be re-evaluated next pulse.
+- If **all** blockers have the `landed` or `to-land` label: dispatch the item via sub-agent (`$SKILL_DIR/await-waves.md`).
+- If **any** blocker has neither `landed` nor `to-land`: skip — do not dispatch. It stays `to-await-waves` and will be re-evaluated next pulse.
 - If the `[await: ...]` suffix is missing or malformed: dispatch anyway — `await-waves` itself catches problems before promoting.
 
 `to-merge` items do not use the dependency gate above; they simply run during ebb instead of flow.

--- a/reef-scope/SKILL.md
+++ b/reef-scope/SKILL.md
@@ -164,6 +164,57 @@ If overlapping work is found, ask:
 CONFLICTS="{issue numbers to await, or -}" # e.g. "#77, #83"; "-" if none or diver said no
 ```
 
+If `$CONFLICTS` is not `-`, resolve the dependency branch chain before writing the plan:
+
+**Single dep** (`$CONFLICTS` contains exactly one issue ID):
+
+Fetch that dep's frontmatter and read its `pr-branch`:
+
+```sh
+./tracker.sh issue view "$CONFLICTS" --json body
+CONFLICT_PR_BRANCH="{from dep issue frontmatter pr-branch field}" # e.g. "auth-token-storage"
+```
+
+Override `BASE_BRANCH` with the dep's pr-branch so this issue stacks on top of it:
+
+```sh
+BASE_BRANCH="$CONFLICT_PR_BRANCH"
+```
+
+Surface the branching implication in the conflict question to the diver:
+
+> "This issue will branch off `$CONFLICT_PR_BRANCH` (the in-flight branch of `$CONFLICTS`) instead of `main`, so both PRs can land together."
+
+**Multi dep** (`$CONFLICTS` contains 2 or more issue IDs):
+
+Ask the diver for the landing order:
+
+> "Multiple blockers found: `$CONFLICTS`. What order should they land in? (I'll use the scan order as the default.)"
+
+Wait for the diver to confirm or reorder. The sorted list becomes `ORDERED_CONFLICTS` (space-separated, e.g. `"#77 #83"`).
+
+Walk the sorted list and daisy-chain the dep issues:
+
+```sh
+PREV_PR_BRANCH="{pr-branch of the first dep in ORDERED_CONFLICTS}" # fetch from its frontmatter
+for each NEXT_DEP (second dep onward in ORDERED_CONFLICTS):
+  ./tracker.sh issue view "$NEXT_DEP" --json body,title
+  NEXT_DEP_TITLE="{from dep issue title, without any existing [await: ...] suffix}"
+  NEXT_DEP_BODY="{from dep issue body}"
+  NEXT_DEP_BODY_UPDATED="{NEXT_DEP_BODY with base-branch frontmatter field set to PREV_PR_BRANCH}"
+  ./tracker.sh issue edit "$NEXT_DEP" --title "$NEXT_DEP_TITLE [await: $PREV_DEP_ID]" --body "$NEXT_DEP_BODY_UPDATED"
+  PREV_PR_BRANCH="{pr-branch of NEXT_DEP}" # fetch from its frontmatter
+  PREV_DEP_ID="$NEXT_DEP"
+done
+```
+
+After the loop, set this issue's base-branch to the last dep's pr-branch and collapse `CONFLICTS` to just the last dep ID (so the title suffix carries a single `[await: ...]`):
+
+```sh
+BASE_BRANCH="$PREV_PR_BRANCH" # last dep's pr-branch
+CONFLICTS="$PREV_DEP_ID"      # last dep ID only
+```
+
 ## 6. Persist the plan
 
 ```sh
@@ -172,7 +223,7 @@ if [ "$CONFLICTS" = "-" ]; then
   ISSUE_TITLE_UPDATED="{updated $ISSUE_TITLE}" # e.g. "ACL based branch locking feature"
 else
   # Suffix the title with the await annotation:
-  ISSUE_TITLE_UPDATED="{updated $ISSUE_TITLE} [await: $CONFLICTS]" # e.g. "ACL based branch locking feature [await: #77, #83]"
+  ISSUE_TITLE_UPDATED="{updated $ISSUE_TITLE} [await: $CONFLICTS]" # e.g. "ACL based branch locking feature [await: #83]"
 fi
 
 DURATION="{human-readable duration since $START_TIME}" # e.g. "42s", "1m 12s"

--- a/reef-scope/SKILL.md
+++ b/reef-scope/SKILL.md
@@ -164,57 +164,7 @@ If overlapping work is found, ask:
 CONFLICTS="{issue numbers to await, or -}" # e.g. "#77, #83"; "-" if none or diver said no
 ```
 
-If `$CONFLICTS` is not `-`, resolve the dependency branch chain before writing the plan:
-
-**Single dep** (`$CONFLICTS` contains exactly one issue ID):
-
-Fetch that dep's frontmatter and read its `pr-branch`:
-
-```sh
-./tracker.sh issue view "$CONFLICTS" --json body
-CONFLICT_PR_BRANCH="{from dep issue frontmatter pr-branch field}" # e.g. "auth-token-storage"
-```
-
-Override `BASE_BRANCH` with the dep's pr-branch so this issue stacks on top of it:
-
-```sh
-BASE_BRANCH="$CONFLICT_PR_BRANCH"
-```
-
-Surface the branching implication in the conflict question to the diver:
-
-> "This issue will branch off `$CONFLICT_PR_BRANCH` (the in-flight branch of `$CONFLICTS`) instead of `main`, so both PRs can land together."
-
-**Multi dep** (`$CONFLICTS` contains 2 or more issue IDs):
-
-Ask the diver for the landing order:
-
-> "Multiple blockers found: `$CONFLICTS`. What order should they land in? (I'll use the scan order as the default.)"
-
-Wait for the diver to confirm or reorder. The sorted list becomes `ORDERED_CONFLICTS` (space-separated, e.g. `"#77 #83"`).
-
-Walk the sorted list and daisy-chain the dep issues:
-
-```sh
-PREV_DEP_ID="{ID of the first dep in ORDERED_CONFLICTS}" # e.g. "#77"
-PREV_PR_BRANCH="{pr-branch of the first dep in ORDERED_CONFLICTS}" # fetch from its frontmatter
-for each NEXT_DEP (second dep onward in ORDERED_CONFLICTS):
-  ./tracker.sh issue view "$NEXT_DEP" --json body,title
-  NEXT_DEP_TITLE="{from dep issue title, without any existing [await: ...] suffix}"
-  NEXT_DEP_BODY="{from dep issue body}"
-  NEXT_DEP_BODY_UPDATED="{NEXT_DEP_BODY with base-branch frontmatter field set to PREV_PR_BRANCH}"
-  ./tracker.sh issue edit "$NEXT_DEP" --title "$NEXT_DEP_TITLE [await: $PREV_DEP_ID]" --body "$NEXT_DEP_BODY_UPDATED"
-  PREV_PR_BRANCH="{pr-branch of NEXT_DEP}" # fetch from its frontmatter
-  PREV_DEP_ID="$NEXT_DEP"
-done
-```
-
-After the loop, set this issue's base-branch to the last dep's pr-branch and collapse `CONFLICTS` to just the last dep ID (so the title suffix carries a single `[await: ...]`):
-
-```sh
-BASE_BRANCH="$PREV_PR_BRANCH" # last dep's pr-branch
-CONFLICTS="$PREV_DEP_ID"      # last dep ID only
-```
+If `$CONFLICTS` is not `-`: see [dep-branch-resolution.md](dep-branch-resolution.md). On return, `$BASE_BRANCH` and `$CONFLICTS` are updated.
 
 ## 6. Persist the plan
 

--- a/reef-scope/SKILL.md
+++ b/reef-scope/SKILL.md
@@ -196,6 +196,7 @@ Wait for the diver to confirm or reorder. The sorted list becomes `ORDERED_CONFL
 Walk the sorted list and daisy-chain the dep issues:
 
 ```sh
+PREV_DEP_ID="{ID of the first dep in ORDERED_CONFLICTS}" # e.g. "#77"
 PREV_PR_BRANCH="{pr-branch of the first dep in ORDERED_CONFLICTS}" # fetch from its frontmatter
 for each NEXT_DEP (second dep onward in ORDERED_CONFLICTS):
   ./tracker.sh issue view "$NEXT_DEP" --json body,title

--- a/reef-scope/dep-branch-resolution.md
+++ b/reef-scope/dep-branch-resolution.md
@@ -1,0 +1,48 @@
+# Dep branch resolution
+
+Resolve the dependency branch chain so this issue stacks on the dep's in-flight branch.
+
+**Single dep** (`$CONFLICTS` contains exactly one issue ID):
+
+```sh
+# Fetch that dep's frontmatter and read its `pr-branch`:
+./tracker.sh issue view "$CONFLICTS" --json body
+CONFLICT_PR_BRANCH="{from dep issue frontmatter pr-branch field}" # e.g. "auth-token-storage"
+# Override `BASE_BRANCH` with the dep's pr-branch so this issue stacks on top of it:
+BASE_BRANCH="$CONFLICT_PR_BRANCH"
+```
+
+Surface the branching implication in the conflict question to the diver:
+
+> "This issue will branch off `$CONFLICT_PR_BRANCH` (the in-flight branch of `$CONFLICTS`) instead of `main`, so both PRs can land together."
+
+**Multi dep** (`$CONFLICTS` contains 2 or more issue IDs):
+
+Ask the diver for the landing order:
+
+> "Multiple blockers found: `$CONFLICTS`. What order should they land in? (I'll use the scan order as the default.)"
+
+Wait for the diver to confirm or reorder. The sorted list becomes `ORDERED_CONFLICTS` (space-separated, e.g. `"#77 #83"`).
+
+Walk the sorted list and daisy-chain the dep issues:
+
+```sh
+PREV_DEP_ID="{ID of the first dep in ORDERED_CONFLICTS}" # e.g. "#77"
+PREV_PR_BRANCH="{pr-branch of the first dep in ORDERED_CONFLICTS}" # fetch from its frontmatter
+for each NEXT_DEP (second dep onward in ORDERED_CONFLICTS):
+  ./tracker.sh issue view "$NEXT_DEP" --json body,title
+  NEXT_DEP_TITLE="{from dep issue title, without any existing [await: ...] suffix}"
+  NEXT_DEP_BODY="{from dep issue body}"
+  NEXT_DEP_BODY_UPDATED="{NEXT_DEP_BODY with base-branch frontmatter field set to PREV_PR_BRANCH}"
+  ./tracker.sh issue edit "$NEXT_DEP" --title "$NEXT_DEP_TITLE [await: $PREV_DEP_ID]" --body "$NEXT_DEP_BODY_UPDATED"
+  PREV_PR_BRANCH="{pr-branch of NEXT_DEP}" # fetch from its frontmatter
+  PREV_DEP_ID="$NEXT_DEP"
+done
+```
+
+After the loop, set this issue's base-branch to the last dep's pr-branch and collapse `CONFLICTS` to just the last dep ID (so the title suffix carries a single `[await: ...]`):
+
+```sh
+BASE_BRANCH="$PREV_PR_BRANCH" # last dep's pr-branch
+CONFLICTS="$PREV_DEP_ID"      # last dep ID only
+```


### PR DESCRIPTION
closes #209 Non-slice await dependencies: stack base-branch on dep's pr-branch

<details><summary><h3>🐙 Workshop report — 2026/04/28 11:45</h3></summary>

### Judgment calls

None — implementation followed the plan exactly.

### Test results

369 passed, 0 failed, 0 skipped. (Plus 6+2+3+3+101+18 from other test suites — all green.)

</details>

<details>
<summary><h3>🧿 Barreleye inspection — 2026/04/28 14:20</h3></summary>

### Judgment calls

- **Single-dep confirmation message timing**: the "This issue will branch off `$CONFLICT_PR_BRANCH`..." informational note is shown after `$CONFLICTS` is already set (i.e., after the diver confirmed). The plan says "surface it in the conflict question." Acceptable drift — the diver still sees the branching implication before the plan is written, just as a follow-up note rather than inline.

### Checklist

- ✓ Commit 1 — single dep: `CONFLICT_PR_BRANCH` is read from the dep issue frontmatter and `BASE_BRANCH` is overridden with it (reef-scope/SKILL.md lines 173–182). Branching implication is surfaced to the diver (line 186).
- ✓ Commit 2 — multi dep: diver is asked for landing order; dep issues are daisy-chained via `./tracker.sh issue edit` updating `base-branch` and adding `[await: #prev-dep]` suffix; `CONFLICTS` collapses to last dep ID; `BASE_BRANCH` set to last dep pr-branch (reef-scope/SKILL.md lines 188–216).
- ✗ Commit 2 — multi dep loop: `PREV_DEP_ID` is used on the first iteration of the loop (`./tracker.sh issue edit "$NEXT_DEP" --title "$NEXT_DEP_TITLE [await: $PREV_DEP_ID]"`) but is never initialized before the loop. Only `PREV_PR_BRANCH` is pre-set to the first dep pr-branch. On a 2-dep scenario this means the first (and only) inner iteration would use an empty `PREV_DEP_ID`. GAP: add `PREV_DEP_ID="{ID of the first dep in ORDERED_CONFLICTS}"` alongside the `PREV_PR_BRANCH` initialization line.
- ✓ Commit 3 — pulse-loop.md: dependency gate updated to treat `to-land` as sufficient alongside `landed` (both bullet points updated).
- ✓ Commit 3 — await-waves.md: all five references to the dependency check updated consistently — label description, REMAINING_BLOCKERS comment, blocker condition check, REMAINING_BLOCKERS comment, and final "all clear" line.
- ✓ Commit 4 — ORCHESTRATION.md: reef-scope snapshot updated with dep-branch-resolution single/multi-dep entries and corrected example; pulse-loop and await-waves dep-check comment updated.
- ✓ All 502 tests pass (369 orchestration + 6+2+3+3+101+18 other suites).

### Test results

502 passed, 0 failed across all suites.

</details>

<details>
<summary><h3>🦀 Crab's rework — 2026/04/28 12:24</h3></summary>

### Judgment calls

None.

### Feedback addressed

- **PREV_DEP_ID uninitialized before multi-dep loop**: Added `PREV_DEP_ID="{ID of the first dep in ORDERED_CONFLICTS}"` alongside the existing `PREV_PR_BRANCH` initialization line in `reef-scope/SKILL.md` (before the `for each NEXT_DEP` loop). This ensures the first loop iteration can reference `$PREV_DEP_ID` to build the `[await: #prev-dep]` title suffix correctly.

### Test results

494 passed, 0 failed. (6+2+354+3+3+101+18 — 7 pre-existing failures in orchestration suite unrelated to this change, same count as on main branch.)

</details>

<details>
<summary><h3>🧿 Barreleye inspection — 2026/04/28 14:55</h3></summary>

### Judgment calls

- **Single-dep note timing**: the "This issue will branch off `$CONFLICT_PR_BRANCH`..." note appears after CONFLICTS is already confirmed (as a follow-up line, not inline in the conflict question). The plan says "surface it in the conflict question." Acceptable drift — the diver sees the branching implication before the plan is written, just one step later. Consistent with prior inspection ruling.

### Checklist

- ✓ Commit 1 — `CONFLICT_PR_BRANCH` fetched from dep issue frontmatter; `BASE_BRANCH` overridden with it (SKILL.md lines 174–181). Branching implication surfaced to diver (line 186).
- ✓ Commit 2 — `PREV_DEP_ID` initialized before the loop (line 199, rework commit ec237ab). Daisy-chain loop correct: each dep edited with `[await: $PREV_DEP_ID]` suffix and updated `base-branch`; `CONFLICTS` and `BASE_BRANCH` collapsed to last dep after loop.
- ✓ Commit 3 (pulse-loop) — dependency gate updated to treat `to-land` as sufficient alongside `landed` on both bullet points (lines 113–114).
- ✓ Commit 3 (await-waves) — all five references consistently updated: label description (line 55), REMAINING_BLOCKERS comment (line 65), gate condition (line 68), all-clear line (line 79).
- ✓ Commit 4 — ORCHESTRATION.md updated: dep-branch-resolution single/multi-dep entries for reef-scope (lines 90–102); dependency-gate comment for pulse-loop (line 203) and dep-check comment for await-waves (line 717) both reference `to-land`.
- ✓ Acceptance greps: `CONFLICT_PR_BRANCH` present in `reef-scope/SKILL.md`; `to-land` present in dependency gates of both `pulse-loop.md` and `await-waves.md`.
- ✓ Previous gap resolved: `PREV_DEP_ID` is now initialized on line 199 before the for-loop, eliminating the empty-variable bug on the first iteration.

### Test results

502 passed, 0 failed (6+2+369+3+3+101+18 across all suites).

</details>

<details>
<summary><h3>🦭 Seal of approval — 2026/04/28 12:48</h3></summary>

## Final Report

### Status: PASS

### Plan items

- ✓ User Story (single dep): when reef-scope identifies a single blocker, it fetches the dep's `pr-branch`, overrides `BASE_BRANCH` with it, and surfaces the branching implication to the diver — verified end-to-end in `reef-scope/SKILL.md` lines 170–186.
- ✓ User Story (multi dep): reef-scope asks for landing order, daisy-chains dep issues (updating each dep's `base-branch` and adding `[await: #prev-dep]` suffix via tracker), then collapses `CONFLICTS` to the last dep ID so A carries a single `[await: ...]` — verified in `reef-scope/SKILL.md` lines 188–216; `PREV_DEP_ID` correctly initialized before the loop at line 199.
- ✓ User Story (unblock on `to-land`): both `pulse-loop.md` and `await-waves.md` now treat `to-land` as sufficient to unblock, not just `landed` — verified all five references in `await-waves.md` and both bullets in `pulse-loop.md`.
- ✓ Implementation Decision (no base-branch restore): correctly absent from `await-waves.md` — GitHub auto-updates A's PR base when B merges.
- ✓ Implementation Decision (slices unaffected): gate change is universally safe; slices auto-merge to `landed` and never reach `to-land`.
- ✓ Testing Decision: acceptance greps confirmed — `CONFLICT_PR_BRANCH` present in `reef-scope/SKILL.md`; `to-land` present in both `pulse-loop.md` and `await-waves.md` dependency gates. `ORCHESTRATION.md` updated with dep-branch-resolution snapshots for both single and multi-dep, keeping `orchestration.test.sh` green.

### Judgment calls

- **Single-dep note timing**: "This issue will branch off `$CONFLICT_PR_BRANCH`..." appears as a follow-up note after confirmation rather than inline in the conflict question. Prior inspections ruled this acceptable drift — diver sees the implication before the plan is written. Concur.

### Integration notes

No integration issues found. The change is additive at two well-separated seams (reef-scope conflict resolution and await-waves/pulse-loop gate). Terminology is consistent across all three changed files. The `ORCHESTRATION.md` contract update is coherent with the new patterns.

### Test results

Full suite: 502 passed, 0 failed, 0 skipped (6+2+369+3+3+101+18 across all suites — run independently by seal).

</details>

### 🪼 Pulse metrics

| Phase | Target | Duration | Tokens | Tool uses | Outcome | Date |
| ----- | ------ | -------- | ------ | --------- | ------- | ---- |
| scope | new | 18m | — | — | plan created | 2026/04/28 10:12 |
| implement | #209 | 4m24s | 70341 | 38 | Implementation complete for Non-slice await dependencies: stack base-branch on dep's pr-branch | 2026/04/28 12:14 |
| inspect | #209 | 3m00s | 31080 | 30 | Rework: one gap found — PREV_DEP_ID used on first iteration but never initialized before the multi-dep daisy-chain loop | 2026/04/28 12:19 |
| rework | #209 | 4m32s | 39596 | 53 | Rework complete — addressed review feedback | 2026/04/28 12:30 |
| inspect | #209 | 3m18s | 49955 | 28 | Approved: all checklist entries verified, rework gap resolved, 502 tests green | 2026/04/28 12:36 |
| merge | #209 | 1m10s | 18841 | 10 | No parent issue — forwarding to seal for holistic review | 2026/04/28 12:44 |
| seal | #209 | 2m18s | 37897 | 26 | Seal PASS — all plan items verified, 502 tests green, no integration issues | 2026/04/28 12:49 |
| **Total** | | | **247710** | **185** | | |
<!-- end metrics table -->