### PR TITLE
Make tracker.sh and merge.sh self-routing by tracker type

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,11 +287,7 @@ All git operations run through shell scripts (`worktree-enter.sh`, `worktree-exi
 
 **Tracker and git contracts**
 
-Every reef phase calls the same shell scripts for git work and `tracker.sh` / `merge.sh` for metadata. Tracker translation is a single global rule:
-
-- For `local-tracker`, run `./tracker.sh` and `./merge.sh` exactly as written.
-- For GitHub, replace `./tracker.sh` and `./merge.sh` with `gh`.
-- For other trackers with MCP issue tools, replace `./tracker.sh issue` with their MCP equivalent and `./tracker.sh pr` / `./merge.sh pr` with `gh pr`.
+Every reef phase calls the same shell scripts for git work and `tracker.sh` / `merge.sh` for metadata. The scripts are self-routing — they read the tracker type from config, translate to the appropriate backend (`gh` for GitHub, local file operations for local-tracker), and print a helpful error for unsupported tracker types.
 
 #### Tracker operations
 
@@ -313,7 +309,7 @@ Remote presence determines how git scripts behave — scripts auto-detect whethe
 | `commit-push.sh`    | Stage all, commit, advances local branch ref.                                                                              | Stage all, commit, push to `origin/branch`.                                                                                 |
 | `worktree-enter.sh` | Create worktree from local `fork-from`. If fork-from ≠ pull-latest, merge pull-latest (push skipped).                      | Fetch, create detached-HEAD worktree from `origin/fork-from`. If fork-from ≠ pull-latest, merge pull-latest and push clean. |
 | `worktree-exit.sh`  | Remove worktree locally. Fails if uncommitted or untracked.                                                                | same                                                                                                                        |
-| `merge.sh pr merge` | Local git merge. Reads base branch from `progress.md`. (For `github` / `clickup` trackers: becomes `gh pr merge` instead.) | same                                                                                                                        |
+| `merge.sh pr merge` | Local git merge. Reads base branch from `progress.md`. Self-routes to `gh pr merge` for non-local trackers.                 | same                                                                                                                        |
 
 #### Track progress in local md files
 

--- a/WRITING_STYLE_GUIDE.md
+++ b/WRITING_STYLE_GUIDE.md
@@ -67,8 +67,7 @@ The Rules section always contains these items, in this order:
 
 1. Config reading — read `.agents/moonjelly-reef/config.md` to learn the tracker type and installed optional skills. State what to do if the file doesn't exist.
 2. Shell block note — `**Shell blocks are literal commands** — execute them as written.`
-3. Tracker note — bullet list of how to translate `./tracker.sh` per tracker type.
-4. Behavior note — either `**AFK skill**` (no human interaction) or nothing (interactive).
+3. Behavior note — either `**AFK skill**` (no human interaction) or nothing (interactive).
 
 ## Variable declarations
 
@@ -407,12 +406,10 @@ Then fetch the current PR body and append:
 
 ## Tracker abstraction
 
-Always use `./tracker.sh` for issue and PR operations:
+Always use `./tracker.sh` and `./merge.sh` for issue, PR, and merge operations. The scripts self-route based on the tracker type in config — they translate to `gh` for GitHub, run locally for local-tracker, and print a helpful error for unsupported types.
 
 preferred: ./tracker.sh issue view "$ISSUE_ID" --json body,title,labels
 anti-pattern:  gh issue view "$ISSUE_ID" --json body,title,labels
-
-The Rules section's tracker note tells the agent how to translate `./tracker.sh` for each tracker type.
 
 When writing to or editing the issue, always show the `./tracker.sh` command — never describe the operation in prose:
 

--- a/reef-land/SKILL.md
+++ b/reef-land/SKILL.md
@@ -48,11 +48,6 @@ If `"$CURRENT_BRANCH" != "$TRACKER_BRANCH"`, warn the user — **do not continue
 
 **Shell blocks are literal commands** — execute them as written.
 
-**Tracker note**:
-
-- For local-tracker, run `./tracker.sh` and `./merge.sh` exactly as written.
-- For GitHub, replace `./tracker.sh` and `./merge.sh` with `gh`
-- For other trackers with MCP issue tools, replace `./tracker.sh issue` with their MCP equivalent and `./tracker.sh pr` and `./merge.sh pr` with `gh pr`
 
 ## 0. Fetch context
 

--- a/reef-land/SKILL.md
+++ b/reef-land/SKILL.md
@@ -48,7 +48,6 @@ If `"$CURRENT_BRANCH" != "$TRACKER_BRANCH"`, warn the user — **do not continue
 
 **Shell blocks are literal commands** — execute them as written.
 
-
 ## 0. Fetch context
 
 If `$ISSUE_ID` is a specific ID, read the issue body to find the pr-id:

--- a/reef-pulse/SKILL.md
+++ b/reef-pulse/SKILL.md
@@ -46,11 +46,6 @@ If `"$CURRENT_BRANCH" != "$TRACKER_BRANCH"`, warn the user — **do not continue
 
 **Shell blocks are literal commands** — execute them as written.
 
-**Tracker note**:
-
-- For local-tracker, run `./tracker.sh` and `./merge.sh` exactly as written.
-- For GitHub, replace `./tracker.sh` and `./merge.sh` with `gh`
-- For other trackers with MCP issue tools, replace `./tracker.sh issue` with their MCP equivalent and `./tracker.sh pr` and `./merge.sh pr` with `gh pr`
 
 **AFK skill**: this skill runs without human interaction. You are the orchestrator — scan, dispatch, and exit. You hold no state; labels are the state. When in doubt: check the labels, make your best judgment, move on. Never block waiting for human input.
 

--- a/reef-pulse/SKILL.md
+++ b/reef-pulse/SKILL.md
@@ -46,7 +46,6 @@ If `"$CURRENT_BRANCH" != "$TRACKER_BRANCH"`, warn the user — **do not continue
 
 **Shell blocks are literal commands** — execute them as written.
 
-
 **AFK skill**: this skill runs without human interaction. You are the orchestrator — scan, dispatch, and exit. You hold no state; labels are the state. When in doubt: check the labels, make your best judgment, move on. Never block waiting for human input.
 
 ## 0. Fetch context

--- a/reef-pulse/await-waves.md
+++ b/reef-pulse/await-waves.md
@@ -18,7 +18,6 @@ Read `.agents/moonjelly-reef/config.md` to learn the tracker type. If the file d
 
 **Shell blocks are literal commands** — execute them as written.
 
-
 **AFK skill**: this skill runs without human interaction. No judgment calls expected — if blocked, hand off and do not continue. If dependencies are landed, promote. Never block waiting for human input.
 
 ## 0. Fetch context

--- a/reef-pulse/await-waves.md
+++ b/reef-pulse/await-waves.md
@@ -18,11 +18,6 @@ Read `.agents/moonjelly-reef/config.md` to learn the tracker type. If the file d
 
 **Shell blocks are literal commands** — execute them as written.
 
-**Tracker note**:
-
-- For local-tracker, run `./tracker.sh` and `./merge.sh` exactly as written.
-- For GitHub, replace `./tracker.sh` and `./merge.sh` with `gh`
-- For other trackers with MCP issue tools, replace `./tracker.sh issue` with their MCP equivalent and `./tracker.sh pr` and `./merge.sh pr` with `gh pr`
 
 **AFK skill**: this skill runs without human interaction. No judgment calls expected — if blocked, hand off and do not continue. If dependencies are landed, promote. Never block waiting for human input.
 

--- a/reef-pulse/implement.md
+++ b/reef-pulse/implement.md
@@ -16,11 +16,6 @@ Before starting, read `.agents/moonjelly-reef/config.md` to learn the tracker ty
 
 **Shell blocks are literal commands** — execute them as written.
 
-**Tracker note**:
-
-- For local-tracker, run `./tracker.sh` and `./merge.sh` exactly as written.
-- For GitHub, replace `./tracker.sh` and `./merge.sh` with `gh`
-- For other trackers with MCP issue tools, replace `./tracker.sh issue` with their MCP equivalent and `./tracker.sh pr` and `./merge.sh pr` with `gh pr`
 
 **AFK skill**: this skill runs without human interaction. When in doubt: check the plan, make your best judgment, move on. Never block waiting for human input.
 

--- a/reef-pulse/implement.md
+++ b/reef-pulse/implement.md
@@ -16,7 +16,6 @@ Before starting, read `.agents/moonjelly-reef/config.md` to learn the tracker ty
 
 **Shell blocks are literal commands** — execute them as written.
 
-
 **AFK skill**: this skill runs without human interaction. When in doubt: check the plan, make your best judgment, move on. Never block waiting for human input.
 
 ## 0. Fetch context

--- a/reef-pulse/inspect.md
+++ b/reef-pulse/inspect.md
@@ -16,11 +16,6 @@ Read `.agents/moonjelly-reef/config.md` to learn the tracker type. If the file d
 
 **Shell blocks are literal commands** — execute them as written.
 
-**Tracker note**:
-
-- For local-tracker, run `./tracker.sh` and `./merge.sh` exactly as written.
-- For GitHub, replace `./tracker.sh` and `./merge.sh` with `gh`
-- For other trackers with MCP issue tools, replace `./tracker.sh issue` with their MCP equivalent and `./tracker.sh pr` and `./merge.sh pr` with `gh pr`
 
 **AFK skill**: this skill runs without human interaction. When in doubt: check the plan, make your best judgment, move on. Never block waiting for human input.
 

--- a/reef-pulse/inspect.md
+++ b/reef-pulse/inspect.md
@@ -16,7 +16,6 @@ Read `.agents/moonjelly-reef/config.md` to learn the tracker type. If the file d
 
 **Shell blocks are literal commands** — execute them as written.
 
-
 **AFK skill**: this skill runs without human interaction. When in doubt: check the plan, make your best judgment, move on. Never block waiting for human input.
 
 ## 0. Fetch context

--- a/reef-pulse/merge.md
+++ b/reef-pulse/merge.md
@@ -20,11 +20,6 @@ MERGE_STRATEGY="{from .agents/moonjelly-reef/config.md merge-strategy field}" # 
 
 **Shell blocks are literal commands** — execute them as written.
 
-**Tracker note**:
-
-- For local-tracker, run `./tracker.sh` and `./merge.sh` exactly as written.
-- For GitHub, replace `./tracker.sh` and `./merge.sh` with `gh`
-- For other trackers with MCP issue tools, replace `./tracker.sh issue` with their MCP equivalent and `./tracker.sh pr` and `./merge.sh pr` with `gh pr`
 
 **AFK skill**: this skill runs without human interaction. When in doubt: check the plan, make your best judgment, move on. Never block waiting for human input.
 

--- a/reef-pulse/merge.md
+++ b/reef-pulse/merge.md
@@ -20,7 +20,6 @@ MERGE_STRATEGY="{from .agents/moonjelly-reef/config.md merge-strategy field}" # 
 
 **Shell blocks are literal commands** — execute them as written.
 
-
 **AFK skill**: this skill runs without human interaction. When in doubt: check the plan, make your best judgment, move on. Never block waiting for human input.
 
 ## 0. Fetch context

--- a/reef-pulse/merge.sh
+++ b/reef-pulse/merge.sh
@@ -22,6 +22,49 @@ if [ $# -lt 2 ] || [ "$1" != "pr" ] || [ "$2" != "merge" ]; then
 fi
 shift 2
 
+# ============================================================
+# Tracker-type routing — read config and dispatch to gh if needed
+# ============================================================
+
+_find_config() {
+  _gcd="$(git rev-parse --git-common-dir 2>/dev/null)" || {
+    echo "Error: not inside a git repository" >&2
+    exit 1
+  }
+  case "$_gcd" in
+    /*) _main_root="$(dirname "$_gcd")" ;;
+    *)  _main_root="$(git rev-parse --show-toplevel)" ;;
+  esac
+  _config="$_main_root/.agents/moonjelly-reef/config.md"
+  if [ ! -f "$_config" ]; then
+    echo "Error: config not found at $_config" >&2
+    exit 1
+  fi
+}
+
+_find_config
+_tracker_type="$(sed -n 's/^tracker: *//p' "$_config" | head -1)"
+
+# GitHub routing — translate to gh pr merge and exec
+if [ "$_tracker_type" = "github" ]; then
+  exec gh pr merge "$@"
+fi
+
+# Unsupported tracker — helpful error for unknown tracker types
+case "$_tracker_type" in
+  local-tracker-committed|local-tracker-gitignored) ;;
+  *)
+    echo "Error: unsupported tracker type '$_tracker_type'." >&2
+    echo "merge.sh was asked to run: pr merge $*" >&2
+    echo "If your tracker has MCP tools, use gh pr merge for PR merge operations." >&2
+    exit 1
+    ;;
+esac
+
+# ============================================================
+# Local tracker — parse remaining args and perform local merge
+# ============================================================
+
 BRANCH=""
 STRATEGY="merge"
 DELETE_BRANCH=false
@@ -50,19 +93,11 @@ if [ -z "$BRANCH" ]; then
 fi
 
 # Look up base branch from progress.md (written by tracker.sh pr create)
-ROOT="$(git rev-parse --show-toplevel 2>/dev/null)" || {
-  echo "Error: not inside a git repository" >&2
-  exit 1
-}
-CONFIG="$ROOT/.agents/moonjelly-reef/config.md"
-if [ ! -f "$CONFIG" ]; then
-  echo "Error: config not found at $CONFIG" >&2
-  exit 1
-fi
-_raw_path="$(sed -n 's/^tracker-path: *//p' "$CONFIG" | head -1)"
+# Config already read by _find_config above; reuse $_main_root and $_config.
+_raw_path="$(sed -n 's/^tracker-path: *//p' "$_config" | head -1)"
 case "$_raw_path" in
   /*) TRACKER_PATH="$_raw_path" ;;
-  *)  TRACKER_PATH="$ROOT/$_raw_path" ;;
+  *)  TRACKER_PATH="$_main_root/$_raw_path" ;;
 esac
 
 BASE=""

--- a/reef-pulse/merge.sh
+++ b/reef-pulse/merge.sh
@@ -1,9 +1,10 @@
 #!/bin/sh
-# merge.sh — local-tracker equivalent of `gh pr merge`
+# merge.sh — self-routing merge script
 #
-# For GitHub or ClickUp trackers, use: gh pr merge <branch> [flags]
-# This script is the local-tracker equivalent — it reads the base branch from progress.md
-# and performs the git merge directly.
+# Reads tracker type from config and dispatches accordingly:
+# - github: exec gh pr merge with the same flags
+# - local-tracker: reads base branch from progress.md and performs git merge directly
+# - other: prints a helpful error describing what was requested
 #
 # Usage:
 #   merge.sh pr merge <branch> [--squash|-s] [--merge|-m] [--rebase|-r] [--delete-branch|-d]

--- a/reef-pulse/metric-logger.md
+++ b/reef-pulse/metric-logger.md
@@ -23,7 +23,6 @@ Read `.agents/moonjelly-reef/config.md` to learn the tracker type and any instal
 
 **Shell blocks are literal commands** — execute them as written.
 
-
 **AFK skill**: this skill runs without human interaction. If one record fails validation or a write, report it and continue with the remaining records.
 
 ## 0. Read issue and PR bodies

--- a/reef-pulse/metric-logger.md
+++ b/reef-pulse/metric-logger.md
@@ -23,11 +23,6 @@ Read `.agents/moonjelly-reef/config.md` to learn the tracker type and any instal
 
 **Shell blocks are literal commands** — execute them as written.
 
-**Tracker note**:
-
-- For local-tracker, run `./tracker.sh` and `./merge.sh` exactly as written.
-- For GitHub, replace `./tracker.sh` and `./merge.sh` with `gh`
-- For other trackers with MCP issue tools, replace `./tracker.sh issue` with their MCP equivalent and `./tracker.sh pr` and `./merge.sh pr` with `gh pr`
 
 **AFK skill**: this skill runs without human interaction. If one record fails validation or a write, report it and continue with the remaining records.
 

--- a/reef-pulse/pulse-loop.md
+++ b/reef-pulse/pulse-loop.md
@@ -17,11 +17,6 @@ SESSION_START_TS="{from context}" # e.g. 1735000000
 
 **Shell blocks are literal commands** — execute them as written.
 
-**Tracker note**:
-
-- For local-tracker, run `./tracker.sh` and `./merge.sh` exactly as written.
-- For GitHub, replace `./tracker.sh` and `./merge.sh` with `gh`
-- For other trackers with MCP issue tools, replace `./tracker.sh issue` with their MCP equivalent and `./tracker.sh pr` and `./merge.sh pr` with `gh pr`
 
 **AFK skill**: this file runs without human interaction. When in doubt: check the labels, make your best judgment, move on. Never block waiting for human input.
 

--- a/reef-pulse/pulse-loop.md
+++ b/reef-pulse/pulse-loop.md
@@ -17,7 +17,6 @@ SESSION_START_TS="{from context}" # e.g. 1735000000
 
 **Shell blocks are literal commands** — execute them as written.
 
-
 **AFK skill**: this file runs without human interaction. When in doubt: check the labels, make your best judgment, move on. Never block waiting for human input.
 
 Each time [`SKILL.md`](SKILL.md) invokes this file, execute exactly one full pulse-loop iteration. Do not collapse a pulse-loop iteration into a quick rescan or tracker-only follow-up. Each pulse-loop iteration must emit the same pulse transcript structure: pulse header, dispatch lines when applicable, return results when applicable, then return control to [`SKILL.md`](SKILL.md).

--- a/reef-pulse/research.md
+++ b/reef-pulse/research.md
@@ -16,11 +16,6 @@ Read `.agents/moonjelly-reef/config.md` to learn the tracker type. If the file d
 
 **Shell blocks are literal commands** — execute them as written.
 
-**Tracker note**:
-
-- For local-tracker, run `./tracker.sh` and `./merge.sh` exactly as written.
-- For GitHub, replace `./tracker.sh` and `./merge.sh` with `gh`
-- For other trackers with MCP issue tools, replace `./tracker.sh issue` with their MCP equivalent and `./tracker.sh pr` and `./merge.sh pr` with `gh pr`
 
 **AFK skill**: this skill runs without human interaction. When in doubt: check the plan, make your best judgment, move on. Never block waiting for human input.
 

--- a/reef-pulse/research.md
+++ b/reef-pulse/research.md
@@ -16,7 +16,6 @@ Read `.agents/moonjelly-reef/config.md` to learn the tracker type. If the file d
 
 **Shell blocks are literal commands** — execute them as written.
 
-
 **AFK skill**: this skill runs without human interaction. When in doubt: check the plan, make your best judgment, move on. Never block waiting for human input.
 
 ## 0. Fetch context

--- a/reef-pulse/rework.md
+++ b/reef-pulse/rework.md
@@ -16,11 +16,6 @@ Read `.agents/moonjelly-reef/config.md` to learn the tracker type. If the file d
 
 **Shell blocks are literal commands** — execute them as written.
 
-**Tracker note**:
-
-- For local-tracker, run `./tracker.sh` and `./merge.sh` exactly as written.
-- For GitHub, replace `./tracker.sh` and `./merge.sh` with `gh`
-- For other trackers with MCP issue tools, replace `./tracker.sh issue` with their MCP equivalent and `./tracker.sh pr` and `./merge.sh pr` with `gh pr`
 
 **AFK skill**: this skill runs without human interaction. When in doubt: check the plan, make your best judgment, move on. Never block waiting for human input.
 

--- a/reef-pulse/rework.md
+++ b/reef-pulse/rework.md
@@ -16,7 +16,6 @@ Read `.agents/moonjelly-reef/config.md` to learn the tracker type. If the file d
 
 **Shell blocks are literal commands** — execute them as written.
 
-
 **AFK skill**: this skill runs without human interaction. When in doubt: check the plan, make your best judgment, move on. Never block waiting for human input.
 
 ## 0. Fetch context

--- a/reef-pulse/seal.md
+++ b/reef-pulse/seal.md
@@ -16,11 +16,6 @@ Before starting, read `.agents/moonjelly-reef/config.md` to learn the tracker ty
 
 **Shell blocks are literal commands** — execute them as written.
 
-**Tracker note**:
-
-- For local-tracker, run `./tracker.sh` and `./merge.sh` exactly as written.
-- For GitHub, replace `./tracker.sh` and `./merge.sh` with `gh`
-- For other trackers with MCP issue tools, replace `./tracker.sh issue` with their MCP equivalent and `./tracker.sh pr` and `./merge.sh pr` with `gh pr`
 
 **AFK skill**: this skill runs without human interaction. When in doubt: check the plan, make your best judgment, move on. Never block waiting for human input.
 

--- a/reef-pulse/seal.md
+++ b/reef-pulse/seal.md
@@ -16,7 +16,6 @@ Before starting, read `.agents/moonjelly-reef/config.md` to learn the tracker ty
 
 **Shell blocks are literal commands** — execute them as written.
 
-
 **AFK skill**: this skill runs without human interaction. When in doubt: check the plan, make your best judgment, move on. Never block waiting for human input.
 
 ## 0. Fetch context

--- a/reef-pulse/slice.md
+++ b/reef-pulse/slice.md
@@ -16,7 +16,6 @@ Read `.agents/moonjelly-reef/config.md` to learn the tracker type. If the file d
 
 **Shell blocks are literal commands** — execute them as written.
 
-
 **AFK skill**: this phase runs without human interaction. When in doubt: check the plan, make your best judgment, move on. Never block waiting for human input.
 
 ## 0. Fetch context

--- a/reef-pulse/slice.md
+++ b/reef-pulse/slice.md
@@ -16,11 +16,6 @@ Read `.agents/moonjelly-reef/config.md` to learn the tracker type. If the file d
 
 **Shell blocks are literal commands** — execute them as written.
 
-**Tracker note**:
-
-- For local-tracker, run `./tracker.sh` and `./merge.sh` exactly as written.
-- For GitHub, replace `./tracker.sh` and `./merge.sh` with `gh`
-- For other trackers with MCP issue tools, replace `./tracker.sh issue` with their MCP equivalent and `./tracker.sh pr` and `./merge.sh pr` with `gh pr`
 
 **AFK skill**: this phase runs without human interaction. When in doubt: check the plan, make your best judgment, move on. Never block waiting for human input.
 

--- a/reef-pulse/tracker.sh
+++ b/reef-pulse/tracker.sh
@@ -41,12 +41,15 @@ find_config() {
   fi
 }
 
-read_config() {
+read_tracker_type() {
   find_config
-  # Read frontmatter values
+  TRACKER_TYPE="$(sed -n 's/^tracker: *//p' "$CONFIG" | head -1)"
+}
+
+read_local_config() {
+  # Read remaining frontmatter values (find_config already called by read_tracker_type)
   _raw_path="$(sed -n 's/^tracker-path: *//p' "$CONFIG" | head -1)"
   TRACKER_BRANCH="$(sed -n 's/^tracker-branch: *//p' "$CONFIG" | head -1)"
-  TRACKER_TYPE="$(sed -n 's/^tracker: *//p' "$CONFIG" | head -1)"
 
   if [ -z "$_raw_path" ] || [ "$_raw_path" = "—" ]; then
     echo "Error: tracker-path not set in config" >&2
@@ -856,7 +859,61 @@ CMD_GROUP="$1"
 SUBCMD="$2"
 shift 2
 
-read_config
+read_tracker_type
+
+# ============================================================
+# GitHub routing — if tracker is github, translate to gh and exec
+# ============================================================
+
+if [ "$TRACKER_TYPE" = "github" ]; then
+  # Strip --parent and its value (a local-tracker concept for slice
+  # hierarchy that gh doesn't support), then exec gh with the rest.
+  _gh_args=""
+  _skip_next=false
+  for _arg in "$@"; do
+    if [ "$_skip_next" = true ]; then
+      _skip_next=false
+      continue
+    fi
+    if [ "$_arg" = "--parent" ]; then
+      _skip_next=true
+      continue
+    fi
+    # Rebuild positional parameters without --parent
+    if [ -z "$_gh_args" ]; then
+      set -- "$_arg"
+      _gh_args=set
+    else
+      set -- "$@" "$_arg"
+    fi
+  done
+  if [ -z "$_gh_args" ]; then
+    # No remaining args after stripping
+    exec gh "$CMD_GROUP" "$SUBCMD"
+  else
+    exec gh "$CMD_GROUP" "$SUBCMD" "$@"
+  fi
+fi
+
+# ============================================================
+# Unsupported tracker — helpful error for unknown tracker types
+# ============================================================
+
+case "$TRACKER_TYPE" in
+  local-tracker-committed|local-tracker-gitignored) ;;
+  *)
+    echo "Error: unsupported tracker type '$TRACKER_TYPE'." >&2
+    echo "tracker.sh was asked to run: $CMD_GROUP $SUBCMD $*" >&2
+    echo "If your tracker has MCP tools, use them for issue operations and gh for PR operations." >&2
+    exit 1
+    ;;
+esac
+
+# ============================================================
+# Local tracker — read remaining config and dispatch
+# ============================================================
+
+read_local_config
 
 case "$CMD_GROUP" in
   issue)

--- a/reef-scope/SKILL.md
+++ b/reef-scope/SKILL.md
@@ -45,11 +45,6 @@ If `"$CURRENT_BRANCH" != "$TRACKER_BRANCH"`, warn the user — **do not continue
 
 **Shell blocks are literal commands** — execute them as written.
 
-**Tracker note**:
-
-- For local-tracker, run `./tracker.sh` and `./merge.sh` exactly as written.
-- For GitHub, replace `./tracker.sh` and `./merge.sh` with `gh`
-- For other trackers with MCP issue tools, replace `./tracker.sh issue` with their MCP equivalent and `./tracker.sh pr` and `./merge.sh pr` with `gh pr`
 
 ## 0. Fetch context
 

--- a/reef-scope/SKILL.md
+++ b/reef-scope/SKILL.md
@@ -45,7 +45,6 @@ If `"$CURRENT_BRANCH" != "$TRACKER_BRANCH"`, warn the user — **do not continue
 
 **Shell blocks are literal commands** — execute them as written.
 
-
 ## 0. Fetch context
 
 ```sh


### PR DESCRIPTION
closes #214 Make tracker.sh and merge.sh self-routing by tracker type

<details>
<summary><h3>🐙 Workshop report — 2026-04-28 21:24</h3></summary>

### Judgment calls

None — implementation followed the plan exactly.

### Test results

504 tests passed, 0 failed, 0 skipped (6 + 2 + 371 + 3 + 3 + 101 + 18).

</details>

<details>
<summary><h3>🧿 Barreleye inspection — 2026-04-28 21:32</h3></summary>

### Judgment calls

None.

### Checklist

- ✓ **Commit 1 — Add GitHub routing to tracker.sh**: Verified. `read_tracker_type()` reads tracker type from config. When `github`, strips `--parent` flag and its value, then `exec gh` with remaining args. Code path traced through the for-loop arg rebuilding — logic is correct (original `$@` captured at loop entry, `set --` rebuilds a clean arg list).
- ✓ **Commit 2 — Add unsupported-tracker error to tracker.sh**: Verified. `case` statement after GitHub routing catches anything that is not `local-tracker-committed` or `local-tracker-gitignored`, prints descriptive stderr with the requested command, exits 1.
- ✓ **Commit 3 — Add GitHub routing to merge.sh**: Verified. `_find_config()` reads config, checks tracker type. When `github`, `exec gh pr merge "$@"`. Unsupported tracker case prints stderr and exits 1. Local-tracker path reuses `_main_root` and `_config` from the routing preamble instead of duplicating config reads.
- ✓ **Commit 4 — Remove Tracker note from all 13 files**: Verified. Grep for "Tracker note" and "For local-tracker, run" returns zero matches across the entire worktree. Diff confirms exactly 13 files had the 5-line block removed.
- ✓ **Commit 5 — Update WRITING_STYLE_GUIDE.md**: Verified. Tracker note removed from the Rules section ordering (item 3 renumbered). Tracker abstraction section updated to describe self-routing behavior.
- ✓ **Commit 6 — Update README.md**: Verified. Old 5-line bullet list replaced with single-line description of self-routing. Merge table row updated from "For github/clickup trackers: becomes gh pr merge instead" to "Self-routes to gh pr merge for non-local trackers."

### Trivial cleanups applied

- Removed double blank lines left behind in all 13 phase/skill files after Tracker note removal.
- Updated stale header comment in `merge.sh` (was "local-tracker equivalent of gh pr merge" — now accurately describes self-routing behavior).

### Test results

504 tests passed, 0 failed (6 + 2 + 371 + 3 + 3 + 101 + 18).

</details>

<details>
<summary><h3>🦭 Seal of approval — 2026/04/28 21:38</h3></summary>

## Final Report

### Status: PASS

### Plan items

- ✓ Commit 1 — Add GitHub routing to `tracker.sh` — verified: `read_tracker_type()` reads config, `exec gh` with `--parent` stripped. Arg-rebuilding loop correctly snapshots `$@` before modifying it.
- ✓ Commit 2 — Add unsupported-tracker error to `tracker.sh` — verified: case statement catches non-local, non-github types, prints descriptive stderr with the requested command, exits 1.
- ✓ Commit 3 — Add GitHub routing to `merge.sh` — verified: same routing pattern as tracker.sh. `_find_config()` resolves config from worktree-safe git-common-dir. `exec gh pr merge "$@"` passes all flags through.
- ✓ Commit 4 — Remove Tracker note from all 13 phase/skill files — verified: grep confirms zero remaining occurrences of "Tracker note" and "For local-tracker, run". Exactly 13 files changed, each with 6 lines removed.
- ✓ Commit 5 — Update WRITING_STYLE_GUIDE.md — verified: Rules section item 3 (Tracker note) removed, numbering updated. Tracker abstraction section rewritten to describe self-routing behavior.
- ✓ Commit 6 — Update README.md — verified: old 5-line bullet list replaced with single-line self-routing description. Merge table row updated.
- ✓ Decision Record: `--parent` stripped when routing to gh (with comment) — confirmed in code and comment.
- ✓ What Won't Change: `fetch.sh`, `pull.sh`, ORCHESTRATION.md, existing tests, and all `./tracker.sh`/`./merge.sh` calls in phase files are untouched.
- ✓ Testing Decisions: existing tests unchanged, still use isolated mock configs with `local-tracker-gitignored`.

### Integration notes

No integration issues found. Both scripts follow an identical routing pattern (read config, check github, check unsupported, fall through to local). The `_find_config` / `find_config` functions in both scripts handle worktree paths correctly via `git-common-dir`.

### Test results

Full suite: 504 passed, 0 failed, 0 skipped (6 + 2 + 371 + 3 + 3 + 101 + 18).

</details>

### 🪼 Pulse metrics

| Phase | Target     | Duration  | Tokens | Tool uses | Outcome      | Date       |
| ----- | ---------- | --------- | ------ | --------- | ------------ | ---------- |
| scope | #214       | 4m 42s    | —      | —         | plan created | 2026/04/28 19:52 |
| implement | #214 | 17m37s | 116909 | 158 | Implementation complete for Make tracker.sh and merge.sh self-routing by tracker type | 2026-04-28 21:26 |
| inspect | #214 | 5m57s | 56685 | 54 | Approved: all 6 checklist entries verified, 504 tests green. Cleaned up double blank lines in 13 files and stale header comment in merge.sh. | 2026-04-28 21:35 |
| merge | #214 | 1m52s | 20394 | 17 | No parent issue — forwarding to seal for holistic review | 2026-04-28 21:35 |
| seal | #214 | 3m39s | 54940 | 40 | Seal PASS — all 6 plan items verified, 504 tests green, no integration issues. Scripts self-route correctly for github/local-tracker/unsupported types. Tracker note cleanly removed from all 13 files. | 2026-04-28 21:40 |
| **Total** | | **33m47s** | **248928** | **269** | | |
<!-- end metrics table -->